### PR TITLE
fix: remove !important from workspace session tab custom background to allow color overrides

### DIFF
--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -85,7 +85,7 @@
 }
 
 .workspace-row--active {
-  background: #0091FF !important;
+  background: #0091FF;
 }
 
 /* Left rail indicator */


### PR DESCRIPTION
### Fix: workspace session tab background now updates correctly when selecting a color

This fixes an issue where the **workspace** did not update its background color when using the custom color choosers.

## Root Cause
The CSS rule for the workspace used `!important`, which prevented background styles (color picker) from having effect.

## Fix Applied
Removed `!important` so inline styles take precedence:

```css
.workspace-row--active {
  background: #0091FF; /* removed !important */
}

Fixes #10 
