### PR TITLE
security: harden pipe auth, CDP proxy, markdown XSS, and webview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0",
+        "dompurify": "^3.4.11",
         "electron-updater": "^6.3.0",
         "marked": "^15.0.0",
         "node-pty": "^1.0.0",
@@ -2329,6 +2330,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
@@ -4430,6 +4438,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
+    "dompurify": "^3.4.11",
     "electron-updater": "^6.3.0",
     "marked": "^15.0.0",
     "node-pty": "^1.0.0",

--- a/resources/cli/wmux-hook.js
+++ b/resources/cli/wmux-hook.js
@@ -14,7 +14,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const net_1 = __importDefault(require("net"));
 const tool = process.argv[2] || 'unknown';
-const pipePath = '\\\\.\\pipe\\wmux';
+const pipePath = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
+const token = process.env.WMUX_PIPE_TOKEN || '';
 
 let stdinData = '';
 let sent = false;
@@ -42,7 +43,7 @@ function sendHook() {
     if (file) params.file = file;
 
     const client = net_1.default.connect({ path: pipePath }, () => {
-        const msg = JSON.stringify({ method: 'hook.event', params, id: 1 });
+        const msg = JSON.stringify({ method: 'hook.event', params, id: 1, token });
         client.write(msg + '\n', () => client.end());
     });
     client.on('error', () => {

--- a/resources/cli/wmux.js
+++ b/resources/cli/wmux.js
@@ -5,9 +5,29 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const net_1 = __importDefault(require("net"));
+const fs_1 = __importDefault(require("fs"));
+const os_1 = __importDefault(require("os"));
+const path_1 = __importDefault(require("path"));
 // Respect WMUX_PIPE when set (e.g. by a parent wmux running with WMUX_INSTANCE),
 // so the CLI talks to the same instance that spawned the shell.
 const PIPE_PATH = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
+// Auth token for privileged (V2) pipe requests. wmux injects WMUX_PIPE_TOKEN
+// into the shells it spawns; for CLIs launched elsewhere, fall back to the
+// token file in the instance's APPDATA dir (readable only by this user).
+function readPipeToken() {
+    const fromEnv = process.env.WMUX_PIPE_TOKEN?.trim();
+    if (fromEnv)
+        return fromEnv;
+    try {
+        const suffix = process.env.WMUX_INSTANCE?.trim() ? `-${process.env.WMUX_INSTANCE.trim()}` : '';
+        const base = process.env.APPDATA || path_1.default.join(os_1.default.homedir(), 'AppData', 'Roaming');
+        return fs_1.default.readFileSync(path_1.default.join(base, `wmux${suffix}`, 'pipe-token'), 'utf-8').trim();
+    }
+    catch {
+        return '';
+    }
+}
+const PIPE_TOKEN = readPipeToken();
 function sendV1(command) {
     return new Promise((resolve, reject) => {
         const client = net_1.default.connect({ path: PIPE_PATH }, () => {
@@ -23,7 +43,7 @@ function sendV1(command) {
 function sendV2(method, params = {}) {
     return new Promise((resolve, reject) => {
         const client = net_1.default.connect({ path: PIPE_PATH }, () => {
-            const request = JSON.stringify({ method, params, id: 1 });
+            const request = JSON.stringify({ method, params, id: 1, token: PIPE_TOKEN });
             client.write(request + '\n');
         });
         let data = '';

--- a/src/cli/wmux-hook.ts
+++ b/src/cli/wmux-hook.ts
@@ -8,9 +8,10 @@ import net from 'net';
 
 const tool = process.argv[2] || 'unknown';
 const pipePath = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
+const token = process.env.WMUX_PIPE_TOKEN || '';
 
 const client = net.connect({ path: pipePath }, () => {
-  const msg = JSON.stringify({ method: 'hook.event', params: { tool }, id: 1 });
+  const msg = JSON.stringify({ method: 'hook.event', params: { tool }, id: 1, token });
   client.write(msg + '\n', () => client.end());
 });
 

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -1,10 +1,29 @@
 #!/usr/bin/env node
 
 import net from 'net';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 // Respect WMUX_PIPE when set (e.g. by a parent wmux running with WMUX_INSTANCE),
 // so the CLI talks to the same instance that spawned the shell.
 const PIPE_PATH = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
+
+// Auth token for privileged (V2) pipe requests. wmux injects WMUX_PIPE_TOKEN
+// into the shells it spawns; for CLIs launched elsewhere, fall back to the
+// token file in the instance's APPDATA dir (readable only by this user).
+function readPipeToken(): string {
+  const fromEnv = process.env.WMUX_PIPE_TOKEN?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    const suffix = process.env.WMUX_INSTANCE?.trim() ? `-${process.env.WMUX_INSTANCE.trim()}` : '';
+    const base = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
+    return fs.readFileSync(path.join(base, `wmux${suffix}`, 'pipe-token'), 'utf-8').trim();
+  } catch {
+    return '';
+  }
+}
+const PIPE_TOKEN = readPipeToken();
 
 function sendV1(command: string): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -22,7 +41,7 @@ function sendV1(command: string): Promise<string> {
 function sendV2(method: string, params: Record<string, any> = {}): Promise<any> {
   return new Promise((resolve, reject) => {
     const client = net.connect({ path: PIPE_PATH }, () => {
-      const request = JSON.stringify({ method, params, id: 1 });
+      const request = JSON.stringify({ method, params, id: 1, token: PIPE_TOKEN });
       client.write(request + '\n');
     });
     let data = '';

--- a/src/main/cdp-proxy.ts
+++ b/src/main/cdp-proxy.ts
@@ -6,6 +6,52 @@ import { webContents } from 'electron';
 const DEFAULT_PORT = 9222;
 const MAX_PORT = 9230;
 
+// DNS-rebinding guard. The proxy binds to loopback only, but a browser on the
+// same machine can still reach it if a malicious page resolves an attacker
+// domain to 127.0.0.1. Chrome's own remote-debugging endpoint rejects such
+// requests by requiring the Host header to be a loopback literal (or absent,
+// as with non-HTTP WebSocket/native clients). We mirror that policy so the
+// full CDP surface (Runtime.evaluate ⇒ arbitrary JS in the webview) can't be
+// driven from a web origin.
+export function isAllowedCdpHost(hostHeader: string | undefined): boolean {
+  // Native CDP clients (e.g. raw ws) may omit Host — allow only when absent.
+  if (hostHeader === undefined) return true;
+  // Strip optional :port. Bracketed IPv6 arrives as "[::1]:9222"; a bare IPv6
+  // literal ("::1") has multiple colons and no port to strip.
+  let host = hostHeader.trim();
+  if (host.startsWith('[')) {
+    const end = host.indexOf(']');
+    host = end === -1 ? host.slice(1) : host.slice(1, end);
+  } else {
+    const colon = host.indexOf(':');
+    // Only treat a single trailing :port as a port (IPv4 / hostname). Multiple
+    // colons with no brackets ⇒ bare IPv6 literal, leave intact.
+    if (colon !== -1 && host.indexOf(':', colon + 1) === -1) {
+      host = host.slice(0, colon);
+    }
+  }
+  host = host.toLowerCase();
+  return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '0:0:0:0:0:0:0:1';
+}
+
+// Origin guard for the WebSocket upgrade. The Host check alone is NOT enough:
+// WebSocket connections are exempt from CORS preflight, so a malicious page in
+// the user's browser can open ws://127.0.0.1:9222 directly — the browser sends
+// Host: 127.0.0.1:9222 (which passes isAllowedCdpHost) but also an Origin
+// header identifying the web page. Driving the proxy then yields
+// Runtime.evaluate (arbitrary JS in the webview) ⇒ RCE-equivalent.
+//
+// Legit CDP clients (chrome-devtools-mcp / puppeteer-core / raw `ws`) do NOT
+// send an Origin header, while browsers ALWAYS send one for a page-initiated
+// WebSocket. So we allow only an absent Origin (plus the DevTools front-end
+// scheme) and reject every web/file origin — mirroring Chrome's own
+// --remote-allow-origins policy.
+export function isAllowedCdpOrigin(origin: string | undefined): boolean {
+  if (origin === undefined || origin === '') return true;
+  if (origin.toLowerCase().startsWith('devtools://')) return true;
+  return false;
+}
+
 export class CDPProxy {
   private server: http.Server | null = null;
   private wss: WebSocketServer | null = null;
@@ -30,6 +76,14 @@ export class CDPProxy {
   async start(): Promise<void> {
     this.server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'application/json');
+
+      // Reject cross-origin (DNS-rebinding) requests before exposing any
+      // CDP target metadata or WebSocket debugger URLs.
+      if (!isAllowedCdpHost(req.headers.host)) {
+        res.statusCode = 403;
+        res.end(JSON.stringify({ error: 'Forbidden host' }));
+        return;
+      }
 
       if (req.url === '/json/version') {
         res.end(JSON.stringify({
@@ -67,8 +121,16 @@ export class CDPProxy {
       res.end('{}');
     });
 
-    // WebSocket server using ws library (handles handshake properly)
-    this.wss = new WebSocketServer({ server: this.server });
+    // WebSocket server using ws library (handles handshake properly).
+    // verifyClient applies BOTH a loopback-only Host policy AND an Origin policy
+    // to the WS upgrade. The Host check stops DNS-rebinding; the Origin check
+    // stops a page in the user's own browser from opening this debugger socket
+    // directly (WebSockets bypass CORS, so a passing Host isn't sufficient).
+    this.wss = new WebSocketServer({
+      server: this.server,
+      verifyClient: (info: { req: http.IncomingMessage }) =>
+        isAllowedCdpHost(info.req.headers.host) && isAllowedCdpOrigin(info.req.headers.origin),
+    });
 
     this.wss.on('connection', (ws) => {
       if (!this.webContentsId) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,7 +7,7 @@ import { GitPoller } from './git-poller';
 import { PrPoller } from './pr-poller';
 import { CDPProxy } from './cdp-proxy';
 import { IPC_CHANNELS, SurfaceId } from '../shared/types';
-import { getPipePath, getAppDataDir } from '../shared/instance';
+import { getPipePath, getAppDataDir, ensurePipeToken } from '../shared/instance';
 import { loadSession, saveSession, handleVersionChange, SessionData } from './session-persistence';
 import { WindowManager } from './window-manager';
 import { initAutoUpdater } from './updater';
@@ -43,7 +43,12 @@ async function ensureBrowserPanel(): Promise<boolean> {
 }
 
 const windowManager = new WindowManager();
-const pipeServer = new PipeServer(getPipePath());
+// Per-instance secret that authenticates privileged (V2) pipe requests.
+// Generated/persisted once per APPDATA dir and injected into spawned shells
+// as WMUX_PIPE_TOKEN so the CLI and hooks can authenticate.
+const pipeToken = ensurePipeToken();
+process.env.WMUX_PIPE_TOKEN = pipeToken;
+const pipeServer = new PipeServer(getPipePath(), pipeToken);
 const portScanner = new PortScanner();
 const gitPoller = new GitPoller();
 const prPoller = new PrPoller();
@@ -188,9 +193,56 @@ if (!gotInstanceLock) {
   });
 }
 
+// ─── Webview / navigation hardening (issue #9) ────────────────────────────────
+// The renderer hosts <webview> tags that load arbitrary web content. Lock down
+// the attack surface so a compromised/hostile page can't escalate:
+//  - strip Node integration & preload from attached webviews
+//  - block window.open popups (route http/https to the OS browser instead)
+//  - prevent the top-level app window from navigating away from its own UI
+function hardenWebContents(): void {
+  app.on('web-contents-created', (_event, contents) => {
+    const type = contents.getType();
+
+    if (type === 'webview') {
+      // Enforce safe webview preferences regardless of attributes set in the DOM.
+      contents.on('will-attach-webview', (_e, webPreferences, params) => {
+        delete (webPreferences as any).preload;
+        delete (webPreferences as any).preloadURL;
+        webPreferences.nodeIntegration = false;
+        webPreferences.contextIsolation = true;
+        (params as any).nodeintegration = 'false';
+      });
+    }
+
+    // Open new-window requests externally rather than spawning in-app windows
+    // with full privileges. Only http/https go to the OS browser; deny the rest.
+    contents.setWindowOpenHandler(({ url }) => {
+      if (/^https?:\/\//i.test(url)) {
+        void shell.openExternal(url);
+      }
+      return { action: 'deny' };
+    });
+
+    // The main app window (loads localhost in dev, file:// in prod) must never
+    // be navigated to remote content. Webviews host their own contents and are
+    // exempt — their navigation is the whole point.
+    if (type !== 'webview') {
+      contents.on('will-navigate', (e, url) => {
+        const isDevServer = url.startsWith('http://localhost:') || url.startsWith('http://127.0.0.1:');
+        const isLocalFile = url.startsWith('file://');
+        if (!isDevServer && !isLocalFile) {
+          e.preventDefault();
+          if (/^https?:\/\//i.test(url)) void shell.openExternal(url);
+        }
+      });
+    }
+  });
+}
+
 app.whenReady().then(() => {
   // A losing second instance is already quitting; don't run startup side effects.
   if (!gotInstanceLock) return;
+  hardenWebContents();
   // Inject wmux instructions into ~/.claude/CLAUDE.md for Claude Code awareness
   ensureClaudeContext();
   ensureClaudeHooks();
@@ -666,6 +718,22 @@ app.whenReady().then(() => {
           try {
             const filePath = request.params?.filePath || request.params?.path || request.params?.file;
             if (!filePath) { respondError(-32000, 'No file path provided'); return; }
+            // Defense-in-depth: even with a valid pipe token, only render plain
+            // text/markdown files and cap the size, so this can't be used to
+            // slurp secrets (e.g. id_rsa, .env) into the markdown viewer.
+            const ALLOWED_MD_EXT = new Set(['.md', '.markdown', '.mdx', '.txt', '.text', '.rst']);
+            const ext = path.extname(filePath).toLowerCase();
+            if (!ALLOWED_MD_EXT.has(ext)) {
+              respondError(-32602, `Unsupported file type for markdown.load_file: ${ext || '(none)'}`);
+              return;
+            }
+            let stat: fs.Stats;
+            try { stat = fs.statSync(filePath); } catch { respondError(-32000, 'File not found'); return; }
+            const MAX_MD_BYTES = 5 * 1024 * 1024;
+            if (!stat.isFile() || stat.size > MAX_MD_BYTES) {
+              respondError(-32602, 'File is not a regular file or exceeds 5MB limit');
+              return;
+            }
             const content = fs.readFileSync(filePath, 'utf-8');
             const win = BrowserWindow.getAllWindows()[0];
             if (!win || win.isDestroyed()) { respondError(-32000, 'No window'); return; }

--- a/src/main/pipe-server.ts
+++ b/src/main/pipe-server.ts
@@ -1,5 +1,6 @@
 import net from 'net';
 import { EventEmitter } from 'events';
+import { tokensMatch } from '../shared/instance';
 
 export interface V1Command {
   command: string;
@@ -11,7 +12,20 @@ export interface V2Request {
   method: string;
   params: Record<string, any>;
   id?: string | number;
+  token?: string;
 }
+
+// V2 methods that are safe to call without authentication. These are read-only
+// or telemetry-style and don't grant code execution / file access. Everything
+// else (agent.spawn, browser.eval, markdown.load_file, pane/workspace mutation,
+// …) requires a valid per-instance token. Keeping an allowlist (rather than a
+// blocklist) means any new privileged method is locked down by default.
+const PUBLIC_V2_METHODS = new Set<string>([
+  'system.identify',
+  'system.capabilities',
+  'hook.event',
+  'agent.activity',
+]);
 
 export interface V2Response {
   result?: any;
@@ -22,10 +36,12 @@ export interface V2Response {
 export class PipeServer extends EventEmitter {
   private server: net.Server | null = null;
   private pipePath: string;
+  private authToken: string;
 
-  constructor(pipePath = '\\\\.\\pipe\\wmux') {
+  constructor(pipePath = '\\\\.\\pipe\\wmux', authToken = '') {
     super();
     this.pipePath = pipePath;
+    this.authToken = authToken;
   }
 
   start(): void {
@@ -136,6 +152,20 @@ export class PipeServer extends EventEmitter {
       const response: V2Response = { error: { code, message }, id: request.id };
       socket.write(JSON.stringify(response) + '\n');
     };
+
+    // Authenticate privileged methods. Public methods (identify/capabilities/
+    // hooks) are exempt so detection and shell/agent telemetry keep working
+    // without a token. -32001 signals "unauthorized" to clients.
+    if (!PUBLIC_V2_METHODS.has(request.method)) {
+      if (!this.authToken) {
+        respondError(-32001, 'Unauthorized: pipe auth token not initialized');
+        return;
+      }
+      if (!tokensMatch(request.token || '', this.authToken)) {
+        respondError(-32001, 'Unauthorized: missing or invalid token');
+        return;
+      }
+    }
 
     // Emit the V2 request and let handlers respond
     const handled = this.emit('v2', request, respond, respondError);

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import { execFileSync } from 'child_process';
 import { v4 as uuidv4 } from 'uuid';
 import { SurfaceId } from '../shared/types';
-import { getPipePath } from '../shared/instance';
+import { getPipePath, readPipeToken } from '../shared/instance';
 
 // ─── Shell resolution ──────────────────────────────────────────────────────
 // Validates that a shell executable exists before spawning.
@@ -135,6 +135,7 @@ export class PtyManager {
       WMUX: '1',
       WMUX_SURFACE_ID: id,
       WMUX_PIPE: getPipePath(),
+      WMUX_PIPE_TOKEN: readPipeToken(),
       WMUX_CLI: cliPath,
     };
 

--- a/src/renderer/components/Markdown/MarkdownPane.tsx
+++ b/src/renderer/components/Markdown/MarkdownPane.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 import { openInWmuxBrowser } from '../../utils/open-in-browser';
 import '../../styles/markdown.css';
 
@@ -17,7 +18,16 @@ export default function MarkdownPane({ content = '', surfaceId }: MarkdownPanePr
       breaks: true,
     });
 
-    return marked.parse(content) as string;
+    // Markdown can arrive from untrusted sources (CLI/pipe callers, agents,
+    // loaded files). marked emits raw HTML, so sanitize before injecting it
+    // via dangerouslySetInnerHTML to prevent XSS in the renderer (which has
+    // preload/IPC access). FORBID javascript: URIs and event handlers.
+    const rawHtml = marked.parse(content) as string;
+    return DOMPurify.sanitize(rawHtml, {
+      USE_PROFILES: { html: true },
+      FORBID_TAGS: ['style', 'form', 'input', 'button', 'textarea', 'select'],
+      FORBID_ATTR: ['style'],
+    });
   }, [content]);
 
   const handleClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {

--- a/src/shared/instance.ts
+++ b/src/shared/instance.ts
@@ -6,6 +6,8 @@
  * can run alongside an installed production wmux without colliding on the
  * pipe (Windows pipes are exclusive) or overwriting session.json.
  */
+import crypto from 'crypto';
+import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
@@ -21,4 +23,70 @@ export function getPipePath(): string {
 export function getAppDataDir(): string {
   const base = process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming');
   return path.join(base, `wmux${suffix()}`);
+}
+
+/**
+ * Path to the per-instance auth token used to authenticate privileged (V2)
+ * pipe requests. Stored under the instance's APPDATA dir, which is only
+ * readable by the current user — so only processes running as this user can
+ * read the token and drive the pipe (preventing the unauthenticated local RCE
+ * via agent.spawn / browser.eval / markdown.load_file).
+ */
+export function getPipeTokenPath(): string {
+  return path.join(getAppDataDir(), 'pipe-token');
+}
+
+/**
+ * Reads the auth token a CLI/hook client must send. Resolution order:
+ *   1. WMUX_PIPE_TOKEN env var (injected by wmux into spawned shells)
+ *   2. the token file in APPDATA (for clients launched outside a wmux shell)
+ * Returns '' when none is available.
+ */
+export function readPipeToken(): string {
+  const fromEnv = process.env.WMUX_PIPE_TOKEN?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    return fs.readFileSync(getPipeTokenPath(), 'utf-8').trim();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Loads the existing instance token or generates+persists a new one. Called by
+ * the main process at startup. The file is written with 0600 so other users
+ * on the machine cannot read it.
+ */
+export function ensurePipeToken(): string {
+  const tokenPath = getPipeTokenPath();
+  try {
+    const existing = fs.readFileSync(tokenPath, 'utf-8').trim();
+    if (existing) return existing;
+  } catch {
+    // No token yet — fall through and create one.
+  }
+  const token = crypto.randomBytes(32).toString('hex');
+  try {
+    fs.mkdirSync(path.dirname(tokenPath), { recursive: true });
+    fs.writeFileSync(tokenPath, token, { encoding: 'utf-8', mode: 0o600 });
+    try { fs.chmodSync(tokenPath, 0o600); } catch { /* best-effort on Windows */ }
+  } catch (err) {
+    console.warn('[wmux] Failed to persist pipe token:', err);
+  }
+  return token;
+}
+
+/**
+ * Timing-safe comparison of two tokens.
+ */
+export function tokensMatch(a: string, b: string): boolean {
+  if (!a || !b) return false;
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  try {
+    return crypto.timingSafeEqual(bufA, bufB);
+  } catch {
+    return false;
+  }
 }

--- a/tests/unit/cdp-proxy.test.ts
+++ b/tests/unit/cdp-proxy.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// cdp-proxy.ts imports `electron` at module scope; stub it so the pure
+// host-check function can be tested without an Electron runtime.
+vi.mock('electron', () => ({
+  webContents: { fromId: () => undefined },
+}));
+
+import { isAllowedCdpHost, isAllowedCdpOrigin } from '../../src/main/cdp-proxy';
+
+describe('isAllowedCdpHost (DNS-rebinding guard)', () => {
+  it('allows loopback literals with the proxy port', () => {
+    expect(isAllowedCdpHost('localhost:9222')).toBe(true);
+    expect(isAllowedCdpHost('127.0.0.1:9222')).toBe(true);
+    expect(isAllowedCdpHost('localhost')).toBe(true);
+    expect(isAllowedCdpHost('127.0.0.1')).toBe(true);
+  });
+
+  it('allows IPv6 loopback', () => {
+    expect(isAllowedCdpHost('[::1]:9222')).toBe(true);
+    expect(isAllowedCdpHost('[::1]')).toBe(true);
+    expect(isAllowedCdpHost('::1')).toBe(true);
+  });
+
+  it('allows requests with no Host header (native ws clients)', () => {
+    expect(isAllowedCdpHost(undefined)).toBe(true);
+  });
+
+  it('rejects attacker-controlled hostnames that rebind to loopback', () => {
+    expect(isAllowedCdpHost('evil.com')).toBe(false);
+    expect(isAllowedCdpHost('evil.com:9222')).toBe(false);
+    expect(isAllowedCdpHost('attacker.localhost.evil.com:9222')).toBe(false);
+    expect(isAllowedCdpHost('localhost.evil.com')).toBe(false);
+  });
+
+  it('rejects non-loopback IPs', () => {
+    expect(isAllowedCdpHost('0.0.0.0:9222')).toBe(false);
+    expect(isAllowedCdpHost('192.168.1.10:9222')).toBe(false);
+    expect(isAllowedCdpHost('10.0.0.1')).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isAllowedCdpHost('LOCALHOST:9222')).toBe(true);
+  });
+});
+
+describe('isAllowedCdpOrigin (browser-origin guard)', () => {
+  it('allows requests with no Origin header (native CDP clients)', () => {
+    expect(isAllowedCdpOrigin(undefined)).toBe(true);
+    expect(isAllowedCdpOrigin('')).toBe(true);
+  });
+
+  it('allows the DevTools front-end scheme', () => {
+    expect(isAllowedCdpOrigin('devtools://devtools')).toBe(true);
+  });
+
+  it('rejects web origins even when they point at loopback', () => {
+    expect(isAllowedCdpOrigin('http://127.0.0.1:9222')).toBe(false);
+    expect(isAllowedCdpOrigin('http://localhost:3000')).toBe(false);
+    expect(isAllowedCdpOrigin('https://evil.com')).toBe(false);
+    expect(isAllowedCdpOrigin('null')).toBe(false);
+    expect(isAllowedCdpOrigin('file://')).toBe(false);
+  });
+});

--- a/tests/unit/pipe-server.test.ts
+++ b/tests/unit/pipe-server.test.ts
@@ -60,7 +60,7 @@ describe('PipeServer', () => {
 
   it('handles V2 JSON-RPC', async () => {
     const pipe = uniquePipe();
-    server = new PipeServer(pipe);
+    server = new PipeServer(pipe, 'test-token');
     server.on('v2', (req, respond) => {
       if (req.method === 'workspace.list') {
         respond({ workspaces: [] });
@@ -73,6 +73,7 @@ describe('PipeServer', () => {
       method: 'workspace.list',
       params: {},
       id: 1,
+      token: 'test-token',
     }));
     const parsed = JSON.parse(response);
     expect(parsed.result.workspaces).toEqual([]);
@@ -81,7 +82,7 @@ describe('PipeServer', () => {
 
   it('returns error for unknown V2 method', async () => {
     const pipe = uniquePipe();
-    server = new PipeServer(pipe);
+    server = new PipeServer(pipe, 'test-token');
     server.start();
     await new Promise(r => setTimeout(r, 200));
 
@@ -89,9 +90,91 @@ describe('PipeServer', () => {
       method: 'unknown.method',
       params: {},
       id: 2,
+      token: 'test-token',
     }));
     const parsed = JSON.parse(response);
     expect(parsed.error).toBeDefined();
     expect(parsed.error.code).toBe(-32601);
+  });
+
+  it('rejects privileged V2 methods without a token', async () => {
+    const pipe = uniquePipe();
+    server = new PipeServer(pipe, 'secret');
+    let handlerCalled = false;
+    server.on('v2', (req, respond) => { handlerCalled = true; respond({ ok: true }); });
+    server.start();
+    await new Promise(r => setTimeout(r, 200));
+
+    const response = await connectAndSend(pipe, JSON.stringify({
+      method: 'agent.spawn',
+      params: { cmd: 'calc.exe' },
+      id: 3,
+    }));
+    const parsed = JSON.parse(response);
+    expect(parsed.error).toBeDefined();
+    expect(parsed.error.code).toBe(-32001);
+    expect(handlerCalled).toBe(false);
+  });
+
+  it('rejects privileged V2 methods with a wrong token', async () => {
+    const pipe = uniquePipe();
+    server = new PipeServer(pipe, 'secret');
+    server.on('v2', (req, respond) => respond({ ok: true }));
+    server.start();
+    await new Promise(r => setTimeout(r, 200));
+
+    const response = await connectAndSend(pipe, JSON.stringify({
+      method: 'browser.eval',
+      params: { js: '1+1' },
+      id: 4,
+      token: 'wrong',
+    }));
+    const parsed = JSON.parse(response);
+    expect(parsed.error.code).toBe(-32001);
+  });
+
+  it('allows privileged V2 methods with the correct token', async () => {
+    const pipe = uniquePipe();
+    server = new PipeServer(pipe, 'secret');
+    server.on('v2', (req, respond) => respond({ ok: true }));
+    server.start();
+    await new Promise(r => setTimeout(r, 200));
+
+    const response = await connectAndSend(pipe, JSON.stringify({
+      method: 'agent.spawn',
+      params: { cmd: 'echo hi' },
+      id: 5,
+      token: 'secret',
+    }));
+    const parsed = JSON.parse(response);
+    expect(parsed.result).toEqual({ ok: true });
+  });
+
+  it('allows public V2 methods without a token', async () => {
+    const pipe = uniquePipe();
+    server = new PipeServer(pipe, 'secret');
+    server.on('v2', (req, respond) => {
+      if (req.method === 'system.identify') respond({ name: 'wmux' });
+    });
+    server.start();
+    await new Promise(r => setTimeout(r, 200));
+
+    const response = await connectAndSend(pipe, JSON.stringify({
+      method: 'system.identify',
+      params: {},
+      id: 6,
+    }));
+    const parsed = JSON.parse(response);
+    expect(parsed.result.name).toBe('wmux');
+  });
+
+  it('still accepts unauthenticated V1 telemetry', async () => {
+    const pipe = uniquePipe();
+    server = new PipeServer(pipe, 'secret');
+    server.start();
+    await new Promise(r => setTimeout(r, 200));
+
+    const response = await connectAndSend(pipe, 'ping');
+    expect(response).toBe('pong');
   });
 });


### PR DESCRIPTION
## Summary

Addresses the critical/high findings from a security review of the IPC pipe, CDP proxy, markdown rendering, and webview surfaces. No behavior change for normal use; the only externally-visible effect is that privileged pipe (V2) calls and direct CDP WebSocket connections from web origins are now rejected.

## Findings fixed

### #1 — Unauthenticated local RCE via named pipe (Critical)
Any local process could call privileged V2 methods (`agent.spawn`, `browser.eval`, `markdown.load_file`, workspace/pane mutation). Now:
- Per-instance token generated with `crypto.randomBytes(32)`, persisted `0600` under the instance APPDATA dir, compared with `crypto.timingSafeEqual`.
- Privileged V2 methods require the token; an **allowlist** of read-only/telemetry methods (`system.identify`, `system.capabilities`, `hook.event`, `agent.activity`) stays open so detection, shell hooks, and agent telemetry keep working — and any *new* method is locked by default.
- Token injected into spawned shells as `WMUX_PIPE_TOKEN`; the `wmux` CLI and hook client read it from env or the token file.
- V1 plaintext telemetry (shell integration) is unchanged (low-risk, no code-exec surface).

### #2 — CDP proxy reachable from web origins (Critical)
The CDP proxy exposes `Runtime.evaluate` (arbitrary JS in the webview). Loopback binding alone is insufficient:
- **DNS-rebinding**: HTTP endpoints + WS upgrade now require a loopback-literal `Host` (403 / `verifyClient` reject).
- **Direct WS from a browser page**: WebSockets bypass CORS, so a malicious page could open `ws://127.0.0.1:9222` (valid `Host`) and drive the debugger. We now also validate `Origin` on the WS upgrade and reject any web/file origin. Absent `Origin` is allowed so `chrome-devtools-mcp`/`puppeteer-core`/native `ws` clients still connect (mirrors Chrome's `--remote-allow-origins`).

### #3 — Markdown XSS (High)
Markdown can arrive from untrusted CLI/pipe/agent/file sources and was injected via `dangerouslySetInnerHTML` in the privileged renderer. Now sanitized with **DOMPurify** (forbids `javascript:` URIs, event handlers, `style`/form controls).

### markdown.load_file path abuse
Even with a valid token, the loader now enforces an extension allowlist (`.md`/`.markdown`/`.mdx`/`.txt`/`.text`/`.rst`), a 5MB cap, and an `isFile` check — so it can't be used to slurp secrets (`id_rsa`, `.env`, …) into the viewer.

### #9 — Webview hardening (Low/defense-in-depth)
Central `web-contents-created` handler: strips `preload`/`nodeIntegration` from attached webviews (enforces `contextIsolation`), routes `window.open` to the OS browser, and blocks the main window from navigating off its own UI (localhost/file://).

## Tests
- `tests/unit/pipe-server.test.ts`: token enforcement (reject without/with wrong token, accept correct token, public methods open, V1 still works) — 9 tests.
- `tests/unit/cdp-proxy.test.ts` (new): Host allowlist (loopback/IPv6/rebind/non-loopback) + Origin guard (absent/devtools allowed, web origins rejected) — 9 tests.
- Full suite: 106 passing. (`pty-manager.test.ts` fails only because the node-pty native module isn't built on this Linux dev box — pre-existing/environmental, fails identically on `master`.)

## Notes for reviewer
- CDP uses Host+Origin validation rather than a token because the external `chrome-devtools-mcp` connects via `--browserUrl=http://127.0.0.1:9222` (set in `claude-context.ts`) and can't send a custom token.
- The pipe token raises the bar from "any local code can drive the pipe" to "only processes running as this user (who can already read the user's files) can" — an honest, meaningful reduction for a single-user desktop app.