### PR TITLE
[codex] Add live layout preview for surface dragging

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,17 @@
+# wmux
+
+wmux is a Windows terminal multiplexer organized around workspaces, split panes, and draggable surfaces. This glossary keeps product language precise when discussing layout and terminal interaction behavior.
+
+## Language
+
+**Surface**:
+A single terminal, browser, markdown, or diff instance shown as a tab inside a pane. Users drag a surface by grabbing its tab title.
+_Avoid_: Console window, terminal window, panel
+
+**Pane**:
+A rectangular region in a workspace split tree that contains one or more surfaces.
+_Avoid_: Console window, tab
+
+**Live Layout Preview**:
+The temporary workspace appearance shown while a surface tab is being dragged, matching the layout that would exist if the surface were dropped at the current target.
+_Avoid_: Drop zone highlight, ghost split preview, preshow

--- a/docs/superpowers/specs/2026-06-25-live-layout-preview-design.md
+++ b/docs/superpowers/specs/2026-06-25-live-layout-preview-design.md
@@ -1,0 +1,214 @@
+# Live Layout Preview for Surface Dragging
+
+**Date:** 2026-06-25
+**Status:** Approved
+
+## Overview
+
+When a user drags a Surface by its tab title, wmux should show a Live Layout Preview: the active workspace temporarily appears in the layout that would result from dropping the Surface at the current target. The preview must feel like live reflow, but it must not mutate the real split tree or move live terminal/browser content until drop.
+
+This extends the existing drag-and-drop system from `2026-04-07-drag-and-drop-design.md`.
+
+## Terminology
+
+- **Surface**: a terminal, browser, markdown, or diff instance shown as a tab inside a pane.
+- **Pane**: a rectangular leaf in the workspace split tree that contains one or more surfaces.
+- **Live Layout Preview**: a temporary full-workspace visual projection of the post-drop layout shown during Surface drag.
+
+## Current State
+
+wmux already supports Surface dragging from `SurfaceTabBar.tsx`:
+
+- Drag data uses `application/wmux-surface` with `{ sourcePaneId, surfaceId }`.
+- Same-pane tab reorder uses an insertion marker and `reorderSurface()`.
+- Center drop into another pane uses `moveSurface()`.
+- Edge drop zones in `PaneWrapper.tsx` call `splitAndMoveSurface()`.
+- `.pane-drop-zone` elements provide hit testing and hover feedback.
+
+The missing behavior is full-workspace live preview before drop. Current edge-zone hover styles show only the target region, not the resulting layout.
+
+## Design
+
+### User Experience
+
+Dragging starts from the Surface tab title. When the cursor enters a geometry-changing target, wmux renders a Live Layout Preview over the active workspace.
+
+Geometry-changing targets are:
+
+- Left/right/top/bottom edge zones.
+- Center drop into another pane when the dragged Surface is the only Surface in its source pane and the source pane would collapse.
+
+Dragging the only Surface in a pane onto an edge of that same pane is not a geometry-changing target. wmux does not model empty panes, so v1 treats that drop as a no-op and shows no Live Layout Preview.
+
+Non-geometry targets keep existing feedback:
+
+- Same-pane reorder keeps the insertion marker.
+- Center drop into another pane keeps the center cue when the source pane will not collapse.
+- Edge drop onto the source pane when it contains only the dragged Surface is a no-op.
+- Invalid targets show no preview.
+
+The preview reflows the whole workspace into the post-drop pane geometry. It includes source-pane collapse if the final drop would remove an empty source pane. The destination preview pane is subtly highlighted and shows the dragged Surface title in its tab bar.
+
+The preview is speculative. Releasing outside a valid target or canceling the drag clears the preview with no split tree, PTY, webview, active tab, or focus change.
+
+If pane zoom is active and a geometry-changing preview begins, the preview renders as if zoom is exited so the user can see the whole workspace consequence. If the drag is canceled, the previous zoom state is restored. After a successful geometry-changing drop, the workspace stays unzoomed.
+
+### Rendering Model
+
+Use a temporary preview split tree rendered by a lightweight overlay. The real `SplitContainer` remains mounted underneath so terminal and browser surfaces keep running exactly where they are.
+
+The overlay renderer should not mount:
+
+- `TerminalPane`
+- `BrowserPane`
+- `MarkdownPane`
+- `DiffPane`
+
+Instead it renders preview shells:
+
+- Pane rectangle.
+- Tab bar with representative Surface titles.
+- Terminal-like placeholder lines.
+- Destination highlight for the would-be landing pane.
+
+This gives spatial fidelity without live DOM relocation.
+
+### State And Data Flow
+
+The real workspace `splitTree` remains the source of truth. Drag preview state is separate renderer state:
+
+```ts
+type SurfaceDragPreview =
+  | null
+  | {
+      workspaceId: WorkspaceId;
+      sourcePaneId: PaneId;
+      surfaceId: SurfaceId;
+      targetPaneId: PaneId;
+      target: 'left' | 'right' | 'up' | 'down' | 'center';
+      previewTree: SplitNode;
+      destinationPaneId: PaneId;
+      collapsesSourcePane: boolean;
+    };
+```
+
+`previewTree` is derived from the current real split tree by pure helpers. Zustand workspace state is not updated during dragover.
+
+On drop:
+
+- Edge target: call existing `splitAndMoveSurface()`.
+- Center target: call existing `moveSurface()`.
+- Reorder target: call existing `reorderSurface()`.
+- Cancel/invalid drop: clear preview only.
+
+Preview updates should be throttled with `requestAnimationFrame`. The browser may fire many `dragover` events; React state should update at most once per animation frame.
+
+Cleanup should run on `drop`, `dragend`, and cancel/Escape paths where available. Cleanup clears preview state and removes body drag classes without touching workspace state.
+
+### Preview Helpers
+
+Add pure helper functions near `split-utils.ts`. They should mirror store behavior without mutating state or creating throwaway real PTY/browser surfaces.
+
+Suggested helpers:
+
+```ts
+previewSplitAndMoveSurface(
+  tree: SplitNode,
+  targetPaneId: PaneId,
+  sourcePaneId: PaneId,
+  surfaceId: SurfaceId,
+  direction: 'left' | 'right' | 'up' | 'down',
+): {
+  tree: SplitNode;
+  destinationPaneId: PaneId;
+  collapsesSourcePane: boolean;
+} | null;
+
+previewMoveSurface(
+  tree: SplitNode,
+  sourcePaneId: PaneId,
+  surfaceId: SurfaceId,
+  targetPaneId: PaneId,
+): {
+  tree: SplitNode;
+  destinationPaneId: PaneId;
+  collapsesSourcePane: boolean;
+} | null;
+```
+
+The helpers must preserve all existing Surface IDs in the preview tree and must never kill or create PTYs. If they need a preview-only pane ID, it should be clearly branded as preview-only and never passed to main-process APIs.
+
+### Component Shape
+
+Keep the implementation at the renderer split-pane boundary:
+
+- `App.tsx`: owns workspace-level preview state and renders the overlay above the active workspace.
+- `SplitContainer.tsx`: passes preview callbacks down to pane leaves.
+- `PaneWrapper.tsx`: edge and center drop zones update or clear preview state during dragover/drop.
+- `SurfaceTabBar.tsx`: starts drag from tab titles and keeps same-pane reorder behavior.
+- `SplitPreviewOverlay.tsx`: new lightweight recursive renderer for `previewTree`.
+- `splitpane.css`: styles preview overlay, destination highlight, and suppresses visible edge-zone hover feedback while preview is active.
+
+Keep `.pane-drop-zone` elements for hit testing. Replace their visible edge hover feedback with the overlay for geometry-changing targets.
+
+### Scope
+
+Included:
+
+- Active workspace only.
+- Surface drag that starts from a tab title.
+- Edge split preview.
+- Source-pane collapse preview.
+- Center move preview only when geometry changes through source collapse.
+- Zoom exit for geometry-changing preview/drop.
+
+Excluded:
+
+- Cross-workspace drag.
+- Cross-window drag.
+- Moving whole panes.
+- Moving native OS console windows.
+- Dragging by terminal content area.
+- Live relocation of actual xterm/browser/markdown DOM during drag.
+- Custom drag image beyond current browser drag behavior.
+
+## Acceptance Criteria
+
+- Dragging a Surface tab over a left/right/top/bottom edge shows a full-workspace Live Layout Preview matching the post-drop pane geometry.
+- The destination preview pane is subtly highlighted and shows the dragged Surface title.
+- The real layout, PTYs, browser surfaces, active tabs, and focused pane do not change until drop.
+- Dropping commits the same result as today's edge drop behavior.
+- Canceling or dropping outside a valid target clears the preview with no state change.
+- Dragging the only Surface out of a pane previews source-pane collapse.
+- Same-pane reorder remains insertion-marker only.
+- Center drop remains the existing center cue unless source-pane collapse changes layout.
+- If zoom is active, geometry-changing preview shows the full workspace; cancel restores zoom and successful geometry-changing drop remains unzoomed.
+- Preview updates feel continuous and are internally animation-frame throttled.
+
+## Testing Strategy
+
+Unit test the pure preview helpers:
+
+- Edge split right/left/down/up.
+- Left/up child ordering.
+- Dragging the only Surface out of a pane collapses the source pane in the preview.
+- Center move with source collapse.
+- Center move without source collapse returns `null` because it does not need a geometry preview.
+- Invalid source/target/surface returns `null`.
+- All original Surface IDs survive in the preview tree.
+
+Manual verification:
+
+- `npm run build:renderer`.
+- `npm run dev`.
+- Drag across multiple panes and edges.
+- Drag last Surface out of a pane.
+- Drag the only Surface onto its own pane edge and verify no preview/drop change.
+- Cancel drag outside valid targets.
+- Reorder tabs inside a pane.
+- Center drop between panes.
+- Drag while a pane is zoomed.
+
+## ADR Decision
+
+No ADR is needed. This is a localized extension of the existing drag-and-drop design, reversible, and unsurprising once the feature spec exists.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -750,6 +750,17 @@ export default function App() {
     document.body.classList.remove('wmux-dragging');
   }, []);
 
+  useEffect(() => {
+    if (!surfaceDrag) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') handleSurfaceDragEnd();
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [surfaceDrag, handleSurfaceDragEnd]);
+
   // Clear zoom when the zoomed pane no longer exists
   useEffect(() => {
     if (!zoomedPaneId || !activeWorkspace) return;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -19,7 +19,7 @@ import type {
   SurfaceDragPreview,
   SurfaceDragPreviewTarget,
 } from './components/SplitPane/drag-preview-types';
-import { previewMoveSurface, previewSplitAndMoveSurface } from './store/split-preview-utils';
+import { buildSurfaceDragPreview } from './components/SplitPane/surface-drag-preview';
 
 const DEFAULT_SIDEBAR_WIDTH = 240;
 
@@ -701,31 +701,12 @@ export default function App() {
         return;
       }
 
-      const ws = useStore.getState().workspaces.find((workspace) => workspace.id === drag.workspaceId);
-      if (!ws || ws.id !== activeWorkspaceId) {
-        surfaceDragPreviewRef.current = null;
-        setSurfaceDragPreview(null);
-        return;
-      }
-
-      const result = pending.target === 'center'
-        ? previewMoveSurface(ws.splitTree, drag.sourcePaneId, drag.surfaceId, pending.targetPaneId)
-        : previewSplitAndMoveSurface(ws.splitTree, pending.targetPaneId, drag.sourcePaneId, drag.surfaceId, pending.target);
-
-      if (!result) {
-        surfaceDragPreviewRef.current = null;
-        setSurfaceDragPreview(null);
-        return;
-      }
-
-      const nextPreview: SurfaceDragPreview = {
-        ...drag,
-        targetPaneId: pending.targetPaneId,
-        target: pending.target,
-        previewTree: result.tree,
-        destinationPaneId: result.destinationPaneId,
-        collapsesSourcePane: result.collapsesSourcePane,
-      };
+      const nextPreview = buildSurfaceDragPreview({
+        workspaces: useStore.getState().workspaces,
+        activeWorkspaceId,
+        drag,
+        pendingTarget: pending,
+      });
       surfaceDragPreviewRef.current = nextPreview;
       setSurfaceDragPreview(nextPreview);
     });
@@ -879,6 +860,7 @@ export default function App() {
                   tree={surfaceDragPreview.previewTree}
                   destinationPaneId={surfaceDragPreview.destinationPaneId}
                   draggedSurfaceId={surfaceDragPreview.surfaceId}
+                  workspaceShell={ws.shell}
                 />
               )}
             </div>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,8 +11,10 @@ import SettingsWindow from './components/Settings/SettingsWindow';
 import CommandPalette from './components/CommandPalette/CommandPalette';
 import BrowserPane from './components/Browser/BrowserPane';
 import Tutorial from './components/Tutorial/Tutorial';
+import SplitPreviewOverlay from './components/SplitPane/SplitPreviewOverlay';
 import { initPipeBridge } from './pipe-bridge';
 import type { SurfaceDragPayload, SurfaceDragPreview, SurfaceDragPreviewTarget } from './components/SplitPane/drag-preview-types';
+import { previewMoveSurface, previewSplitAndMoveSurface } from './store/split-preview-utils';
 
 const DEFAULT_SIDEBAR_WIDTH = 240;
 
@@ -634,35 +636,119 @@ export default function App() {
   const [zoomedPaneId, setZoomedPaneId] = useState<PaneId | null>(null);
   const [surfaceDrag, setSurfaceDrag] = useState<SurfaceDragPayload | null>(null);
   const [surfaceDragPreview, setSurfaceDragPreview] = useState<SurfaceDragPreview | null>(null);
+  const surfaceDragRef = useRef<SurfaceDragPayload | null>(null);
+  const surfaceDragPreviewRef = useRef<SurfaceDragPreview | null>(null);
+  const previewFrameRef = useRef<number | null>(null);
+  const pendingPreviewTargetRef = useRef<{ targetPaneId: PaneId; target: SurfaceDragPreviewTarget } | null>(null);
 
   const handleToggleZoom = useCallback(() => {
     setZoomedPaneId((prev) => (prev ? null : focusedPaneId));
   }, [focusedPaneId]);
 
+  useEffect(() => {
+    surfaceDragRef.current = surfaceDrag;
+  }, [surfaceDrag]);
+
+  useEffect(() => {
+    surfaceDragPreviewRef.current = surfaceDragPreview;
+  }, [surfaceDragPreview]);
+
+  useEffect(() => {
+    return () => {
+      if (previewFrameRef.current !== null) {
+        cancelAnimationFrame(previewFrameRef.current);
+        previewFrameRef.current = null;
+      }
+    };
+  }, []);
+
   const handleSurfaceDragStart = useCallback((payload: SurfaceDragPayload) => {
+    surfaceDragRef.current = payload;
     setSurfaceDrag(payload);
   }, []);
 
   const handleSurfaceDragEnd = useCallback(() => {
+    pendingPreviewTargetRef.current = null;
+    if (previewFrameRef.current !== null) {
+      cancelAnimationFrame(previewFrameRef.current);
+      previewFrameRef.current = null;
+    }
+    surfaceDragRef.current = null;
+    surfaceDragPreviewRef.current = null;
     setSurfaceDrag(null);
     setSurfaceDragPreview(null);
     document.body.classList.remove('wmux-dragging');
   }, []);
 
-  const handleSurfaceDragPreviewTarget = useCallback((_targetPaneId: PaneId, _target: SurfaceDragPreviewTarget) => {
-    setSurfaceDragPreview(null);
-  }, []);
+  const handleSurfaceDragPreviewTarget = useCallback((targetPaneId: PaneId, target: SurfaceDragPreviewTarget) => {
+    pendingPreviewTargetRef.current = { targetPaneId, target };
+
+    if (previewFrameRef.current !== null) return;
+
+    previewFrameRef.current = requestAnimationFrame(() => {
+      previewFrameRef.current = null;
+
+      const pending = pendingPreviewTargetRef.current;
+      const drag = surfaceDragRef.current;
+      if (!pending || !drag) {
+        surfaceDragPreviewRef.current = null;
+        setSurfaceDragPreview(null);
+        return;
+      }
+
+      const ws = useStore.getState().workspaces.find((workspace) => workspace.id === drag.workspaceId);
+      if (!ws || ws.id !== activeWorkspaceId) {
+        surfaceDragPreviewRef.current = null;
+        setSurfaceDragPreview(null);
+        return;
+      }
+
+      const result = pending.target === 'center'
+        ? previewMoveSurface(ws.splitTree, drag.sourcePaneId, drag.surfaceId, pending.targetPaneId)
+        : previewSplitAndMoveSurface(ws.splitTree, pending.targetPaneId, drag.sourcePaneId, drag.surfaceId, pending.target);
+
+      if (!result) {
+        surfaceDragPreviewRef.current = null;
+        setSurfaceDragPreview(null);
+        return;
+      }
+
+      const nextPreview: SurfaceDragPreview = {
+        ...drag,
+        targetPaneId: pending.targetPaneId,
+        target: pending.target,
+        previewTree: result.tree,
+        destinationPaneId: result.destinationPaneId,
+        collapsesSourcePane: result.collapsesSourcePane,
+      };
+      surfaceDragPreviewRef.current = nextPreview;
+      setSurfaceDragPreview(nextPreview);
+    });
+  }, [activeWorkspaceId]);
 
   const handleClearSurfaceDragPreview = useCallback(() => {
+    pendingPreviewTargetRef.current = null;
+    if (previewFrameRef.current !== null) {
+      cancelAnimationFrame(previewFrameRef.current);
+      previewFrameRef.current = null;
+    }
+    surfaceDragPreviewRef.current = null;
     setSurfaceDragPreview(null);
   }, []);
 
   const handleSurfaceDragCommit = useCallback(() => {
-    if (surfaceDragPreview) setZoomedPaneId(null);
+    if (surfaceDragPreviewRef.current) setZoomedPaneId(null);
+    pendingPreviewTargetRef.current = null;
+    if (previewFrameRef.current !== null) {
+      cancelAnimationFrame(previewFrameRef.current);
+      previewFrameRef.current = null;
+    }
+    surfaceDragRef.current = null;
+    surfaceDragPreviewRef.current = null;
     setSurfaceDrag(null);
     setSurfaceDragPreview(null);
     document.body.classList.remove('wmux-dragging');
-  }, [surfaceDragPreview]);
+  }, []);
 
   // Clear zoom when the zoomed pane no longer exists
   useEffect(() => {
@@ -772,6 +858,13 @@ export default function App() {
                 onClearSurfaceDragPreview={handleClearSurfaceDragPreview}
                 onSurfaceDragCommit={handleSurfaceDragCommit}
               />
+              {surfaceDragPreview?.workspaceId === ws.id && ws.id === activeWorkspaceId && (
+                <SplitPreviewOverlay
+                  tree={surfaceDragPreview.previewTree}
+                  destinationPaneId={surfaceDragPreview.destinationPaneId}
+                  draggedSurfaceId={surfaceDragPreview.surfaceId}
+                />
+              )}
             </div>
           ))}
         </div>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,7 +13,12 @@ import BrowserPane from './components/Browser/BrowserPane';
 import Tutorial from './components/Tutorial/Tutorial';
 import SplitPreviewOverlay from './components/SplitPane/SplitPreviewOverlay';
 import { initPipeBridge } from './pipe-bridge';
-import type { SurfaceDragPayload, SurfaceDragPreview, SurfaceDragPreviewTarget } from './components/SplitPane/drag-preview-types';
+import type {
+  SurfaceDragCommitOptions,
+  SurfaceDragPayload,
+  SurfaceDragPreview,
+  SurfaceDragPreviewTarget,
+} from './components/SplitPane/drag-preview-types';
 import { previewMoveSurface, previewSplitAndMoveSurface } from './store/split-preview-utils';
 
 const DEFAULT_SIDEBAR_WIDTH = 240;
@@ -736,8 +741,8 @@ export default function App() {
     setSurfaceDragPreview(null);
   }, []);
 
-  const handleSurfaceDragCommit = useCallback(() => {
-    if (surfaceDragPreviewRef.current) setZoomedPaneId(null);
+  const handleSurfaceDragCommit = useCallback((options?: SurfaceDragCommitOptions) => {
+    if (options?.clearZoom || surfaceDragPreviewRef.current) setZoomedPaneId(null);
     pendingPreviewTargetRef.current = null;
     if (previewFrameRef.current !== null) {
       cancelAnimationFrame(previewFrameRef.current);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import CommandPalette from './components/CommandPalette/CommandPalette';
 import BrowserPane from './components/Browser/BrowserPane';
 import Tutorial from './components/Tutorial/Tutorial';
 import { initPipeBridge } from './pipe-bridge';
+import type { SurfaceDragPayload, SurfaceDragPreview, SurfaceDragPreviewTarget } from './components/SplitPane/drag-preview-types';
 
 const DEFAULT_SIDEBAR_WIDTH = 240;
 
@@ -631,10 +632,37 @@ export default function App() {
   }, []);
 
   const [zoomedPaneId, setZoomedPaneId] = useState<PaneId | null>(null);
+  const [surfaceDrag, setSurfaceDrag] = useState<SurfaceDragPayload | null>(null);
+  const [surfaceDragPreview, setSurfaceDragPreview] = useState<SurfaceDragPreview | null>(null);
 
   const handleToggleZoom = useCallback(() => {
     setZoomedPaneId((prev) => (prev ? null : focusedPaneId));
   }, [focusedPaneId]);
+
+  const handleSurfaceDragStart = useCallback((payload: SurfaceDragPayload) => {
+    setSurfaceDrag(payload);
+  }, []);
+
+  const handleSurfaceDragEnd = useCallback(() => {
+    setSurfaceDrag(null);
+    setSurfaceDragPreview(null);
+    document.body.classList.remove('wmux-dragging');
+  }, []);
+
+  const handleSurfaceDragPreviewTarget = useCallback((_targetPaneId: PaneId, _target: SurfaceDragPreviewTarget) => {
+    setSurfaceDragPreview(null);
+  }, []);
+
+  const handleClearSurfaceDragPreview = useCallback(() => {
+    setSurfaceDragPreview(null);
+  }, []);
+
+  const handleSurfaceDragCommit = useCallback(() => {
+    if (surfaceDragPreview) setZoomedPaneId(null);
+    setSurfaceDrag(null);
+    setSurfaceDragPreview(null);
+    document.body.classList.remove('wmux-dragging');
+  }, [surfaceDragPreview]);
 
   // Clear zoom when the zoomed pane no longer exists
   useEffect(() => {
@@ -737,6 +765,12 @@ export default function App() {
                 focusedPaneId={ws.id === activeWorkspaceId ? focusedPaneId : null}
                 onRatioChange={ws.id === activeWorkspaceId ? handleRatioChange : undefined}
                 onPaneFocus={handlePaneFocus}
+                surfaceDrag={ws.id === activeWorkspaceId ? surfaceDrag : null}
+                onSurfaceDragStart={handleSurfaceDragStart}
+                onSurfaceDragEnd={handleSurfaceDragEnd}
+                onSurfaceDragPreviewTarget={handleSurfaceDragPreviewTarget}
+                onClearSurfaceDragPreview={handleClearSurfaceDragPreview}
+                onSurfaceDragCommit={handleSurfaceDragCommit}
               />
             </div>
           ))}

--- a/src/renderer/components/SplitPane/PaneWrapper.tsx
+++ b/src/renderer/components/SplitPane/PaneWrapper.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { PaneId, SplitNode, SurfaceId, WorkspaceId, QuickLaunchProfile, ShellInfo } from '../../../shared/types';
-import { removeLeaf, splitNode } from '../../store/split-utils';
+import { findLeaf, removeLeaf, splitNode } from '../../store/split-utils';
 import TerminalPane from '../Terminal/TerminalPane';
 import BrowserPane from '../Browser/BrowserPane';
 import MarkdownPane from '../Markdown/MarkdownPane';
@@ -11,6 +11,11 @@ import { useStore } from '../../store';
 import type { SurfaceDragPayload, SurfaceDragPreviewTarget } from './drag-preview-types';
 import '../../styles/splitpane.css';
 import '../../styles/terminal.css';
+
+interface SurfaceDragData {
+  sourcePaneId: PaneId;
+  surfaceId: SurfaceId;
+}
 
 interface PaneWrapperProps {
   paneId: PaneId;
@@ -179,6 +184,12 @@ export default function PaneWrapper({
       setDragActive(false);
     }
   }, [isWorkspaceActive]);
+
+  useEffect(() => {
+    if (!surfaceDrag) {
+      setDragActive(false);
+    }
+  }, [surfaceDrag]);
 
   const renderAllSurfaces = () =>
     surfaces.map((surface, index) => {
@@ -368,6 +379,29 @@ export default function PaneWrapper({
     }
   };
 
+  const getValidSurfaceDragData = (data: string): SurfaceDragData | null => {
+    try {
+      const parsed = JSON.parse(data) as Partial<Record<'sourcePaneId' | 'surfaceId', unknown>>;
+      if (typeof parsed.sourcePaneId !== 'string' || typeof parsed.surfaceId !== 'string') {
+        return null;
+      }
+
+      const sourcePaneId = parsed.sourcePaneId as PaneId;
+      const surfaceId = parsed.surfaceId as SurfaceId;
+      const ws = activeWorkspaceId
+        ? useStore.getState().workspaces.find(w => w.id === activeWorkspaceId)
+        : undefined;
+      const sourceLeaf = ws ? findLeaf(ws.splitTree, sourcePaneId) : undefined;
+      if (!sourceLeaf?.surfaces.some((surface) => surface.id === surfaceId)) {
+        return null;
+      }
+
+      return { sourcePaneId, surfaceId };
+    } catch {
+      return null;
+    }
+  };
+
   const handleEdgeDrop = (e: React.DragEvent, direction: 'left' | 'right' | 'up' | 'down') => {
     e.preventDefault();
     setDragActive(false);
@@ -378,9 +412,20 @@ export default function PaneWrapper({
       return;
     }
     try {
-      const { sourcePaneId, surfaceId } = JSON.parse(data);
+      const dragData = getValidSurfaceDragData(data);
+      if (!dragData) {
+        onSurfaceDragEnd();
+        return;
+      }
+      const { sourcePaneId, surfaceId } = dragData;
+
+      if (sourcePaneId === paneId && surfaces.length === 1) {
+        onSurfaceDragEnd();
+        return;
+      }
+
       onSurfaceDragCommit();
-      splitAndMoveSurface(activeWorkspaceId, paneId, sourcePaneId as PaneId, surfaceId as SurfaceId, direction);
+      splitAndMoveSurface(activeWorkspaceId, paneId, sourcePaneId, surfaceId, direction);
     } catch {
       onSurfaceDragEnd();
     }
@@ -396,10 +441,15 @@ export default function PaneWrapper({
       return;
     }
     try {
-      const { sourcePaneId, surfaceId } = JSON.parse(data);
+      const dragData = getValidSurfaceDragData(data);
+      if (!dragData) {
+        onSurfaceDragEnd();
+        return;
+      }
+      const { sourcePaneId, surfaceId } = dragData;
       if (sourcePaneId !== paneId) {
         onSurfaceDragCommit();
-        moveSurface(activeWorkspaceId, sourcePaneId as PaneId, surfaceId as SurfaceId, paneId);
+        moveSurface(activeWorkspaceId, sourcePaneId, surfaceId, paneId);
         return;
       }
       onSurfaceDragEnd();

--- a/src/renderer/components/SplitPane/PaneWrapper.tsx
+++ b/src/renderer/components/SplitPane/PaneWrapper.tsx
@@ -29,8 +29,11 @@ export default function PaneWrapper({
   leaf,
   workspaceId,
   isFocused,
+  surfaceDrag,
   onSurfaceDragStart,
   onSurfaceDragEnd,
+  onSurfaceDragPreviewTarget,
+  onClearSurfaceDragPreview,
   onSurfaceDragCommit,
 }: PaneWrapperProps) {
   const { surfaces, activeSurfaceIndex, paneId } = leaf;
@@ -405,10 +408,24 @@ export default function PaneWrapper({
     }
   };
 
-  const preventDragDefault = (e: React.DragEvent) => {
+  const handleDropZoneDragOver = (e: React.DragEvent, target: SurfaceDragPreviewTarget) => {
     e.preventDefault();
     e.stopPropagation();
     e.dataTransfer.dropEffect = 'move';
+
+    if (!surfaceDrag) return;
+    onSurfaceDragPreviewTarget(paneId, target);
+  };
+
+  const handleDropZonesDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const outside =
+      e.clientX < rect.left ||
+      e.clientX > rect.right ||
+      e.clientY < rect.top ||
+      e.clientY > rect.bottom;
+
+    if (outside) onClearSurfaceDragPreview();
   };
 
   const handleReorderSurface = (surfaceId: SurfaceId, newIndex: number) => {
@@ -453,12 +470,12 @@ export default function PaneWrapper({
           className="pane-wrapper__unfocused-overlay"
           style={{ opacity: isFocused ? 0 : 1 }}
         />
-        <div className="pane-wrapper__drop-zones">
-          <div className="pane-drop-zone pane-drop-zone--left" onDragOver={preventDragDefault} onDrop={(e) => handleEdgeDrop(e, 'left')} />
-          <div className="pane-drop-zone pane-drop-zone--right" onDragOver={preventDragDefault} onDrop={(e) => handleEdgeDrop(e, 'right')} />
-          <div className="pane-drop-zone pane-drop-zone--top" onDragOver={preventDragDefault} onDrop={(e) => handleEdgeDrop(e, 'up')} />
-          <div className="pane-drop-zone pane-drop-zone--bottom" onDragOver={preventDragDefault} onDrop={(e) => handleEdgeDrop(e, 'down')} />
-          <div className="pane-drop-zone pane-drop-zone--center" onDragOver={preventDragDefault} onDrop={handleCenterDrop} />
+        <div className="pane-wrapper__drop-zones" onDragLeave={handleDropZonesDragLeave}>
+          <div className="pane-drop-zone pane-drop-zone--left" onDragOver={(e) => handleDropZoneDragOver(e, 'left')} onDrop={(e) => handleEdgeDrop(e, 'left')} />
+          <div className="pane-drop-zone pane-drop-zone--right" onDragOver={(e) => handleDropZoneDragOver(e, 'right')} onDrop={(e) => handleEdgeDrop(e, 'right')} />
+          <div className="pane-drop-zone pane-drop-zone--top" onDragOver={(e) => handleDropZoneDragOver(e, 'up')} onDrop={(e) => handleEdgeDrop(e, 'up')} />
+          <div className="pane-drop-zone pane-drop-zone--bottom" onDragOver={(e) => handleDropZoneDragOver(e, 'down')} onDrop={(e) => handleEdgeDrop(e, 'down')} />
+          <div className="pane-drop-zone pane-drop-zone--center" onDragOver={(e) => handleDropZoneDragOver(e, 'center')} onDrop={handleCenterDrop} />
         </div>
       </div>
     </div>

--- a/src/renderer/components/SplitPane/PaneWrapper.tsx
+++ b/src/renderer/components/SplitPane/PaneWrapper.tsx
@@ -8,7 +8,7 @@ import DiffPane from '../Diff/DiffPane';
 import NotificationRing from '../Terminal/NotificationRing';
 import SurfaceTabBar from './SurfaceTabBar';
 import { useStore } from '../../store';
-import type { SurfaceDragPayload, SurfaceDragPreviewTarget } from './drag-preview-types';
+import type { SurfaceDragCommitOptions, SurfaceDragPayload, SurfaceDragPreviewTarget } from './drag-preview-types';
 import '../../styles/splitpane.css';
 import '../../styles/terminal.css';
 
@@ -27,7 +27,7 @@ interface PaneWrapperProps {
   onSurfaceDragEnd: () => void;
   onSurfaceDragPreviewTarget: (targetPaneId: PaneId, target: SurfaceDragPreviewTarget) => void;
   onClearSurfaceDragPreview: () => void;
-  onSurfaceDragCommit: () => void;
+  onSurfaceDragCommit: (options?: SurfaceDragCommitOptions) => void;
 }
 
 export default function PaneWrapper({
@@ -326,9 +326,19 @@ export default function PaneWrapper({
   };
 
   const handleDropSurface = (sourcePaneId: PaneId, surfaceId: SurfaceId, targetPaneId: PaneId) => {
-    if (activeWorkspaceId) {
-      moveSurface(activeWorkspaceId, sourcePaneId, surfaceId, targetPaneId);
+    if (!activeWorkspaceId || targetPaneId !== paneId || sourcePaneId === targetPaneId) {
+      onSurfaceDragEnd();
+      return;
     }
+
+    const sourceLeaf = getSourceLeaf(sourcePaneId);
+    if (!sourceLeaf?.surfaces.some((surface) => surface.id === surfaceId)) {
+      onSurfaceDragEnd();
+      return;
+    }
+
+    onSurfaceDragCommit({ clearZoom: sourceLeaf.surfaces.length === 1 });
+    moveSurface(activeWorkspaceId, sourcePaneId, surfaceId, targetPaneId);
   };
 
   const handleCloseSurface = (surfaceId: SurfaceId) => {
@@ -379,6 +389,13 @@ export default function PaneWrapper({
     }
   };
 
+  const getSourceLeaf = (sourcePaneId: PaneId) => {
+    const ws = activeWorkspaceId
+      ? useStore.getState().workspaces.find(w => w.id === activeWorkspaceId)
+      : undefined;
+    return ws ? findLeaf(ws.splitTree, sourcePaneId) : undefined;
+  };
+
   const getValidSurfaceDragData = (data: string): SurfaceDragData | null => {
     try {
       const parsed = JSON.parse(data) as Partial<Record<'sourcePaneId' | 'surfaceId', unknown>>;
@@ -388,10 +405,7 @@ export default function PaneWrapper({
 
       const sourcePaneId = parsed.sourcePaneId as PaneId;
       const surfaceId = parsed.surfaceId as SurfaceId;
-      const ws = activeWorkspaceId
-        ? useStore.getState().workspaces.find(w => w.id === activeWorkspaceId)
-        : undefined;
-      const sourceLeaf = ws ? findLeaf(ws.splitTree, sourcePaneId) : undefined;
+      const sourceLeaf = getSourceLeaf(sourcePaneId);
       if (!sourceLeaf?.surfaces.some((surface) => surface.id === surfaceId)) {
         return null;
       }
@@ -424,7 +438,7 @@ export default function PaneWrapper({
         return;
       }
 
-      onSurfaceDragCommit();
+      onSurfaceDragCommit({ clearZoom: true });
       splitAndMoveSurface(activeWorkspaceId, paneId, sourcePaneId, surfaceId, direction);
     } catch {
       onSurfaceDragEnd();
@@ -448,7 +462,8 @@ export default function PaneWrapper({
       }
       const { sourcePaneId, surfaceId } = dragData;
       if (sourcePaneId !== paneId) {
-        onSurfaceDragCommit();
+        const sourceLeaf = getSourceLeaf(sourcePaneId);
+        onSurfaceDragCommit({ clearZoom: sourceLeaf?.surfaces.length === 1 });
         moveSurface(activeWorkspaceId, sourcePaneId, surfaceId, paneId);
         return;
       }
@@ -504,6 +519,9 @@ export default function PaneWrapper({
         onSplitDown={handleSplitDown}
         onDropSurface={handleDropSurface}
         onReorderSurface={handleReorderSurface}
+        surfaceDrag={surfaceDrag}
+        onSurfaceDragPreviewTarget={onSurfaceDragPreviewTarget}
+        onClearSurfaceDragPreview={onClearSurfaceDragPreview}
         onSurfaceDragStart={(surfaceId) => onSurfaceDragStart({
           workspaceId,
           sourcePaneId: paneId,

--- a/src/renderer/components/SplitPane/PaneWrapper.tsx
+++ b/src/renderer/components/SplitPane/PaneWrapper.tsx
@@ -9,13 +9,13 @@ import NotificationRing from '../Terminal/NotificationRing';
 import SurfaceTabBar from './SurfaceTabBar';
 import { useStore } from '../../store';
 import type { SurfaceDragCommitOptions, SurfaceDragPayload, SurfaceDragPreviewTarget } from './drag-preview-types';
+import {
+  getSurfaceDragDropDecision,
+  parseSurfaceDragData,
+  type SurfaceDragData,
+} from './surface-drag-preview';
 import '../../styles/splitpane.css';
 import '../../styles/terminal.css';
-
-interface SurfaceDragData {
-  sourcePaneId: PaneId;
-  surfaceId: SurfaceId;
-}
 
 interface PaneWrapperProps {
   paneId: PaneId;
@@ -397,23 +397,15 @@ export default function PaneWrapper({
   };
 
   const getValidSurfaceDragData = (data: string): SurfaceDragData | null => {
-    try {
-      const parsed = JSON.parse(data) as Partial<Record<'sourcePaneId' | 'surfaceId', unknown>>;
-      if (typeof parsed.sourcePaneId !== 'string' || typeof parsed.surfaceId !== 'string') {
-        return null;
-      }
+    const parsed = parseSurfaceDragData(data);
+    if (!parsed) return null;
 
-      const sourcePaneId = parsed.sourcePaneId as PaneId;
-      const surfaceId = parsed.surfaceId as SurfaceId;
-      const sourceLeaf = getSourceLeaf(sourcePaneId);
-      if (!sourceLeaf?.surfaces.some((surface) => surface.id === surfaceId)) {
-        return null;
-      }
-
-      return { sourcePaneId, surfaceId };
-    } catch {
+    const sourceLeaf = getSourceLeaf(parsed.sourcePaneId);
+    if (!sourceLeaf?.surfaces.some((surface) => surface.id === parsed.surfaceId)) {
       return null;
     }
+
+    return parsed;
   };
 
   const handleEdgeDrop = (e: React.DragEvent, direction: 'left' | 'right' | 'up' | 'down') => {
@@ -432,13 +424,25 @@ export default function PaneWrapper({
         return;
       }
       const { sourcePaneId, surfaceId } = dragData;
-
-      if (sourcePaneId === paneId && surfaces.length === 1) {
+      const sourceLeaf = getSourceLeaf(sourcePaneId);
+      if (!sourceLeaf) {
         onSurfaceDragEnd();
         return;
       }
 
-      onSurfaceDragCommit({ clearZoom: true });
+      const decision = getSurfaceDragDropDecision({
+        target: 'edge',
+        sourcePaneId,
+        targetPaneId: paneId,
+        sourceSurfaceCount: sourceLeaf.surfaces.length,
+      });
+
+      if (decision.action === 'cancel') {
+        onSurfaceDragEnd();
+        return;
+      }
+
+      onSurfaceDragCommit(decision.commitOptions);
       splitAndMoveSurface(activeWorkspaceId, paneId, sourcePaneId, surfaceId, direction);
     } catch {
       onSurfaceDragEnd();
@@ -461,13 +465,26 @@ export default function PaneWrapper({
         return;
       }
       const { sourcePaneId, surfaceId } = dragData;
-      if (sourcePaneId !== paneId) {
-        const sourceLeaf = getSourceLeaf(sourcePaneId);
-        onSurfaceDragCommit({ clearZoom: sourceLeaf?.surfaces.length === 1 });
-        moveSurface(activeWorkspaceId, sourcePaneId, surfaceId, paneId);
+      const sourceLeaf = getSourceLeaf(sourcePaneId);
+      if (!sourceLeaf) {
+        onSurfaceDragEnd();
         return;
       }
-      onSurfaceDragEnd();
+
+      const decision = getSurfaceDragDropDecision({
+        target: 'center',
+        sourcePaneId,
+        targetPaneId: paneId,
+        sourceSurfaceCount: sourceLeaf.surfaces.length,
+      });
+
+      if (decision.action === 'cancel') {
+        onSurfaceDragEnd();
+        return;
+      }
+
+      onSurfaceDragCommit(decision.commitOptions);
+      moveSurface(activeWorkspaceId, sourcePaneId, surfaceId, paneId);
     } catch {
       onSurfaceDragEnd();
     }

--- a/src/renderer/components/SplitPane/PaneWrapper.tsx
+++ b/src/renderer/components/SplitPane/PaneWrapper.tsx
@@ -8,6 +8,7 @@ import DiffPane from '../Diff/DiffPane';
 import NotificationRing from '../Terminal/NotificationRing';
 import SurfaceTabBar from './SurfaceTabBar';
 import { useStore } from '../../store';
+import type { SurfaceDragPayload, SurfaceDragPreviewTarget } from './drag-preview-types';
 import '../../styles/splitpane.css';
 import '../../styles/terminal.css';
 
@@ -16,9 +17,22 @@ interface PaneWrapperProps {
   workspaceId: WorkspaceId;
   leaf: SplitNode & { type: 'leaf' };
   isFocused: boolean;
+  surfaceDrag: SurfaceDragPayload | null;
+  onSurfaceDragStart: (payload: SurfaceDragPayload) => void;
+  onSurfaceDragEnd: () => void;
+  onSurfaceDragPreviewTarget: (targetPaneId: PaneId, target: SurfaceDragPreviewTarget) => void;
+  onClearSurfaceDragPreview: () => void;
+  onSurfaceDragCommit: () => void;
 }
 
-export default function PaneWrapper({ leaf, workspaceId, isFocused }: PaneWrapperProps) {
+export default function PaneWrapper({
+  leaf,
+  workspaceId,
+  isFocused,
+  onSurfaceDragStart,
+  onSurfaceDragEnd,
+  onSurfaceDragCommit,
+}: PaneWrapperProps) {
   const { surfaces, activeSurfaceIndex, paneId } = leaf;
 
   const notifications = useStore((s) => s.notifications);
@@ -356,11 +370,17 @@ export default function PaneWrapper({ leaf, workspaceId, isFocused }: PaneWrappe
     setDragActive(false);
     document.body.classList.remove('wmux-dragging');
     const data = e.dataTransfer.getData('application/wmux-surface');
-    if (!data || !activeWorkspaceId) return;
+    if (!data || !activeWorkspaceId) {
+      onSurfaceDragEnd();
+      return;
+    }
     try {
       const { sourcePaneId, surfaceId } = JSON.parse(data);
+      onSurfaceDragCommit();
       splitAndMoveSurface(activeWorkspaceId, paneId, sourcePaneId as PaneId, surfaceId as SurfaceId, direction);
-    } catch {}
+    } catch {
+      onSurfaceDragEnd();
+    }
   };
 
   const handleCenterDrop = (e: React.DragEvent) => {
@@ -368,13 +388,21 @@ export default function PaneWrapper({ leaf, workspaceId, isFocused }: PaneWrappe
     setDragActive(false);
     document.body.classList.remove('wmux-dragging');
     const data = e.dataTransfer.getData('application/wmux-surface');
-    if (!data || !activeWorkspaceId) return;
+    if (!data || !activeWorkspaceId) {
+      onSurfaceDragEnd();
+      return;
+    }
     try {
       const { sourcePaneId, surfaceId } = JSON.parse(data);
       if (sourcePaneId !== paneId) {
+        onSurfaceDragCommit();
         moveSurface(activeWorkspaceId, sourcePaneId as PaneId, surfaceId as SurfaceId, paneId);
+        return;
       }
-    } catch {}
+      onSurfaceDragEnd();
+    } catch {
+      onSurfaceDragEnd();
+    }
   };
 
   const preventDragDefault = (e: React.DragEvent) => {
@@ -409,6 +437,12 @@ export default function PaneWrapper({ leaf, workspaceId, isFocused }: PaneWrappe
         onSplitDown={handleSplitDown}
         onDropSurface={handleDropSurface}
         onReorderSurface={handleReorderSurface}
+        onSurfaceDragStart={(surfaceId) => onSurfaceDragStart({
+          workspaceId,
+          sourcePaneId: paneId,
+          surfaceId,
+        })}
+        onSurfaceDragEnd={onSurfaceDragEnd}
         isDragActive={dragActive}
         isFocused={isFocused}
       />

--- a/src/renderer/components/SplitPane/SplitContainer.tsx
+++ b/src/renderer/components/SplitPane/SplitContainer.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 import { SplitNode, PaneId, WorkspaceId } from '../../../shared/types';
 import PaneWrapper from './PaneWrapper';
 import SplitDivider from './SplitDivider';
-import type { SurfaceDragPayload, SurfaceDragPreviewTarget } from './drag-preview-types';
+import type { SurfaceDragCommitOptions, SurfaceDragPayload, SurfaceDragPreviewTarget } from './drag-preview-types';
 import '../../styles/splitpane.css';
 
 /** Get all pane IDs from a subtree — used as stable React key */
@@ -27,7 +27,7 @@ interface SplitContainerProps {
   onSurfaceDragEnd: () => void;
   onSurfaceDragPreviewTarget: (targetPaneId: PaneId, target: SurfaceDragPreviewTarget) => void;
   onClearSurfaceDragPreview: () => void;
-  onSurfaceDragCommit: () => void;
+  onSurfaceDragCommit: (options?: SurfaceDragCommitOptions) => void;
 }
 
 export default function SplitContainer({

--- a/src/renderer/components/SplitPane/SplitContainer.tsx
+++ b/src/renderer/components/SplitPane/SplitContainer.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { SplitNode, PaneId, WorkspaceId } from '../../../shared/types';
 import PaneWrapper from './PaneWrapper';
 import SplitDivider from './SplitDivider';
+import type { SurfaceDragPayload, SurfaceDragPreviewTarget } from './drag-preview-types';
 import '../../styles/splitpane.css';
 
 /** Get all pane IDs from a subtree — used as stable React key */
@@ -21,6 +22,12 @@ interface SplitContainerProps {
   focusedPaneId: PaneId | null;
   onRatioChange?: (leftPaneId: PaneId, rightPaneId: PaneId, ratio: number) => void;
   onPaneFocus: (paneId: PaneId) => void;
+  surfaceDrag: SurfaceDragPayload | null;
+  onSurfaceDragStart: (payload: SurfaceDragPayload) => void;
+  onSurfaceDragEnd: () => void;
+  onSurfaceDragPreviewTarget: (targetPaneId: PaneId, target: SurfaceDragPreviewTarget) => void;
+  onClearSurfaceDragPreview: () => void;
+  onSurfaceDragCommit: () => void;
 }
 
 export default function SplitContainer({
@@ -29,6 +36,12 @@ export default function SplitContainer({
   focusedPaneId,
   onRatioChange,
   onPaneFocus,
+  surfaceDrag,
+  onSurfaceDragStart,
+  onSurfaceDragEnd,
+  onSurfaceDragPreviewTarget,
+  onClearSurfaceDragPreview,
+  onSurfaceDragCommit,
 }: SplitContainerProps) {
   if (node.type === 'leaf') {
     return (
@@ -43,6 +56,12 @@ export default function SplitContainer({
           workspaceId={workspaceId}
           leaf={node}
           isFocused={focusedPaneId === node.paneId}
+          surfaceDrag={surfaceDrag}
+          onSurfaceDragStart={onSurfaceDragStart}
+          onSurfaceDragEnd={onSurfaceDragEnd}
+          onSurfaceDragPreviewTarget={onSurfaceDragPreviewTarget}
+          onClearSurfaceDragPreview={onClearSurfaceDragPreview}
+          onSurfaceDragCommit={onSurfaceDragCommit}
         />
       </div>
     );
@@ -77,6 +96,12 @@ export default function SplitContainer({
           focusedPaneId={focusedPaneId}
           onRatioChange={onRatioChange}
           onPaneFocus={onPaneFocus}
+          surfaceDrag={surfaceDrag}
+          onSurfaceDragStart={onSurfaceDragStart}
+          onSurfaceDragEnd={onSurfaceDragEnd}
+          onSurfaceDragPreviewTarget={onSurfaceDragPreviewTarget}
+          onClearSurfaceDragPreview={onClearSurfaceDragPreview}
+          onSurfaceDragCommit={onSurfaceDragCommit}
         />
       </div>
 
@@ -93,6 +118,12 @@ export default function SplitContainer({
           focusedPaneId={focusedPaneId}
           onRatioChange={onRatioChange}
           onPaneFocus={onPaneFocus}
+          surfaceDrag={surfaceDrag}
+          onSurfaceDragStart={onSurfaceDragStart}
+          onSurfaceDragEnd={onSurfaceDragEnd}
+          onSurfaceDragPreviewTarget={onSurfaceDragPreviewTarget}
+          onClearSurfaceDragPreview={onClearSurfaceDragPreview}
+          onSurfaceDragCommit={onSurfaceDragCommit}
         />
       </div>
     </div>

--- a/src/renderer/components/SplitPane/SplitPreviewOverlay.tsx
+++ b/src/renderer/components/SplitPane/SplitPreviewOverlay.tsx
@@ -1,0 +1,103 @@
+import type { PaneId, SplitNode, SurfaceId, SurfaceRef } from '../../../shared/types';
+import '../../styles/splitpane.css';
+
+interface SplitPreviewOverlayProps {
+  tree: SplitNode;
+  destinationPaneId: PaneId;
+  draggedSurfaceId: SurfaceId;
+}
+
+export default function SplitPreviewOverlay({
+  tree,
+  destinationPaneId,
+  draggedSurfaceId,
+}: SplitPreviewOverlayProps) {
+  return (
+    <div className="split-preview-overlay" aria-hidden="true">
+      <PreviewNode
+        node={tree}
+        destinationPaneId={destinationPaneId}
+        draggedSurfaceId={draggedSurfaceId}
+      />
+    </div>
+  );
+}
+
+function PreviewNode({
+  node,
+  destinationPaneId,
+  draggedSurfaceId,
+}: {
+  node: SplitNode;
+  destinationPaneId: PaneId;
+  draggedSurfaceId: SurfaceId;
+}) {
+  if (node.type === 'leaf') {
+    const isDestination = node.paneId === destinationPaneId;
+
+    return (
+      <div className={`split-preview-pane ${isDestination ? 'split-preview-pane--destination' : ''}`}>
+        <div className="split-preview-pane__tabs">
+          {node.surfaces.map((surface, index) => (
+            <span
+              key={surface.id}
+              className={[
+                'split-preview-pane__tab',
+                surface.id === draggedSurfaceId ? 'split-preview-pane__tab--dragged' : '',
+                index === node.activeSurfaceIndex ? 'split-preview-pane__tab--active' : '',
+              ].filter(Boolean).join(' ')}
+            >
+              {surfaceLabel(surface)}
+            </span>
+          ))}
+        </div>
+        <div className="split-preview-pane__body">
+          <span className="split-preview-pane__line" />
+          <span className="split-preview-pane__line" />
+          <span className="split-preview-pane__line" />
+          <span className="split-preview-pane__line" />
+        </div>
+        {isDestination && <span className="split-preview-pane__destination-label">Drop here</span>}
+      </div>
+    );
+  }
+
+  const [left, right] = node.children;
+
+  return (
+    <div className={`split-preview-container split-preview-container--${node.direction}`}>
+      <div className="split-preview-container__child" style={{ flex: node.ratio }}>
+        <PreviewNode
+          node={left}
+          destinationPaneId={destinationPaneId}
+          draggedSurfaceId={draggedSurfaceId}
+        />
+      </div>
+      <div className={`split-preview-container__divider split-preview-container__divider--${node.direction}`} />
+      <div className="split-preview-container__child" style={{ flex: 1 - node.ratio }}>
+        <PreviewNode
+          node={right}
+          destinationPaneId={destinationPaneId}
+          draggedSurfaceId={draggedSurfaceId}
+        />
+      </div>
+    </div>
+  );
+}
+
+function surfaceLabel(surface: SurfaceRef): string {
+  if (surface.customTitle) return surface.customTitle;
+
+  switch (surface.type) {
+    case 'terminal':
+      return 'Terminal';
+    case 'browser':
+      return 'Browser';
+    case 'markdown':
+      return 'Markdown';
+    case 'diff':
+      return 'Diff';
+    default:
+      return 'Surface';
+  }
+}

--- a/src/renderer/components/SplitPane/SplitPreviewOverlay.tsx
+++ b/src/renderer/components/SplitPane/SplitPreviewOverlay.tsx
@@ -1,23 +1,32 @@
 import type { PaneId, SplitNode, SurfaceId, SurfaceRef } from '../../../shared/types';
+import { useStore } from '../../store';
 import '../../styles/splitpane.css';
+import { getSurfaceLabel } from './surface-label';
 
 interface SplitPreviewOverlayProps {
   tree: SplitNode;
   destinationPaneId: PaneId;
   draggedSurfaceId: SurfaceId;
+  workspaceShell?: string;
 }
 
 export default function SplitPreviewOverlay({
   tree,
   destinationPaneId,
   draggedSurfaceId,
+  workspaceShell,
 }: SplitPreviewOverlayProps) {
+  const agentMeta = useStore((state) => state.agentMeta);
+  const getPreviewSurfaceLabel = (surface: SurfaceRef) =>
+    getSurfaceLabel(surface, agentMeta.get(surface.id)?.label, workspaceShell);
+
   return (
     <div className="split-preview-overlay" aria-hidden="true">
       <PreviewNode
         node={tree}
         destinationPaneId={destinationPaneId}
         draggedSurfaceId={draggedSurfaceId}
+        getPreviewSurfaceLabel={getPreviewSurfaceLabel}
       />
     </div>
   );
@@ -27,10 +36,12 @@ function PreviewNode({
   node,
   destinationPaneId,
   draggedSurfaceId,
+  getPreviewSurfaceLabel,
 }: {
   node: SplitNode;
   destinationPaneId: PaneId;
   draggedSurfaceId: SurfaceId;
+  getPreviewSurfaceLabel: (surface: SurfaceRef) => string;
 }) {
   if (node.type === 'leaf') {
     const isDestination = node.paneId === destinationPaneId;
@@ -47,7 +58,7 @@ function PreviewNode({
                 index === node.activeSurfaceIndex ? 'split-preview-pane__tab--active' : '',
               ].filter(Boolean).join(' ')}
             >
-              {surfaceLabel(surface)}
+              {getPreviewSurfaceLabel(surface)}
             </span>
           ))}
         </div>
@@ -71,6 +82,7 @@ function PreviewNode({
           node={left}
           destinationPaneId={destinationPaneId}
           draggedSurfaceId={draggedSurfaceId}
+          getPreviewSurfaceLabel={getPreviewSurfaceLabel}
         />
       </div>
       <div className={`split-preview-container__divider split-preview-container__divider--${node.direction}`} />
@@ -79,25 +91,9 @@ function PreviewNode({
           node={right}
           destinationPaneId={destinationPaneId}
           draggedSurfaceId={draggedSurfaceId}
+          getPreviewSurfaceLabel={getPreviewSurfaceLabel}
         />
       </div>
     </div>
   );
-}
-
-function surfaceLabel(surface: SurfaceRef): string {
-  if (surface.customTitle) return surface.customTitle;
-
-  switch (surface.type) {
-    case 'terminal':
-      return 'Terminal';
-    case 'browser':
-      return 'Browser';
-    case 'markdown':
-      return 'Markdown';
-    case 'diff':
-      return 'Diff';
-    default:
-      return 'Surface';
-  }
 }

--- a/src/renderer/components/SplitPane/SurfaceTabBar.tsx
+++ b/src/renderer/components/SplitPane/SurfaceTabBar.tsx
@@ -107,6 +107,13 @@ export default function SurfaceTabBar({
   const renameSurface = useStore((state) => state.renameSurface);
   const getAgentMeta = (surfaceId: string) => agentMeta.get(surfaceId as any);
 
+  useEffect(() => {
+    if (!isDragActive) {
+      setDraggingSurfaceId(null);
+      setInsertIndex(null);
+    }
+  }, [isDragActive]);
+
   // Start rename for the active surface
   const startRename = useCallback(() => {
     const activeSurface = surfaces[activeSurfaceIndex];

--- a/src/renderer/components/SplitPane/SurfaceTabBar.tsx
+++ b/src/renderer/components/SplitPane/SurfaceTabBar.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { SurfaceRef, SurfaceId, PaneId, WorkspaceId, QuickLaunchProfile, ShellInfo } from '../../../shared/types';
 import { useStore } from '../../store';
 import { IconAdd, IconSplit, IconSplitDown, IconClose, IconCaret } from './icons';
+import type { SurfaceDragPayload, SurfaceDragPreviewTarget } from './drag-preview-types';
 
 interface SurfaceTabBarProps {
   paneId: PaneId;
@@ -24,6 +25,9 @@ interface SurfaceTabBarProps {
   onSplitDown?: () => void;
   onDropSurface?: (sourcePaneId: PaneId, surfaceId: SurfaceId, targetPaneId: PaneId) => void;
   onReorderSurface?: (surfaceId: SurfaceId, newIndex: number) => void;
+  surfaceDrag?: SurfaceDragPayload | null;
+  onSurfaceDragPreviewTarget?: (targetPaneId: PaneId, target: SurfaceDragPreviewTarget) => void;
+  onClearSurfaceDragPreview?: () => void;
   onSurfaceDragStart?: (surfaceId: SurfaceId) => void;
   onSurfaceDragEnd?: () => void;
   isDragActive?: boolean;
@@ -84,6 +88,9 @@ export default function SurfaceTabBar({
   onSplitDown,
   onDropSurface,
   onReorderSurface,
+  surfaceDrag,
+  onSurfaceDragPreviewTarget,
+  onClearSurfaceDragPreview,
   onSurfaceDragStart,
   onSurfaceDragEnd,
   isDragActive,
@@ -211,6 +218,12 @@ export default function SurfaceTabBar({
     else onSplitDown?.();
   }, [onSplitRight, onSplitDown]);
 
+  const requestCenterPreview = useCallback(() => {
+    if (surfaceDrag?.sourcePaneId !== paneId) {
+      onSurfaceDragPreviewTarget?.(paneId, 'center');
+    }
+  }, [onSurfaceDragPreviewTarget, paneId, surfaceDrag]);
+
   // Always show tab bar (even for 1 surface — like browser tabs)
   return (
     <div
@@ -219,6 +232,7 @@ export default function SurfaceTabBar({
       onDragOver={(e) => {
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
+        requestCenterPreview();
       }}
       onDrop={(e) => {
         e.preventDefault();
@@ -248,7 +262,12 @@ export default function SurfaceTabBar({
         }
         onSurfaceDragEnd?.();
       }}
-      onDragLeave={() => setInsertIndex(null)}
+      onDragLeave={() => {
+        setInsertIndex(null);
+        if (surfaceDrag?.sourcePaneId !== paneId) {
+          onClearSurfaceDragPreview?.();
+        }
+      }}
     >
       <div className="surface-tab-bar__tabs">
         {surfaces.map((surface, index) => {
@@ -298,6 +317,7 @@ export default function SurfaceTabBar({
                 const midpoint = rect.left + rect.width / 2;
                 const newInsertIndex = e.clientX < midpoint ? index : index + 1;
                 setInsertIndex(newInsertIndex);
+                requestCenterPreview();
               }}
             >
               <span className="surface-tab__icon">{surfaceIcon(surface.type, isAgent)}</span>

--- a/src/renderer/components/SplitPane/SurfaceTabBar.tsx
+++ b/src/renderer/components/SplitPane/SurfaceTabBar.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { SurfaceRef, SurfaceId, PaneId, WorkspaceId, QuickLaunchProfile, ShellInfo } from '../../../shared/types';
+import { SurfaceRef, SurfaceId, PaneId, QuickLaunchProfile, ShellInfo } from '../../../shared/types';
 import { useStore } from '../../store';
 import { IconAdd, IconSplit, IconSplitDown, IconClose, IconCaret } from './icons';
 import type { SurfaceDragPayload, SurfaceDragPreviewTarget } from './drag-preview-types';
+import { parseSurfaceDragData } from './surface-drag-preview';
+import { getSurfaceLabel } from './surface-label';
 
 interface SurfaceTabBarProps {
   paneId: PaneId;
@@ -42,31 +44,6 @@ function surfaceIcon(type: string, isAgent: boolean): string {
     case 'markdown': return '¶';
     case 'diff': return '±';
     default: return '○';
-  }
-}
-
-function getShellLabel(shell?: string): string | null {
-  if (!shell) return null;
-  const normalized = shell.replace(/\\/g, '/').split('/').pop()?.toLowerCase() || shell.toLowerCase();
-  if (normalized === 'pwsh.exe' || normalized === 'pwsh') return 'PowerShell';
-  if (normalized === 'powershell.exe' || normalized === 'powershell') return 'Windows PowerShell';
-  if (normalized === 'cmd.exe' || normalized === 'cmd') return 'Command Prompt';
-  if (normalized === 'bash.exe' || normalized === 'bash') return 'Bash';
-  if (normalized === 'zsh' || normalized === 'zsh.exe') return 'Zsh';
-  if (normalized === 'wsl.exe' || normalized === 'wsl') return 'WSL';
-  if (normalized === 'git-bash.exe') return 'Git Bash';
-  return normalized.replace(/\.exe$/i, '').replace(/[-_]/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
-function surfaceLabel(surface: SurfaceRef, agentLabel?: string, workspaceShell?: string): string {
-  if (surface.customTitle) return surface.customTitle;
-  if (agentLabel) return agentLabel;
-  switch (surface.type) {
-    case 'terminal': return getShellLabel(surface.shell || workspaceShell) || 'Terminal';
-    case 'browser': return 'Browser';
-    case 'markdown': return 'Markdown';
-    case 'diff': return 'Diff';
-    default: return 'Tab';
   }
 }
 
@@ -246,7 +223,12 @@ export default function SurfaceTabBar({
           return;
         }
         try {
-          const { sourcePaneId, surfaceId } = JSON.parse(data);
+          const dragData = parseSurfaceDragData(data);
+          if (!dragData) {
+            onSurfaceDragEnd?.();
+            return;
+          }
+          const { sourcePaneId, surfaceId } = dragData;
           if (sourcePaneId === paneId && onReorderSurface && savedInsertIndex !== null) {
             const currentIndex = surfaces.findIndex(s => s.id === surfaceId);
             const adjustedIndex = savedInsertIndex > currentIndex ? savedInsertIndex - 1 : savedInsertIndex;
@@ -334,10 +316,10 @@ export default function SurfaceTabBar({
                   }}
                   onBlur={commitRename}
                   onClick={(e) => e.stopPropagation()}
-                  placeholder={surfaceLabel(surface, agentMeta?.label, workspaceShell)}
+                  placeholder={getSurfaceLabel(surface, agentMeta?.label, workspaceShell)}
                 />
               ) : (
-                <span className="surface-tab__label">{surfaceLabel(surface, agentMeta?.label, workspaceShell)}</span>
+                <span className="surface-tab__label">{getSurfaceLabel(surface, agentMeta?.label, workspaceShell)}</span>
               )}
               {surfaces.length > 1 && !isRenaming && (
                 <button

--- a/src/renderer/components/SplitPane/SurfaceTabBar.tsx
+++ b/src/renderer/components/SplitPane/SurfaceTabBar.tsx
@@ -24,6 +24,8 @@ interface SurfaceTabBarProps {
   onSplitDown?: () => void;
   onDropSurface?: (sourcePaneId: PaneId, surfaceId: SurfaceId, targetPaneId: PaneId) => void;
   onReorderSurface?: (surfaceId: SurfaceId, newIndex: number) => void;
+  onSurfaceDragStart?: (surfaceId: SurfaceId) => void;
+  onSurfaceDragEnd?: () => void;
   isDragActive?: boolean;
   isFocused?: boolean;
 }
@@ -82,6 +84,8 @@ export default function SurfaceTabBar({
   onSplitDown,
   onDropSurface,
   onReorderSurface,
+  onSurfaceDragStart,
+  onSurfaceDragEnd,
   isDragActive,
   isFocused,
 }: SurfaceTabBarProps) {
@@ -216,7 +220,10 @@ export default function SurfaceTabBar({
         setDraggingSurfaceId(null);
         document.body.classList.remove('wmux-dragging');
         const data = e.dataTransfer.getData('application/wmux-surface');
-        if (!data) return;
+        if (!data) {
+          onSurfaceDragEnd?.();
+          return;
+        }
         try {
           const { sourcePaneId, surfaceId } = JSON.parse(data);
           if (sourcePaneId === paneId && onReorderSurface && savedInsertIndex !== null) {
@@ -228,7 +235,11 @@ export default function SurfaceTabBar({
           } else if (sourcePaneId !== paneId && onDropSurface) {
             onDropSurface(sourcePaneId as PaneId, surfaceId as SurfaceId, paneId);
           }
-        } catch {}
+        } catch {
+          onSurfaceDragEnd?.();
+          return;
+        }
+        onSurfaceDragEnd?.();
       }}
       onDragLeave={() => setInsertIndex(null)}
     >
@@ -264,11 +275,13 @@ export default function SurfaceTabBar({
                 );
                 e.dataTransfer.effectAllowed = 'move';
                 setDraggingSurfaceId(surface.id);
+                onSurfaceDragStart?.(surface.id);
                 document.body.classList.add('wmux-dragging');
               }}
               onDragEnd={() => {
                 setDraggingSurfaceId(null);
                 setInsertIndex(null);
+                onSurfaceDragEnd?.();
                 document.body.classList.remove('wmux-dragging');
               }}
               onDragOver={(e) => {

--- a/src/renderer/components/SplitPane/drag-preview-types.ts
+++ b/src/renderer/components/SplitPane/drag-preview-types.ts
@@ -1,0 +1,17 @@
+import type { PaneId, SplitNode, SurfaceId, WorkspaceId } from '../../../shared/types';
+
+export type SurfaceDragPreviewTarget = 'left' | 'right' | 'up' | 'down' | 'center';
+
+export interface SurfaceDragPayload {
+  workspaceId: WorkspaceId;
+  sourcePaneId: PaneId;
+  surfaceId: SurfaceId;
+}
+
+export interface SurfaceDragPreview extends SurfaceDragPayload {
+  targetPaneId: PaneId;
+  target: SurfaceDragPreviewTarget;
+  previewTree: SplitNode;
+  destinationPaneId: PaneId;
+  collapsesSourcePane: boolean;
+}

--- a/src/renderer/components/SplitPane/drag-preview-types.ts
+++ b/src/renderer/components/SplitPane/drag-preview-types.ts
@@ -15,3 +15,7 @@ export interface SurfaceDragPreview extends SurfaceDragPayload {
   destinationPaneId: PaneId;
   collapsesSourcePane: boolean;
 }
+
+export interface SurfaceDragCommitOptions {
+  clearZoom?: boolean;
+}

--- a/src/renderer/components/SplitPane/surface-drag-preview.ts
+++ b/src/renderer/components/SplitPane/surface-drag-preview.ts
@@ -1,0 +1,107 @@
+import type { PaneId, SurfaceId, WorkspaceId, WorkspaceInfo } from '../../../shared/types';
+import { previewMoveSurface, previewSplitAndMoveSurface } from '../../store/split-preview-utils';
+import type {
+  SurfaceDragCommitOptions,
+  SurfaceDragPayload,
+  SurfaceDragPreview,
+  SurfaceDragPreviewTarget,
+} from './drag-preview-types';
+
+export interface SurfaceDragData {
+  sourcePaneId: PaneId;
+  surfaceId: SurfaceId;
+}
+
+export interface PendingSurfaceDragPreviewTarget {
+  targetPaneId: PaneId;
+  target: SurfaceDragPreviewTarget;
+}
+
+export interface BuildSurfaceDragPreviewOptions {
+  workspaces: Pick<WorkspaceInfo, 'id' | 'splitTree'>[];
+  activeWorkspaceId: WorkspaceId | null;
+  drag: SurfaceDragPayload | null;
+  pendingTarget: PendingSurfaceDragPreviewTarget | null;
+}
+
+export type SurfaceDragDropDecision =
+  | { action: 'cancel' }
+  | { action: 'commit'; commitOptions: SurfaceDragCommitOptions };
+
+export function buildSurfaceDragPreview({
+  workspaces,
+  activeWorkspaceId,
+  drag,
+  pendingTarget,
+}: BuildSurfaceDragPreviewOptions): SurfaceDragPreview | null {
+  if (!pendingTarget || !drag) return null;
+
+  const workspace = workspaces.find((candidate) => candidate.id === drag.workspaceId);
+  if (!workspace || workspace.id !== activeWorkspaceId) return null;
+
+  const result = pendingTarget.target === 'center'
+    ? previewMoveSurface(workspace.splitTree, drag.sourcePaneId, drag.surfaceId, pendingTarget.targetPaneId)
+    : previewSplitAndMoveSurface(
+      workspace.splitTree,
+      pendingTarget.targetPaneId,
+      drag.sourcePaneId,
+      drag.surfaceId,
+      pendingTarget.target,
+    );
+
+  if (!result) return null;
+
+  return {
+    ...drag,
+    targetPaneId: pendingTarget.targetPaneId,
+    target: pendingTarget.target,
+    previewTree: result.tree,
+    destinationPaneId: result.destinationPaneId,
+    collapsesSourcePane: result.collapsesSourcePane,
+  };
+}
+
+export function getSurfaceDragDropDecision({
+  target,
+  sourcePaneId,
+  targetPaneId,
+  sourceSurfaceCount,
+}: {
+  target: 'edge' | 'center';
+  sourcePaneId: PaneId;
+  targetPaneId: PaneId;
+  sourceSurfaceCount: number;
+}): SurfaceDragDropDecision {
+  if (target === 'edge') {
+    if (sourcePaneId === targetPaneId && sourceSurfaceCount === 1) {
+      return { action: 'cancel' };
+    }
+
+    return { action: 'commit', commitOptions: { clearZoom: true } };
+  }
+
+  if (sourcePaneId === targetPaneId) {
+    return { action: 'cancel' };
+  }
+
+  return {
+    action: 'commit',
+    commitOptions: { clearZoom: sourceSurfaceCount === 1 },
+  };
+}
+
+export function parseSurfaceDragData(data: string): SurfaceDragData | null {
+  try {
+    const parsed = JSON.parse(data) as Partial<Record<'sourcePaneId' | 'surfaceId', unknown>>;
+    if (typeof parsed.sourcePaneId !== 'string' || typeof parsed.surfaceId !== 'string') {
+      return null;
+    }
+
+    return {
+      sourcePaneId: parsed.sourcePaneId as PaneId,
+      surfaceId: parsed.surfaceId as SurfaceId,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/renderer/components/SplitPane/surface-label.ts
+++ b/src/renderer/components/SplitPane/surface-label.ts
@@ -1,0 +1,32 @@
+import type { SurfaceRef } from '../../../shared/types';
+
+export function getShellLabel(shell?: string): string | null {
+  if (!shell) return null;
+  const normalized = shell.replace(/\\/g, '/').split('/').pop()?.toLowerCase() || shell.toLowerCase();
+  if (normalized === 'pwsh.exe' || normalized === 'pwsh') return 'PowerShell';
+  if (normalized === 'powershell.exe' || normalized === 'powershell') return 'Windows PowerShell';
+  if (normalized === 'cmd.exe' || normalized === 'cmd') return 'Command Prompt';
+  if (normalized === 'bash.exe' || normalized === 'bash') return 'Bash';
+  if (normalized === 'zsh' || normalized === 'zsh.exe') return 'Zsh';
+  if (normalized === 'wsl.exe' || normalized === 'wsl') return 'WSL';
+  if (normalized === 'git-bash.exe') return 'Git Bash';
+  return normalized.replace(/\.exe$/i, '').replace(/[-_]/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function getSurfaceLabel(surface: SurfaceRef, agentLabel?: string, workspaceShell?: string): string {
+  if (surface.customTitle) return surface.customTitle;
+  if (agentLabel) return agentLabel;
+
+  switch (surface.type) {
+    case 'terminal':
+      return getShellLabel(surface.shell || workspaceShell) || 'Terminal';
+    case 'browser':
+      return 'Browser';
+    case 'markdown':
+      return 'Markdown';
+    case 'diff':
+      return 'Diff';
+    default:
+      return 'Tab';
+  }
+}

--- a/src/renderer/store/split-preview-utils.ts
+++ b/src/renderer/store/split-preview-utils.ts
@@ -1,0 +1,187 @@
+import type { PaneId, SplitNode, SurfaceId, SurfaceRef } from '../../shared/types';
+import { findLeaf, removeLeaf } from './split-utils';
+
+export type SplitPreviewDirection = 'left' | 'right' | 'up' | 'down';
+
+export interface SplitPreviewResult {
+  tree: SplitNode;
+  destinationPaneId: PaneId;
+  collapsesSourcePane: boolean;
+}
+
+type LeafNode = SplitNode & { type: 'leaf' };
+
+interface SurfaceRemovalResult {
+  tree: SplitNode | null;
+  surface: SurfaceRef;
+  collapsesSourcePane: boolean;
+}
+
+export function previewSplitAndMoveSurface(
+  tree: SplitNode,
+  targetPaneId: PaneId,
+  sourcePaneId: PaneId,
+  surfaceId: SurfaceId,
+  direction: SplitPreviewDirection,
+): SplitPreviewResult | null {
+  const sourceLeaf = findLeaf(tree, sourcePaneId);
+  const targetLeaf = findLeaf(tree, targetPaneId);
+  if (!sourceLeaf || !targetLeaf) return null;
+
+  const draggedSurface = sourceLeaf.surfaces.find((surface) => surface.id === surfaceId);
+  if (!draggedSurface) return null;
+
+  if (sourcePaneId === targetPaneId && sourceLeaf.surfaces.length === 1) {
+    return null;
+  }
+
+  const removal = removeSurfaceForPreview(tree, sourcePaneId, surfaceId);
+  if (!removal?.tree) return null;
+
+  const destinationPaneId = createPreviewPaneId(targetPaneId, surfaceId, direction);
+  const destinationLeaf: LeafNode = {
+    type: 'leaf',
+    paneId: destinationPaneId,
+    surfaces: [removal.surface],
+    activeSurfaceIndex: 0,
+  };
+
+  const previewTree = splitTargetForPreview(removal.tree, targetPaneId, destinationLeaf, direction);
+  if (!previewTree) return null;
+
+  return {
+    tree: previewTree,
+    destinationPaneId,
+    collapsesSourcePane: removal.collapsesSourcePane,
+  };
+}
+
+export function previewMoveSurface(
+  tree: SplitNode,
+  sourcePaneId: PaneId,
+  surfaceId: SurfaceId,
+  targetPaneId: PaneId,
+): SplitPreviewResult | null {
+  if (sourcePaneId === targetPaneId) return null;
+
+  const sourceLeaf = findLeaf(tree, sourcePaneId);
+  const targetLeaf = findLeaf(tree, targetPaneId);
+  if (!sourceLeaf || !targetLeaf) return null;
+
+  const draggedSurface = sourceLeaf.surfaces.find((surface) => surface.id === surfaceId);
+  if (!draggedSurface) return null;
+
+  if (sourceLeaf.surfaces.length > 1) {
+    return null;
+  }
+
+  const removal = removeSurfaceForPreview(tree, sourcePaneId, surfaceId);
+  if (!removal?.tree) return null;
+
+  const updatedTarget = findLeaf(removal.tree, targetPaneId);
+  if (!updatedTarget) return null;
+
+  const targetSurfaces = [...updatedTarget.surfaces, removal.surface];
+  const previewTree = patchLeaf(removal.tree, targetPaneId, {
+    surfaces: targetSurfaces,
+    activeSurfaceIndex: targetSurfaces.length - 1,
+  });
+
+  return {
+    tree: previewTree,
+    destinationPaneId: targetPaneId,
+    collapsesSourcePane: true,
+  };
+}
+
+function removeSurfaceForPreview(
+  tree: SplitNode,
+  sourcePaneId: PaneId,
+  surfaceId: SurfaceId,
+): SurfaceRemovalResult | null {
+  const sourceLeaf = findLeaf(tree, sourcePaneId);
+  if (!sourceLeaf) return null;
+
+  const surfaceIndex = sourceLeaf.surfaces.findIndex((surface) => surface.id === surfaceId);
+  if (surfaceIndex === -1) return null;
+
+  const surface = sourceLeaf.surfaces[surfaceIndex];
+  const remainingSurfaces = sourceLeaf.surfaces.filter((candidate) => candidate.id !== surfaceId);
+
+  if (remainingSurfaces.length === 0) {
+    return {
+      tree: removeLeaf(tree, sourcePaneId),
+      surface,
+      collapsesSourcePane: true,
+    };
+  }
+
+  return {
+    tree: patchLeaf(tree, sourcePaneId, {
+      surfaces: remainingSurfaces,
+      activeSurfaceIndex: Math.min(sourceLeaf.activeSurfaceIndex, remainingSurfaces.length - 1),
+    }),
+    surface,
+    collapsesSourcePane: false,
+  };
+}
+
+function splitTargetForPreview(
+  tree: SplitNode,
+  targetPaneId: PaneId,
+  destinationLeaf: LeafNode,
+  direction: SplitPreviewDirection,
+): SplitNode | null {
+  let changed = false;
+  const splitDirection = direction === 'left' || direction === 'right' ? 'horizontal' : 'vertical';
+  const destinationFirst = direction === 'left' || direction === 'up';
+
+  const result = replaceLeaf(tree, targetPaneId, (targetLeaf) => {
+    changed = true;
+    return {
+      type: 'branch',
+      direction: splitDirection,
+      ratio: 0.5,
+      children: destinationFirst
+        ? [destinationLeaf, targetLeaf]
+        : [targetLeaf, destinationLeaf],
+    };
+  });
+
+  return changed ? result : null;
+}
+
+function patchLeaf(
+  tree: SplitNode,
+  paneId: PaneId,
+  patch: Partial<Pick<LeafNode, 'surfaces' | 'activeSurfaceIndex'>>,
+): SplitNode {
+  return replaceLeaf(tree, paneId, (leaf) => ({ ...leaf, ...patch }));
+}
+
+function replaceLeaf(
+  tree: SplitNode,
+  paneId: PaneId,
+  replacement: (leaf: LeafNode) => SplitNode,
+): SplitNode {
+  if (tree.type === 'leaf') {
+    return tree.paneId === paneId ? replacement(tree) : tree;
+  }
+
+  const [left, right] = tree.children;
+  const newLeft = replaceLeaf(left, paneId, replacement);
+  const newRight = replaceLeaf(right, paneId, replacement);
+
+  if (newLeft === left && newRight === right) return tree;
+  return { ...tree, children: [newLeft, newRight] };
+}
+
+function createPreviewPaneId(
+  targetPaneId: PaneId,
+  surfaceId: SurfaceId,
+  direction: SplitPreviewDirection,
+): PaneId {
+  const targetSuffix = targetPaneId.replace(/^pane-/, '');
+  const surfaceSuffix = surfaceId.replace(/^surf-/, '');
+  return `pane-preview-${direction}-${targetSuffix}-${surfaceSuffix}` as PaneId;
+}

--- a/src/renderer/styles/splitpane.css
+++ b/src/renderer/styles/splitpane.css
@@ -300,3 +300,138 @@ body.wmux-dragging,
 body.wmux-dragging * {
   cursor: grabbing !important;
 }
+
+/* Live Layout Preview */
+
+.split-preview-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  pointer-events: none;
+  padding: 4px;
+  background: rgba(8, 10, 14, 0.72);
+  backdrop-filter: blur(1px);
+}
+
+.split-preview-container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.split-preview-container--horizontal {
+  flex-direction: row;
+}
+
+.split-preview-container--vertical {
+  flex-direction: column;
+}
+
+.split-preview-container__child {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.split-preview-container__divider {
+  flex-shrink: 0;
+  background: rgba(137, 180, 250, 0.36);
+}
+
+.split-preview-container__divider--horizontal {
+  width: 4px;
+}
+
+.split-preview-container__divider--vertical {
+  height: 4px;
+}
+
+.split-preview-pane {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: rgba(24, 26, 32, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.10);
+}
+
+.split-preview-pane--destination {
+  background: rgba(32, 55, 92, 0.95);
+  border-color: rgba(137, 180, 250, 0.95);
+  box-shadow: inset 0 0 0 1px rgba(137, 180, 250, 0.42);
+}
+
+.split-preview-pane__tabs {
+  display: flex;
+  align-items: center;
+  height: 24px;
+  gap: 4px;
+  padding: 0 6px;
+  background: rgba(34, 36, 43, 0.98);
+  overflow: hidden;
+}
+
+.split-preview-pane__tab {
+  display: inline-flex;
+  align-items: center;
+  max-width: 140px;
+  height: 16px;
+  padding: 0 7px;
+  border-radius: 3px;
+  background: rgba(48, 51, 60, 0.92);
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 11px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.split-preview-pane__tab--active {
+  color: #fff;
+}
+
+.split-preview-pane__tab--dragged {
+  color: #dce9ff;
+  background: rgba(137, 180, 250, 0.24);
+  outline: 1px solid rgba(137, 180, 250, 0.58);
+}
+
+.split-preview-pane__body {
+  position: absolute;
+  inset: 38px 10px 10px;
+  display: grid;
+  align-content: start;
+  gap: 6px;
+}
+
+.split-preview-pane__line {
+  height: 7px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.split-preview-pane__line:nth-child(2) {
+  width: 78%;
+}
+
+.split-preview-pane__line:nth-child(3) {
+  width: 60%;
+}
+
+.split-preview-pane__line:nth-child(4) {
+  width: 86%;
+}
+
+.split-preview-pane__destination-label {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  padding: 3px 7px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.56);
+  color: rgba(255, 255, 255, 0.86);
+  font-size: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}

--- a/src/renderer/styles/splitpane.css
+++ b/src/renderer/styles/splitpane.css
@@ -291,6 +291,14 @@
 .pane-drop-zone--top:hover    { border-bottom-color: #89b4fa; }
 .pane-drop-zone--bottom:hover { border-top-color: #89b4fa; }
 
+body.wmux-dragging .pane-drop-zone--left:hover,
+body.wmux-dragging .pane-drop-zone--right:hover,
+body.wmux-dragging .pane-drop-zone--top:hover,
+body.wmux-dragging .pane-drop-zone--bottom:hover {
+  background: transparent;
+  border-color: transparent;
+}
+
 .pane-drop-zone--center:hover {
   background: rgba(166, 227, 161, 0.12);
   border-color: #a6e3a1;

--- a/tests/unit/split-preview.test.ts
+++ b/tests/unit/split-preview.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+import type { PaneId, SplitNode, SurfaceId, SurfaceRef } from '../../src/shared/types';
+import { findLeaf, getAllPaneIds } from '../../src/renderer/store/split-utils';
+import {
+  previewMoveSurface,
+  previewSplitAndMoveSurface,
+} from '../../src/renderer/store/split-preview-utils';
+
+function surface(id: string, type: SurfaceRef['type'] = 'terminal'): SurfaceRef {
+  return { id: id as SurfaceId, type };
+}
+
+function leaf(paneId: string, surfaces: SurfaceRef[], activeSurfaceIndex = 0): SplitNode & { type: 'leaf' } {
+  return {
+    type: 'leaf',
+    paneId: paneId as PaneId,
+    surfaces,
+    activeSurfaceIndex,
+  };
+}
+
+function branch(left: SplitNode, right: SplitNode, direction: 'horizontal' | 'vertical' = 'horizontal'): SplitNode {
+  return {
+    type: 'branch',
+    direction,
+    ratio: 0.5,
+    children: [left, right],
+  };
+}
+
+function allSurfaceIds(tree: SplitNode): string[] {
+  if (tree.type === 'leaf') return tree.surfaces.map((s) => s.id);
+  return [...allSurfaceIds(tree.children[0]), ...allSurfaceIds(tree.children[1])];
+}
+
+describe('split preview helpers', () => {
+  it('previews splitting the source pane right when the pane still has another surface', () => {
+    const tree = leaf('pane-1', [surface('surf-drag'), surface('surf-stay')]);
+
+    const result = previewSplitAndMoveSurface(
+      tree,
+      'pane-1' as PaneId,
+      'pane-1' as PaneId,
+      'surf-drag' as SurfaceId,
+      'right',
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.collapsesSourcePane).toBe(false);
+    expect(getAllPaneIds(result!.tree)).toHaveLength(2);
+
+    const sourceLeaf = findLeaf(result!.tree, 'pane-1' as PaneId);
+    expect(sourceLeaf?.surfaces.map((s) => s.id)).toEqual(['surf-stay']);
+
+    const destinationLeaf = findLeaf(result!.tree, result!.destinationPaneId);
+    expect(destinationLeaf?.surfaces.map((s) => s.id)).toEqual(['surf-drag']);
+  });
+
+  it('places preview panes on the requested side of the target pane', () => {
+    const tree = leaf('pane-1', [surface('surf-drag'), surface('surf-stay')]);
+
+    const leftResult = previewSplitAndMoveSurface(
+      tree,
+      'pane-1' as PaneId,
+      'pane-1' as PaneId,
+      'surf-drag' as SurfaceId,
+      'left',
+    );
+
+    const upResult = previewSplitAndMoveSurface(
+      tree,
+      'pane-1' as PaneId,
+      'pane-1' as PaneId,
+      'surf-drag' as SurfaceId,
+      'up',
+    );
+
+    const rightResult = previewSplitAndMoveSurface(
+      tree,
+      'pane-1' as PaneId,
+      'pane-1' as PaneId,
+      'surf-drag' as SurfaceId,
+      'right',
+    );
+
+    const downResult = previewSplitAndMoveSurface(
+      tree,
+      'pane-1' as PaneId,
+      'pane-1' as PaneId,
+      'surf-drag' as SurfaceId,
+      'down',
+    );
+
+    expect(leftResult).not.toBeNull();
+    expect(getAllPaneIds(leftResult!.tree)[0]).toBe(leftResult!.destinationPaneId);
+    expect(leftResult!.tree.type).toBe('branch');
+    expect(leftResult!.tree.type === 'branch' ? leftResult!.tree.direction : null).toBe('horizontal');
+    expect(upResult).not.toBeNull();
+    expect(getAllPaneIds(upResult!.tree)[0]).toBe(upResult!.destinationPaneId);
+    expect(upResult!.tree.type).toBe('branch');
+    expect(upResult!.tree.type === 'branch' ? upResult!.tree.direction : null).toBe('vertical');
+    expect(rightResult).not.toBeNull();
+    expect(getAllPaneIds(rightResult!.tree)[1]).toBe(rightResult!.destinationPaneId);
+    expect(rightResult!.tree.type).toBe('branch');
+    expect(rightResult!.tree.type === 'branch' ? rightResult!.tree.direction : null).toBe('horizontal');
+    expect(downResult).not.toBeNull();
+    expect(getAllPaneIds(downResult!.tree)[1]).toBe(downResult!.destinationPaneId);
+    expect(downResult!.tree.type).toBe('branch');
+    expect(downResult!.tree.type === 'branch' ? downResult!.tree.direction : null).toBe('vertical');
+  });
+
+  it('previews source pane collapse when dragging its only surface to another pane edge', () => {
+    const tree = branch(
+      leaf('pane-source', [surface('surf-drag')]),
+      leaf('pane-target', [surface('surf-target')]),
+    );
+
+    const result = previewSplitAndMoveSurface(
+      tree,
+      'pane-target' as PaneId,
+      'pane-source' as PaneId,
+      'surf-drag' as SurfaceId,
+      'right',
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.collapsesSourcePane).toBe(true);
+    expect(getAllPaneIds(result!.tree)).not.toContain('pane-source');
+
+    const targetLeaf = findLeaf(result!.tree, 'pane-target' as PaneId);
+    const destinationLeaf = findLeaf(result!.tree, result!.destinationPaneId);
+    expect(targetLeaf?.surfaces.map((s) => s.id)).toEqual(['surf-target']);
+    expect(destinationLeaf?.surfaces.map((s) => s.id)).toEqual(['surf-drag']);
+  });
+
+  it('returns null for dragging the only surface onto its own pane edge', () => {
+    const tree = leaf('pane-1', [surface('surf-drag')]);
+
+    const result = previewSplitAndMoveSurface(
+      tree,
+      'pane-1' as PaneId,
+      'pane-1' as PaneId,
+      'surf-drag' as SurfaceId,
+      'right',
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('previews center move only when the source pane collapses', () => {
+    const tree = branch(
+      leaf('pane-source', [surface('surf-drag')]),
+      leaf('pane-target', [surface('surf-target')]),
+    );
+
+    const result = previewMoveSurface(
+      tree,
+      'pane-source' as PaneId,
+      'surf-drag' as SurfaceId,
+      'pane-target' as PaneId,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.destinationPaneId).toBe('pane-target');
+    expect(result?.collapsesSourcePane).toBe(true);
+    expect(getAllPaneIds(result!.tree)).toEqual(['pane-target']);
+
+    const targetLeaf = findLeaf(result!.tree, 'pane-target' as PaneId);
+    expect(targetLeaf?.surfaces.map((s) => s.id)).toEqual(['surf-target', 'surf-drag']);
+    expect(targetLeaf?.activeSurfaceIndex).toBe(1);
+  });
+
+  it('returns null for center move when the source pane remains visible', () => {
+    const tree = branch(
+      leaf('pane-source', [surface('surf-drag'), surface('surf-stay')]),
+      leaf('pane-target', [surface('surf-target')]),
+    );
+
+    const result = previewMoveSurface(
+      tree,
+      'pane-source' as PaneId,
+      'surf-drag' as SurfaceId,
+      'pane-target' as PaneId,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for invalid pane or surface ids', () => {
+    const tree = leaf('pane-1', [surface('surf-1')]);
+
+    expect(previewSplitAndMoveSurface(
+      tree,
+      'pane-missing' as PaneId,
+      'pane-1' as PaneId,
+      'surf-1' as SurfaceId,
+      'right',
+    )).toBeNull();
+
+    expect(previewSplitAndMoveSurface(
+      tree,
+      'pane-1' as PaneId,
+      'pane-missing' as PaneId,
+      'surf-1' as SurfaceId,
+      'right',
+    )).toBeNull();
+
+    expect(previewSplitAndMoveSurface(
+      tree,
+      'pane-1' as PaneId,
+      'pane-1' as PaneId,
+      'surf-missing' as SurfaceId,
+      'right',
+    )).toBeNull();
+
+    expect(previewMoveSurface(
+      tree,
+      'pane-1' as PaneId,
+      'surf-missing' as SurfaceId,
+      'pane-1' as PaneId,
+    )).toBeNull();
+
+    expect(previewMoveSurface(
+      tree,
+      'pane-1' as PaneId,
+      'surf-1' as SurfaceId,
+      'pane-missing' as PaneId,
+    )).toBeNull();
+  });
+
+  it('preserves every original surface id in split previews', () => {
+    const tree = branch(
+      leaf('pane-source', [surface('surf-drag'), surface('surf-source-stay')]),
+      leaf('pane-target', [surface('surf-target')]),
+      'vertical',
+    );
+
+    const result = previewSplitAndMoveSurface(
+      tree,
+      'pane-target' as PaneId,
+      'pane-source' as PaneId,
+      'surf-drag' as SurfaceId,
+      'down',
+    );
+
+    expect(result).not.toBeNull();
+    expect(allSurfaceIds(result!.tree).sort()).toEqual([
+      'surf-drag',
+      'surf-source-stay',
+      'surf-target',
+    ]);
+  });
+});

--- a/tests/unit/surface-drag-preview.test.ts
+++ b/tests/unit/surface-drag-preview.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import type { PaneId, SplitNode, SurfaceId, SurfaceRef, WorkspaceId, WorkspaceInfo } from '../../src/shared/types';
+import { findLeaf } from '../../src/renderer/store/split-utils';
+import {
+  buildSurfaceDragPreview,
+  getSurfaceDragDropDecision,
+  parseSurfaceDragData,
+} from '../../src/renderer/components/SplitPane/surface-drag-preview';
+
+function surface(id: string, type: SurfaceRef['type'] = 'terminal'): SurfaceRef {
+  return { id: id as SurfaceId, type };
+}
+
+function leaf(paneId: string, surfaces: SurfaceRef[], activeSurfaceIndex = 0): SplitNode & { type: 'leaf' } {
+  return {
+    type: 'leaf',
+    paneId: paneId as PaneId,
+    surfaces,
+    activeSurfaceIndex,
+  };
+}
+
+function branch(left: SplitNode, right: SplitNode): SplitNode {
+  return {
+    type: 'branch',
+    direction: 'horizontal',
+    ratio: 0.5,
+    children: [left, right],
+  };
+}
+
+function workspace(id: string, splitTree: SplitNode): WorkspaceInfo {
+  return {
+    id: id as WorkspaceId,
+    title: id,
+    pinned: false,
+    shell: 'pwsh.exe',
+    splitTree,
+    unreadCount: 0,
+  };
+}
+
+describe('surface drag preview decisions', () => {
+  it('builds an edge preview for the active workspace without mutating the real tree', () => {
+    const splitTree = branch(
+      leaf('pane-source', [surface('surf-drag'), surface('surf-stay')]),
+      leaf('pane-target', [surface('surf-target')]),
+    );
+
+    const preview = buildSurfaceDragPreview({
+      workspaces: [workspace('ws-active', splitTree)],
+      activeWorkspaceId: 'ws-active' as WorkspaceId,
+      drag: {
+        workspaceId: 'ws-active' as WorkspaceId,
+        sourcePaneId: 'pane-source' as PaneId,
+        surfaceId: 'surf-drag' as SurfaceId,
+      },
+      pendingTarget: {
+        targetPaneId: 'pane-target' as PaneId,
+        target: 'right',
+      },
+    });
+
+    expect(preview).not.toBeNull();
+    expect(preview?.workspaceId).toBe('ws-active');
+    expect(preview?.target).toBe('right');
+    expect(preview?.collapsesSourcePane).toBe(false);
+    expect(findLeaf(splitTree, 'pane-source' as PaneId)?.surfaces.map((s) => s.id)).toEqual([
+      'surf-drag',
+      'surf-stay',
+    ]);
+  });
+
+  it('returns null when the drag does not belong to the active workspace', () => {
+    const splitTree = leaf('pane-1', [surface('surf-drag')]);
+
+    const preview = buildSurfaceDragPreview({
+      workspaces: [workspace('ws-active', splitTree), workspace('ws-other', splitTree)],
+      activeWorkspaceId: 'ws-active' as WorkspaceId,
+      drag: {
+        workspaceId: 'ws-other' as WorkspaceId,
+        sourcePaneId: 'pane-1' as PaneId,
+        surfaceId: 'surf-drag' as SurfaceId,
+      },
+      pendingTarget: {
+        targetPaneId: 'pane-1' as PaneId,
+        target: 'right',
+      },
+    });
+
+    expect(preview).toBeNull();
+  });
+
+  it('builds a center preview only when moving the surface collapses the source pane', () => {
+    const collapsingTree = branch(
+      leaf('pane-source', [surface('surf-drag')]),
+      leaf('pane-target', [surface('surf-target')]),
+    );
+    const stableTree = branch(
+      leaf('pane-source', [surface('surf-drag'), surface('surf-stay')]),
+      leaf('pane-target', [surface('surf-target')]),
+    );
+
+    const baseRequest = {
+      activeWorkspaceId: 'ws-active' as WorkspaceId,
+      drag: {
+        workspaceId: 'ws-active' as WorkspaceId,
+        sourcePaneId: 'pane-source' as PaneId,
+        surfaceId: 'surf-drag' as SurfaceId,
+      },
+      pendingTarget: {
+        targetPaneId: 'pane-target' as PaneId,
+        target: 'center' as const,
+      },
+    };
+
+    expect(buildSurfaceDragPreview({
+      ...baseRequest,
+      workspaces: [workspace('ws-active', collapsingTree)],
+    })?.collapsesSourcePane).toBe(true);
+
+    expect(buildSurfaceDragPreview({
+      ...baseRequest,
+      workspaces: [workspace('ws-active', stableTree)],
+    })).toBeNull();
+  });
+
+  it('keeps edge drops on the only surface in its own pane as cancel-only', () => {
+    expect(getSurfaceDragDropDecision({
+      target: 'edge',
+      sourcePaneId: 'pane-source' as PaneId,
+      targetPaneId: 'pane-source' as PaneId,
+      sourceSurfaceCount: 1,
+    })).toEqual({ action: 'cancel' });
+  });
+
+  it('clears zoom for geometry-changing edge drops and source-collapsing center drops', () => {
+    expect(getSurfaceDragDropDecision({
+      target: 'edge',
+      sourcePaneId: 'pane-source' as PaneId,
+      targetPaneId: 'pane-target' as PaneId,
+      sourceSurfaceCount: 2,
+    })).toEqual({ action: 'commit', commitOptions: { clearZoom: true } });
+
+    expect(getSurfaceDragDropDecision({
+      target: 'center',
+      sourcePaneId: 'pane-source' as PaneId,
+      targetPaneId: 'pane-target' as PaneId,
+      sourceSurfaceCount: 1,
+    })).toEqual({ action: 'commit', commitOptions: { clearZoom: true } });
+
+    expect(getSurfaceDragDropDecision({
+      target: 'center',
+      sourcePaneId: 'pane-source' as PaneId,
+      targetPaneId: 'pane-target' as PaneId,
+      sourceSurfaceCount: 2,
+    })).toEqual({ action: 'commit', commitOptions: { clearZoom: false } });
+  });
+
+  it('parses only well-formed surface drag payloads', () => {
+    expect(parseSurfaceDragData(JSON.stringify({
+      sourcePaneId: 'pane-source',
+      surfaceId: 'surf-drag',
+    }))).toEqual({
+      sourcePaneId: 'pane-source',
+      surfaceId: 'surf-drag',
+    });
+
+    expect(parseSurfaceDragData('{ nope')).toBeNull();
+    expect(parseSurfaceDragData(JSON.stringify({ sourcePaneId: 42, surfaceId: 'surf-drag' }))).toBeNull();
+    expect(parseSurfaceDragData(JSON.stringify({ sourcePaneId: 'pane-source' }))).toBeNull();
+  });
+});

--- a/tests/unit/surface-label.test.ts
+++ b/tests/unit/surface-label.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import type { SurfaceId, SurfaceRef } from '../../src/shared/types';
+import { getSurfaceLabel } from '../../src/renderer/components/SplitPane/surface-label';
+
+function surface(id: string, patch: Partial<SurfaceRef> = {}): SurfaceRef {
+  return {
+    id: id as SurfaceId,
+    type: 'terminal',
+    ...patch,
+  };
+}
+
+describe('surface labels', () => {
+  it('prefers custom titles over agent and shell labels', () => {
+    expect(
+      getSurfaceLabel(
+        surface('surf-1', { customTitle: 'API', shell: 'pwsh.exe' }),
+        'Agent runner',
+        'cmd.exe',
+      ),
+    ).toBe('API');
+  });
+
+  it('uses agent labels before terminal shell labels', () => {
+    expect(getSurfaceLabel(surface('surf-1', { shell: 'pwsh.exe' }), 'Agent runner')).toBe('Agent runner');
+  });
+
+  it('uses the surface shell before the workspace shell for terminal labels', () => {
+    expect(
+      getSurfaceLabel(
+        surface('surf-1', { shell: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe' }),
+        undefined,
+        'cmd.exe',
+      ),
+    ).toBe('PowerShell');
+  });
+
+  it('falls back to the workspace shell for terminal labels', () => {
+    expect(getSurfaceLabel(surface('surf-1'), undefined, 'C:\\Windows\\System32\\cmd.exe')).toBe('Command Prompt');
+  });
+
+  it('uses stable labels for non-terminal surface types', () => {
+    expect(getSurfaceLabel(surface('surf-browser', { type: 'browser' }))).toBe('Browser');
+    expect(getSurfaceLabel(surface('surf-markdown', { type: 'markdown' }))).toBe('Markdown');
+    expect(getSurfaceLabel(surface('surf-diff', { type: 'diff' }))).toBe('Diff');
+  });
+});


### PR DESCRIPTION
﻿## Summary

Adds a live layout preview while dragging Surface tabs, so geometry-changing drops show the resulting workspace layout before the real split tree changes.

The preview is rendered as a lightweight overlay and keeps the real terminal, browser, markdown, and diff surfaces mounted underneath until drop. The implementation also covers source-pane collapse previews, center-drop previews only when layout changes, zoom cleanup on valid geometry-changing drops, and shared surface label resolution so preview tabs match real tab titles.

## Why

Before this change, dragging a Surface to an edge only highlighted the current drop zone. It did not show the full post-drop layout, which made source-pane collapse and multi-pane layouts harder to predict.

## Testing

- `npx.cmd vitest run tests/unit/surface-label.test.ts tests/unit/surface-drag-preview.test.ts tests/unit/split-preview.test.ts tests/unit/split-tree.test.ts`
- `npm.cmd run build:main`
- `npm.cmd run build:renderer`

I also ran `npm.cmd test`; it currently fails in the existing `tests/unit/pty-manager.test.ts` suite on this Windows checkout with 5 PTY-manager failures. The new renderer/split-preview tests pass, and this PR does not touch PTY manager code.

## Notes

Opening as draft for maintainer feedback on the interaction model and scope.
