### PR TITLE
fix(ui): caret dropdown clipped by overflow:hidden ancestors

### DIFF
--- a/src/renderer/components/SplitPane/SurfaceTabBar.tsx
+++ b/src/renderer/components/SplitPane/SurfaceTabBar.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { SurfaceRef, SurfaceId, PaneId, WorkspaceId, QuickLaunchProfile } from '../../../shared/types';
 import { useStore } from '../../store';
 
@@ -83,8 +84,10 @@ export default function SurfaceTabBar({
   const [renamingId, setRenamingId] = useState<SurfaceId | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const [newMenuOpen, setNewMenuOpen] = useState(false);
+  const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
   const newMenuRef = useRef<HTMLDivElement>(null);
+  const caretRef = useRef<HTMLButtonElement>(null);
   const agentMeta = useStore((state) => state.agentMeta);
   const activeWorkspaceId = useStore((state) => state.activeWorkspaceId);
   const renameSurface = useStore((state) => state.renameSurface);
@@ -129,11 +132,15 @@ export default function SurfaceTabBar({
     }
   }, [renamingId]);
 
-  // Close the "new surface" menu on outside click or Escape
+  // Close the "new surface" menu on outside click or Escape.
+  // Exclude both the dropdown portal and the caret button — the caret's own
+  // click handler toggles the menu, so a mousedown there must not also close it.
   useEffect(() => {
     if (!newMenuOpen) return;
     const onDown = (e: MouseEvent) => {
-      if (newMenuRef.current && !newMenuRef.current.contains(e.target as Node)) setNewMenuOpen(false);
+      const inMenu = newMenuRef.current?.contains(e.target as Node);
+      const inCaret = caretRef.current?.contains(e.target as Node);
+      if (!inMenu && !inCaret) setNewMenuOpen(false);
     };
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setNewMenuOpen(false); };
     document.addEventListener('mousedown', onDown);
@@ -282,8 +289,15 @@ export default function SurfaceTabBar({
       {onNewTyped && (
         <div className="surface-tab-bar__new-menu-wrap" ref={newMenuRef}>
           <button
+            ref={caretRef}
             className="surface-tab-bar__new-caret"
-            onClick={() => setNewMenuOpen((v) => !v)}
+            onClick={() => {
+              if (!newMenuOpen && caretRef.current) {
+                const rect = caretRef.current.getBoundingClientRect();
+                setMenuPos({ top: rect.bottom, left: rect.left });
+              }
+              setNewMenuOpen((v) => !v);
+            }}
             tabIndex={-1}
             aria-haspopup="menu"
             aria-expanded={newMenuOpen}
@@ -291,42 +305,48 @@ export default function SurfaceTabBar({
           >
             ▾
           </button>
-          {newMenuOpen && (
-            <div className="surface-tab-bar__new-menu" role="menu">
-              <button role="menuitem" onClick={() => pickNew('terminal')}>
-                <span className="surface-tab-bar__new-menu-icon">{surfaceIcon('terminal', false)}</span> Terminal
-              </button>
-              <button role="menuitem" onClick={() => pickNew('browser')}>
-                <span className="surface-tab-bar__new-menu-icon">{surfaceIcon('browser', false)}</span> Browser
-              </button>
-              <button role="menuitem" onClick={() => pickNew('markdown')}>
-                <span className="surface-tab-bar__new-menu-icon">{surfaceIcon('markdown', false)}</span> Markdown
-              </button>
-              {profiles && profiles.length > 0 && (
-                <>
-                  <div className="surface-tab-bar__new-menu-sep" role="separator" />
-                  {profiles.map((profile) => (
-                    <button
-                      key={profile.id}
-                      role="menuitem"
-                      className="surface-tab-bar__new-menu-profile"
-                      onClick={() => pickProfile(profile)}
-                      title={profile.source === 'project' ? 'Project profile (.wmux.json)' : 'Global profile'}
-                    >
-                      <span className="surface-tab-bar__new-menu-icon">
-                        {profile.icon || surfaceIcon(profile.type, false)}
-                      </span>
-                      <span className="surface-tab-bar__new-menu-profile-name">{profile.name}</span>
-                      {profile.source === 'project' && (
-                        <span className="surface-tab-bar__new-menu-badge">project</span>
-                      )}
-                    </button>
-                  ))}
-                </>
-              )}
-            </div>
-          )}
         </div>
+      )}
+      {newMenuOpen && menuPos && onNewTyped && createPortal(
+        <div
+          ref={newMenuRef}
+          className="surface-tab-bar__new-menu"
+          role="menu"
+          style={{ position: 'fixed', top: menuPos.top, left: menuPos.left }}
+        >
+          <button role="menuitem" onClick={() => pickNew('terminal')}>
+            <span className="surface-tab-bar__new-menu-icon">{surfaceIcon('terminal', false)}</span> Terminal
+          </button>
+          <button role="menuitem" onClick={() => pickNew('browser')}>
+            <span className="surface-tab-bar__new-menu-icon">{surfaceIcon('browser', false)}</span> Browser
+          </button>
+          <button role="menuitem" onClick={() => pickNew('markdown')}>
+            <span className="surface-tab-bar__new-menu-icon">{surfaceIcon('markdown', false)}</span> Markdown
+          </button>
+          {profiles && profiles.length > 0 && (
+            <>
+              <div className="surface-tab-bar__new-menu-sep" role="separator" />
+              {profiles.map((profile) => (
+                <button
+                  key={profile.id}
+                  role="menuitem"
+                  className="surface-tab-bar__new-menu-profile"
+                  onClick={() => pickProfile(profile)}
+                  title={profile.source === 'project' ? 'Project profile (.wmux.json)' : 'Global profile'}
+                >
+                  <span className="surface-tab-bar__new-menu-icon">
+                    {profile.icon || surfaceIcon(profile.type, false)}
+                  </span>
+                  <span className="surface-tab-bar__new-menu-profile-name">{profile.name}</span>
+                  {profile.source === 'project' && (
+                    <span className="surface-tab-bar__new-menu-badge">project</span>
+                  )}
+                </button>
+              ))}
+            </>
+          )}
+        </div>,
+        document.body
       )}
       {onSplitRight && (
         <button

--- a/src/renderer/styles/splitpane.css
+++ b/src/renderer/styles/splitpane.css
@@ -147,10 +147,7 @@
 }
 .surface-tab-bar__new-caret:hover { color: #fff; background: rgba(255,255,255,0.08); }
 .surface-tab-bar__new-menu {
-  position: absolute;
-  top: 30px;
-  left: 0;
-  z-index: 50;
+  z-index: 9999;
   min-width: 150px;
   padding: 4px;
   background: #1c1c1c;


### PR DESCRIPTION
Fixes the bug documented in #34 (the dropdown is invisible due to clipping). This is a targeted fix without the broader toolbar redesign also proposed in that issue.

## Root cause

The new-tab type menu (▾ caret next to +) renders `position: absolute; top: 30px` inside `.surface-tab-bar`, but three ancestor elements have `overflow: hidden`:

- `.surface-tab-bar` (28px tall — the menu immediately clips below it)
- `.pane-wrapper__content`
- `.split-child`

`z-index` has no effect on `overflow: hidden` clipping. The click and state toggle work correctly — the menu is just never visible.

## Fix

Render the dropdown via `createPortal` at `document.body` with `position: fixed` + coordinates from `getBoundingClientRect()`. This escapes all parent clipping contexts entirely.

The outside-click handler is also tightened to exclude the caret button itself, preventing a mousedown-then-click double-toggle flicker when dismissing the menu by clicking the caret again.

## What this does not include

The SVG icon redesign and Layout split-button proposed in #34 are intentionally out of scope — those are a separate presentational change. This PR only fixes the clipping bug so the existing menu actually works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)