### PR TITLE
fix(terminal): always scroll buffer on wheel, regardless of mouse tracking

### DIFF
--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -192,6 +192,35 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
     // Open terminal in the DOM
     terminal.open(terminalRef.current);
 
+    // Always scroll wmux's buffer on wheel — never forward to the app.
+    // Without this, when a TUI (Claude Code, vim, tmux…) enables mouse
+    // tracking via DECSET 1000/1002/1003/1006, xterm.js sends wheel
+    // events to the app instead of scrolling the buffer (see
+    // @xterm/xterm Terminal.ts wheel handler: `if (requestedEvents.wheel) return`).
+    // That has two visible effects: scrollback is dead, AND the app paints
+    // a cell highlight that tracks the mouse cursor. We intercept on the
+    // capture phase before xterm's listener runs.
+    const wheelHost = terminalRef.current;
+    const onWheelCapture = (ev: WheelEvent) => {
+      if (ev.deltaY === 0) return;
+      ev.preventDefault();
+      ev.stopPropagation();
+      let amount: number;
+      if (ev.deltaMode === 1 /* DOM_DELTA_LINE */) {
+        amount = ev.deltaY;
+      } else if (ev.deltaMode === 2 /* DOM_DELTA_PAGE */) {
+        amount = ev.deltaY * (terminal.rows || 24);
+      } else {
+        amount = ev.deltaY / 17;
+      }
+      const lines = Math.sign(amount) * Math.max(1, Math.round(Math.abs(amount)));
+      if (lines !== 0) terminal.scrollLines(lines);
+    };
+    wheelHost.addEventListener('wheel', onWheelCapture, { capture: true, passive: false });
+    cleanupFnsRef.current.push(() => {
+      wheelHost.removeEventListener('wheel', onWheelCapture, { capture: true } as any);
+    });
+
     // Korean/CJK IME reliability fix.
     // xterm.js 5.5's CompositionHelper._finalizeComposition defers reading the
     // textarea via setTimeout(0), which races against fast Hangul composition


### PR DESCRIPTION
## Summary

Inside a wmux pane, TUIs that enable xterm mouse tracking via DECSET 1000/1002/1003/1006 (Claude Code, vim, tmux, lazygit, htop, …) broke wheel scrolling and painted a small highlight rectangle that followed the mouse cursor. This PR fixes both with a single capture-phase wheel listener.

## Root cause

xterm.js's wheel handler forwards wheel events to the application instead of scrolling its own buffer when `requestedEvents.wheel` is set (see `@xterm/xterm` `Terminal.ts`: `if (requestedEvents.wheel) return`). Two visible symptoms share that root cause:

1. **Scrollback dead** — wheel events get encoded as button-4/5 mouse reports and sent to the app; xterm's buffer never moves.
2. **Rectangle tracking the cursor** — the cell-resolution motion reports the app receives weren't being consumed for scroll, so the app rendered them as a hover highlight.

## Fix

Install a capture-phase `wheel` listener on the terminal host element. It `preventDefault`s the event and calls `terminal.scrollLines(...)` directly, so xterm's own listener never runs and the app never sees the wheel event.

What's preserved:
- Mouse-button reports still work (clicks, drags, button release)
- Mouse-motion reports still work (just not as wheel)
- Selection, copy, paste behavior unchanged
- WebGL renderer unchanged

## Test plan

- [x] Type-check passes (`npm run build:main`)
- [x] Unit tests pass (5 pre-existing `pty-manager.test.ts` failures unrelated to this change; identical on `master`)
- [ ] Manual: open Claude Code / vim / tmux inside a pane, wheel-scroll works, no hover rectangle

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>