### PR TITLE
fix(pane): prevent drop zones from blocking clicks after workspace switch

### DIFF
--- a/src/renderer/components/SplitPane/PaneWrapper.tsx
+++ b/src/renderer/components/SplitPane/PaneWrapper.tsx
@@ -152,6 +152,15 @@ export default function PaneWrapper({ leaf, workspaceId, isFocused }: PaneWrappe
 
   const isWorkspaceActive = workspaceId === activeWorkspaceId;
 
+  // Safety net: reset stale drag state when this workspace becomes active.
+  // If a drop on an edge/center zone detaches the source element before dragend
+  // fires, other panes stay stuck with dragActive=true across workspace switches.
+  useEffect(() => {
+    if (isWorkspaceActive) {
+      setDragActive(false);
+    }
+  }, [isWorkspaceActive]);
+
   const renderAllSurfaces = () =>
     surfaces.map((surface, index) => {
       const isActive = index === activeSurfaceIndex;
@@ -257,7 +266,6 @@ export default function PaneWrapper({ leaf, workspaceId, isFocused }: PaneWrappe
 
   const handleEdgeDrop = (e: React.DragEvent, direction: 'left' | 'right' | 'up' | 'down') => {
     e.preventDefault();
-    e.stopPropagation();
     setDragActive(false);
     document.body.classList.remove('wmux-dragging');
     const data = e.dataTransfer.getData('application/wmux-surface');
@@ -270,7 +278,6 @@ export default function PaneWrapper({ leaf, workspaceId, isFocused }: PaneWrappe
 
   const handleCenterDrop = (e: React.DragEvent) => {
     e.preventDefault();
-    e.stopPropagation();
     setDragActive(false);
     document.body.classList.remove('wmux-dragging');
     const data = e.dataTransfer.getData('application/wmux-surface');


### PR DESCRIPTION
## Summary

- Removes `e.stopPropagation()` from `handleEdgeDrop` and `handleCenterDrop` in `PaneWrapper.tsx`
- Adds a safety-net `useEffect` that clears `dragActive` whenever a workspace becomes active

## Root cause

In React 17+, synthetic event handlers fire at the React root container (not `document`). Calling `stopPropagation()` inside `handleEdgeDrop` / `handleCenterDrop` prevented the native `drop` event from bubbling past the React root to `document`. Every other `PaneWrapper` listens at the `document` level for `drop` to reset `dragActive = false` — they never received the event and stayed permanently stuck with `dragActive = true`.

After any tab drag-to-split, all panes in all workspaces had `dragActive = true`. Switching to another workspace then rendered the drop zone overlay (the "highlighted sections") over every terminal with `pointer-events: auto`, blocking all mouse interaction.

## Fix

1. **Remove `stopPropagation()`** from both drop handlers so the native `drop` event propagates to `document` and all `PaneWrapper` instances reset correctly.
2. **Safety-net `useEffect`** — clears `dragActive` when `isWorkspaceActive` transitions to `true`, covering the edge case where `dragend` fires on a detached DOM element (e.g. when `splitAndMoveSurface` removes the source tab from the tree before `dragend` fires) and never reaches `document`.

## Test plan

- [x] Drag a terminal tab to an edge drop zone to split the pane
- [x] Switch to another workspace — no highlighted overlay sections should appear, terminal clicks should work normally
- [x] Drag a terminal tab to the center drop zone to merge panes, then switch workspace — same result
- [x] Verify normal tab reordering (drag within the tab bar) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)