### PR TITLE
feat(osc52): support tmux clipboard writes via OSC 52

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -176,6 +176,13 @@ export function registerIpcHandlers(windowManager: WindowManager, cdpProxyInstan
     return agentManager.getStatus(agentId as AgentId);
   });
 
+  // Clipboard text write: used by the OSC 52 handler in the renderer.
+  // navigator.clipboard.writeText() requires a user-gesture context; PTY data
+  // callbacks don't qualify, so we route through Electron's clipboard module.
+  ipcMain.handle('clipboard:write-text', (_event, text: string) => {
+    clipboard.writeText(text);
+  });
+
   // Clipboard image paste: save clipboard image to temp file, return path
   ipcMain.handle('clipboard:paste-image', async () => {
     const img = clipboard.readImage();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -81,6 +81,7 @@ contextBridge.exposeInMainWorld('wmux', {
   },
   clipboard: {
     pasteImage: () => ipcRenderer.invoke('clipboard:paste-image'),
+    writeText: (text: string) => ipcRenderer.invoke('clipboard:write-text', text),
   },
   update: {
     getLatest: () => ipcRenderer.invoke(IPC_CHANNELS.UPDATE_GET_LATEST),

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -301,6 +301,20 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
       return true;
     });
 
+    // OSC 52: clipboard write — emitted by tmux when text is copied (set-clipboard on).
+    // navigator.clipboard.writeText() requires a user-gesture context which PTY data
+    // callbacks don't have, so we go through Electron's clipboard module via IPC.
+    terminal.parser.registerOscHandler(52, (data) => {
+      const semi = data.indexOf(';');
+      const b64 = semi >= 0 ? data.slice(semi + 1) : data;
+      if (!b64 || b64 === '?') return true; // ignore read requests
+      try {
+        const text = atob(b64);
+        if (text) window.wmux?.clipboard?.writeText?.(text);
+      } catch {}
+      return true;
+    });
+
     // Use Canvas2D renderer instead of WebGL. WebGL has a hard per-process
     // limit (~16 contexts in Chromium); with N workspaces x M panes that ceiling
     // gets hit fast and Chromium force-loses the oldest contexts, which in


### PR DESCRIPTION
## Summary

- Registers an OSC 52 handler in xterm.js so tmux copy-mode writes reach the Windows system clipboard
- Routes through Electron's `clipboard` module via IPC rather than `navigator.clipboard`, which requires a user-gesture context that PTY data callbacks don't have
- Adds `clipboard:write-text` IPC channel in main process and exposes it via preload

## How it works

When tmux has `set-clipboard on` (provided by `tmux-sensible` by default), it emits `\x1b]52;c;<base64>\x07` to the outer terminal after each copy. wmux now handles that sequence and writes the decoded text to the Windows clipboard.

## Testing

1. Open a tmux session in a wmux terminal pane
2. Click and drag to select text — it should appear in the Windows clipboard
3. In a plain (non-tmux) pane: `printf '\033]52;c;dGVzdA==\007'` should write `test` to clipboard

No tmux config changes are required — `tmux-sensible` already enables the necessary settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)