### PR TITLE
fix(pty): kill all PTYs on will-quit to prevent MSVC assertion crash

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1016,6 +1016,10 @@ app.on('before-quit', () => {
 });
 
 app.on('will-quit', () => {
+  // Kill all PTYs before anything else tears down. Without this, node-pty's
+  // libuv async handles (batons) are still pending when the process exits,
+  // triggering the "Assertion failed: remove_pty_baton" MSVC runtime error.
+  ptyManager.killAll();
   pipeServer.stop();
   cdpProxy.stop();
   portScanner.stop();


### PR DESCRIPTION
Fixes #50.

## Problem

The `will-quit` handler tears down ancillary services but never calls `ptyManager.killAll()`. When Electron exits with PTY processes still live, node-pty's libuv async handles (batons) are pending as the runtime tears down, triggering:

```
Assertion failed! Expression: remove_pty_baton(baton->id)
```

## Fix

One line — call `ptyManager.killAll()` first in `will-quit`:

```typescript
app.on('will-quit', () => {
  ptyManager.killAll();
  pipeServer.stop();
  // ...
});
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)