### PR TITLE
feat: WMUX_INSTANCE for side-by-side dev/prod instances

### DIFF
--- a/src/cli/wmux-hook.ts
+++ b/src/cli/wmux-hook.ts
@@ -7,7 +7,7 @@
 import net from 'net';
 
 const tool = process.argv[2] || 'unknown';
-const pipePath = '\\\\.\\pipe\\wmux';
+const pipePath = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
 
 const client = net.connect({ path: pipePath }, () => {
   const msg = JSON.stringify({ method: 'hook.event', params: { tool }, id: 1 });

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -2,7 +2,9 @@
 
 import net from 'net';
 
-const PIPE_PATH = '\\\\.\\pipe\\wmux';
+// Respect WMUX_PIPE when set (e.g. by a parent wmux running with WMUX_INSTANCE),
+// so the CLI talks to the same instance that spawned the shell.
+const PIPE_PATH = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
 
 function sendV1(command: string): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import { GitPoller } from './git-poller';
 import { PrPoller } from './pr-poller';
 import { CDPProxy } from './cdp-proxy';
 import { IPC_CHANNELS } from '../shared/types';
+import { getPipePath } from '../shared/instance';
 import { loadSession, saveSession, handleVersionChange, SessionData } from './session-persistence';
 import { WindowManager } from './window-manager';
 import { initAutoUpdater } from './updater';
@@ -40,7 +41,7 @@ async function ensureBrowserPanel(): Promise<boolean> {
 }
 
 const windowManager = new WindowManager();
-const pipeServer = new PipeServer();
+const pipeServer = new PipeServer(getPipePath());
 const portScanner = new PortScanner();
 const gitPoller = new GitPoller();
 const prPoller = new PrPoller();

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import { execFileSync } from 'child_process';
 import { v4 as uuidv4 } from 'uuid';
 import { SurfaceId } from '../shared/types';
+import { getPipePath } from '../shared/instance';
 
 // ─── Shell resolution ──────────────────────────────────────────────────────
 // Validates that a shell executable exists before spawning.
@@ -133,7 +134,7 @@ export class PtyManager {
       ...options.env,
       WMUX: '1',
       WMUX_SURFACE_ID: id,
-      WMUX_PIPE: '\\\\.\\pipe\\wmux',
+      WMUX_PIPE: getPipePath(),
       WMUX_CLI: cliPath,
     };
 

--- a/src/main/session-persistence.ts
+++ b/src/main/session-persistence.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
+import { getAppDataDir } from '../shared/instance';
 
-const APPDATA_DIR = path.join(process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'), 'wmux');
+const APPDATA_DIR = getAppDataDir();
 const SESSIONS_DIR = path.join(APPDATA_DIR, 'sessions');
 const SESSION_FILE = path.join(SESSIONS_DIR, 'session.json');
 const VERSION_FILE = path.join(APPDATA_DIR, 'app-version.txt');

--- a/src/shared/instance.ts
+++ b/src/shared/instance.ts
@@ -1,0 +1,24 @@
+/**
+ * wmux instance identity.
+ *
+ * Set WMUX_INSTANCE=<name> to run wmux as a separate, side-by-side instance:
+ * the named pipe and APPDATA directory get a "-<name>" suffix, so a dev build
+ * can run alongside an installed production wmux without colliding on the
+ * pipe (Windows pipes are exclusive) or overwriting session.json.
+ */
+import path from 'path';
+import os from 'os';
+
+function suffix(): string {
+  const name = process.env.WMUX_INSTANCE?.trim();
+  return name ? `-${name}` : '';
+}
+
+export function getPipePath(): string {
+  return `\\\\.\\pipe\\wmux${suffix()}`;
+}
+
+export function getAppDataDir(): string {
+  const base = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+  return path.join(base, `wmux${suffix()}`);
+}


### PR DESCRIPTION
## Summary

Adds a `WMUX_INSTANCE=<name>` environment variable that lets a dev build of wmux run alongside an installed production wmux without colliding on the named pipe (which is exclusive on Windows) or overwriting the user's `session.json`.

Set `WMUX_INSTANCE=dev` and the running instance uses:
- Pipe: `\.\pipe\wmux-dev` instead of `\.\pipe\wmux`
- APPDATA: `%APPDATA%\wmux-dev\` instead of `%APPDATA%\wmux\`

Unset → unchanged default behavior, no observable difference for existing users.

## Motivation

Today, running `npm run dev` while a daily-driver wmux is running fights over:
1. **The named pipe** — `PipeServer.start()` fails to bind because the production instance already owns `\.\pipe\wmux`. CLI/agent commands from the dev instance break silently.
2. **`%APPDATA%\wmux\sessions\session.json`** — both instances auto-save (30s), so the dev instance overwrites the user's live workspace state. On next restart of the daily-driver wmux, sessions are gone.

This makes verifying fixes in dev hostile to the user's actual work. With this PR you can:

```powershell
$env:WMUX_INSTANCE = "dev"
npm run dev
```

…and the dev instance is fully isolated.

## Design

One tiny shared helper (`src/shared/instance.ts`) exposes `getPipePath()` and `getAppDataDir()`. Both derive a suffix from `process.env.WMUX_INSTANCE`. Five sites now go through the helper:

- `src/main/index.ts` — `new PipeServer(getPipePath())`
- `src/main/pty-manager.ts` — `WMUX_PIPE` injected into PTY env
- `src/main/session-persistence.ts` — `APPDATA_DIR` source
- `src/cli/wmux.ts`, `src/cli/wmux-hook.ts` — prefer `process.env.WMUX_PIPE` (which the main process injects), fall back to the default

That last bit is what makes the CLI inside a spawned shell talk back to the correct instance.

## Test plan

- [x] `npm run build:main` passes
- [x] `pipe-server.test.ts` (4) and `session-persistence.test.ts` (4) pass
- [x] No public API changes; default behavior unchanged when `WMUX_INSTANCE` is unset
- [ ] Manual: run two instances side-by-side, confirm pipes and APPDATA are independent

## Notes

- The 5 failing `pty-manager.test.ts` tests on this branch are pre-existing and identical on `master` (Windows shell-spawn environment issue).
- The unrelated wheel-scroll fix lives in a separate PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>