### PR TITLE
fix(clipboard): correct UTF-8 for terminal copy/paste (OSC 52)

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -202,6 +202,10 @@ export function registerIpcHandlers(windowManager: WindowManager, cdpProxyInstan
     clipboard.writeText(text);
   });
 
+  // Use Electron's clipboard for reads too — navigator.clipboard.readText() can
+  // return garbled text on Windows when the source app wrote a non-UTF-8 format.
+  ipcMain.handle('clipboard:read-text', () => clipboard.readText());
+
   // Clipboard image paste: save clipboard image to temp file, return path
   ipcMain.handle('clipboard:paste-image', async () => {
     const img = clipboard.readImage();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -89,6 +89,7 @@ contextBridge.exposeInMainWorld('wmux', {
   clipboard: {
     pasteImage: () => ipcRenderer.invoke('clipboard:paste-image'),
     writeText: (text: string) => ipcRenderer.invoke('clipboard:write-text', text),
+    readText: () => ipcRenderer.invoke('clipboard:read-text') as Promise<string>,
   },
   shell: {
     // Resolve a dropped File to its real filesystem path. Electron 33 removed

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -398,17 +398,23 @@ export function useKeyboardShortcuts(
         }
 
         case 'paste': {
-          navigator.clipboard.readText().then((text) => {
-            if (!text || !focusedPaneId || !activeWorkspaceId) return;
-            const ws = useStore.getState().workspaces.find((w) => w.id === activeWorkspaceId);
-            if (!ws) return;
-            const leaf = findLeaf(ws.splitTree, focusedPaneId);
-            if (!leaf) return;
-            const activeSurf = leaf.surfaces[leaf.activeSurfaceIndex];
-            if (activeSurf?.type === 'terminal') {
-              window.wmux?.pty?.write(activeSurf.id, text);
-            }
-          });
+          if (!focusedPaneId || !activeWorkspaceId) break;
+          const ws = useStore.getState().workspaces.find((w) => w.id === activeWorkspaceId);
+          if (!ws) break;
+          const leaf = findLeaf(ws.splitTree, focusedPaneId);
+          if (!leaf) break;
+          const activeSurf = leaf.surfaces[leaf.activeSurfaceIndex];
+          if (activeSurf?.type === 'terminal') {
+            // Delegate to the focused terminal instead of reading the clipboard
+            // here: navigator.clipboard.readText() garbles non-UTF-8 Windows
+            // clipboard formats (em dash → "â"), and a raw pty.write strips
+            // bracketed-paste markers (breaking multi-line paste in Claude Code).
+            // The terminal's handler reads via Electron's clipboard and uses
+            // terminal.paste(), matching the Ctrl+V path.
+            document.dispatchEvent(
+              new CustomEvent('wmux:paste-terminal', { detail: { surfaceId: activeSurf.id } }),
+            );
+          }
           break;
         }
 

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -359,7 +359,11 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
       // (handled) either way.
       if (b64 && b64 !== '?') {
         try {
-          const text = atob(b64);
+          // atob() yields a binary (Latin-1) string — one code point per byte.
+          // OSC 52 payloads are UTF-8, so decode the bytes as UTF-8; otherwise
+          // multi-byte chars (em dash E2 80 94) become mojibake (â€").
+          const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+          const text = new TextDecoder('utf-8').decode(bytes);
           if (text) window.wmux?.clipboard?.writeText?.(text);
         } catch {}
       }
@@ -406,14 +410,11 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
               handled = true;
             }
           }
-          // If no image, paste text
+          // If no image, paste text via Electron's clipboard API — navigator.clipboard
+          // can return garbled bytes on Windows when the source wrote a non-UTF-8 format.
           if (!handled && ptyIdRef.current) {
             try {
-              const text = await navigator.clipboard.readText();
-              // Use terminal.paste() — it honors bracketed-paste mode and emits
-              // the data through onData (already wired to PTY). Writing raw to
-              // pty.write strips the \x1b[200~/\x1b[201~ wrappers, so apps like
-              // Claude Code see each \n as Enter and only the first line lands.
+              const text = await window.wmux.clipboard.readText();
               if (text) terminal.paste(text);
             } catch {}
           }
@@ -545,6 +546,26 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Paste delegated from the keyboard-shortcut handler (e.g. Ctrl+Shift+V).
+  // Routed here so it shares the Ctrl+V path's correctness: Electron's
+  // clipboard.readText() (navigator.clipboard garbles non-UTF-8 Windows
+  // formats — em dash → "â") and terminal.paste() (honors bracketed-paste
+  // mode, so multi-line paste into Claude Code doesn't submit on the first \n).
+  useEffect(() => {
+    const handler = async (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.surfaceId !== surfaceId) return;
+      const term = xtermRef.current;
+      if (!term || !ptyIdRef.current) return;
+      try {
+        const text = await window.wmux.clipboard.readText();
+        if (text) term.paste(text);
+      } catch {}
+    };
+    document.addEventListener('wmux:paste-terminal', handler);
+    return () => document.removeEventListener('wmux:paste-terminal', handler);
+  }, [surfaceId]);
 
   // Apply theme + font whenever the resolved scheme or prefs change.
   // Keeps terminals reactive: changing the global theme in Settings, or


### PR DESCRIPTION
## Problem

Copying text containing multi-byte UTF-8 characters from a TUI app (Claude Code, or tmux with `set-clipboard on`) and pasting it back produced mojibake — e.g. an em dash `—` became `â€"`.

Root cause: these apps copy via the **OSC 52** clipboard escape sequence, whose payload is base64-encoded UTF-8. The handler decoded it with `atob()`, which returns a binary/Latin-1 string (one code point per byte), so the em dash bytes `E2 80 94` turned into code points `U+00E2 U+0080 U+0094`.

Plain xterm text-selection copy goes through `navigator.clipboard.writeText()` and was unaffected — which is exactly why "copy from the terminal works, copy from Claude doesn't."

## Fix

- **OSC 52 decode**: decode the base64 payload as UTF-8 (`TextDecoder` over the raw bytes) instead of `atob()`'s Latin-1 string. *(the actual bug)*
- **Paste hardening** (consistency):
  - Read the clipboard via Electron's `clipboard.readText()` instead of `navigator.clipboard.readText()` (no focus/permission requirement).
  - Route the `Ctrl+Shift+V` paste action through the terminal so it honors bracketed-paste mode — multi-line paste no longer submits on the first newline (e.g. pasting into Claude Code).

## Verification

Reproduced with an instrumented build logging clipboard reads/writes:
- Before: copying `foo — bar` from a TUI logged `U+00E2 U+0080 U+0094`.
- After: same copy logs `U+2014`, and the paste round-trips as `foo — bar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)