### PR TITLE
fix(browser): remove hardcoded 800px max width on browser pane

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(npx tsc:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ release/
 
 # Local Netlify folder
 .netlify
+
+# Local Claude Code settings
+.claude/settings.local.json

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -703,7 +703,7 @@ export default function App() {
                 const startWidth = browserWidth;
                 const onMove = (ev: MouseEvent) => {
                   const delta = startX - ev.clientX;
-                  setBrowserWidth(Math.max(250, Math.min(800, startWidth + delta)));
+                  setBrowserWidth(Math.max(250, Math.min(window.innerWidth - 400, startWidth + delta)));
                 };
                 const onUp = () => {
                   setIsResizingBrowser(false);


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `800px` upper bound on browser pane width with `window.innerWidth - 400`, so the pane can scale with the window
- On larger displays (or when the terminal side only needs a narrow strip) the browser pane was artificially capped at 800px regardless of available space
- Also adds `.claude/settings.local.json` to `.gitignore` (local Claude Code settings should not be committed)

## Behaviour

| Before | After |
|--------|-------|
| Drag handle stops at 800px even on wide displays | Drag handle goes up to `windowWidth - 400px`, leaving at least 400px for the terminal side |

## Test plan

- [ ] Open a browser pane and drag the resize handle — confirm it can expand beyond 800px on a display wider than ~1200px
- [ ] Confirm the terminal side never collapses below 400px
- [ ] Confirm minimum browser pane width (250px) is still respected when dragging toward the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)