### PR TITLE
build: use node-pty prebuilt binaries instead of rebuilding from source

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -1,6 +1,7 @@
 {
   "appId": "com.wmux.app",
   "productName": "wmux",
+  "npmRebuild": false,
   "directories": {
     "output": "release"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "wmux",
       "version": "0.15.1",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@types/ws": "^8.18.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "build": "tsc -p tsconfig.node.json && vite build && electron-builder",
     "build:main": "tsc -p tsconfig.node.json",
     "build:renderer": "vite build",
-    "postinstall": "electron-builder install-app-deps",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src/"


### PR DESCRIPTION
## What

Drop the `electron-builder install-app-deps` postinstall and set `npmRebuild: false`, so `npm install` and `npm run build` use node-pty's shipped prebuilt binaries instead of compiling it from source.

## Why

On Windows, `npm install` fails out of the box. The `postinstall` runs `electron-builder install-app-deps`, which rebuilds node-pty from source via node-gyp, and node-pty's bundled winpty fails at its commit-hash step:

```
'GetCommitHash.bat' is not recognized as an internal or external command
gyp: Call to 'cmd /c "cd shared && GetCommitHash.bat"' returned exit status 1 while in deps\winpty\src\winpty.gyp
Error: `gyp` failed with exit code: 1
node-gyp failed to rebuild '...\node_modules\node-pty'
```

Recovering from that means installing a full Visual Studio C++ toolchain and a Python that still has `distutils` (removed from the stdlib in 3.12+) — just to install the repo.

That rebuild isn't necessary. node-pty 1.1.0 is an N-API addon (`node-addon-api`) and ships prebuilt binaries for every target platform — `prebuilds/{win32-x64,win32-arm64,darwin-x64,darwin-arm64}/`. N-API binaries are ABI-stable across Node and Electron, so the prebuilt `pty.node` / `conpty.node` load directly under Electron (node-pty's loader already falls back to `prebuilds/<platform>-<arch>/`). The release packaging never needed a source build.

## Changes

- **`package.json`** — remove `"postinstall": "electron-builder install-app-deps"` (this also drops `hasInstallScript` from the lockfile).
- **`electron-builder.json`** — add `"npmRebuild": false`, so packaging doesn't rebuild native deps either.

## Verification (Windows 11)

- `npm install` → exit 0, no native compilation.
- `npm run build` → packages successfully; electron-builder logs `skipped dependencies rebuild  reason=npmRebuild is set to false`.
- The packaged app carries the same node-pty layout as before — `app.asar.unpacked/node_modules/node-pty/prebuilds/win32-x64/pty.node` — so runtime is unchanged (`asarUnpack: ["**/*.node"]` still unpacks the binaries).

## Note

Prebuilds cover the supported platforms (win32, darwin). If a future contributor targets a platform node-pty doesn't prebuild, that case would need a source build re-enabled.
