### PR TITLE
fix(release): generate and upload latest.yml so electron-updater can …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,11 +125,41 @@ jobs:
           Compress-Archive -Path "release/win-unpacked/*" `
             -DestinationPath "wmux-${{ steps.version.outputs.version }}-win-x64.zip"
 
-      - name: Upload release zip as artifact
+      # ── Generate latest.yml for electron-updater ──────────
+      - name: Generate latest.yml
+        shell: bash
+        run: |
+          node -e "
+            const crypto = require('crypto');
+            const fs = require('fs');
+            const version = '${{ steps.version.outputs.version }}';
+            const zip = 'wmux-' + version + '-win-x64.zip';
+            const data = fs.readFileSync(zip);
+            const sha512 = crypto.createHash('sha512').update(data).digest('base64');
+            const size = data.length;
+            const date = new Date().toISOString();
+            const yaml = [
+              'version: ' + version,
+              'files:',
+              '  - url: ' + zip,
+              '    sha512: ' + sha512,
+              '    size: ' + size,
+              'path: ' + zip,
+              'sha512: ' + sha512,
+              \"releaseDate: '\" + date + \"'\",
+              ''
+            ].join('\n');
+            fs.writeFileSync('latest.yml', yaml);
+            console.log('latest.yml generated for', zip, 'size=' + size, 'sha512=' + sha512.substring(0, 20) + '...');
+          "
+
+      - name: Upload release artifacts as workflow artifacts
         uses: actions/upload-artifact@v4
         with:
           name: wmux-release
-          path: wmux-${{ steps.version.outputs.version }}-win-x64.zip
+          path: |
+            wmux-${{ steps.version.outputs.version }}-win-x64.zip
+            latest.yml
 
       # ── GitHub Release ─────────────────────────────────────
       - name: Create or update GitHub Release
@@ -137,6 +167,8 @@ jobs:
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: wmux ${{ steps.version.outputs.tag }}
-          files: wmux-${{ steps.version.outputs.version }}-win-x64.zip
+          files: |
+            wmux-${{ steps.version.outputs.version }}-win-x64.zip
+            latest.yml
           draft: false
           generate_release_notes: true

--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
     "ws": "^8.20.0",
     "zustand": "^5.0.0"
   },
+  "build": {
+    "appId": "com.wmux.app",
+    "publish": {
+      "provider": "github",
+      "owner": "amirlehmam",
+      "repo": "wmux"
+    }
+  },
   "devDependencies": {
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",


### PR DESCRIPTION
…detect new versions

The release workflow used --win --dir which builds an unpacked directory but never runs the publish step, so latest.yml was never generated. Added a Node.js step that computes the SHA-512 of the zip and writes the latest.yml manifest that electron-updater reads. Also added build.publish config to package.json so electron-builder knows the GitHub provider.

Backported latest.yml to the v0.7.10 release manually.

Fixes #7