### PR TITLE
feat(cli): implement wmux read-screen (surface.read_text was a stub)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,15 +304,13 @@ The pipe server in `index.ts` handles V2 JSON-RPC methods. Most delegate to the 
 - `workspace.create`, `workspace.close`, `workspace.select`, `workspace.rename`, `workspace.list`
 - `pane.split`, `pane.close`, `pane.focus`, `pane.zoom`, `pane.list`
 - `surface.create`, `surface.close`, `surface.focus`, `surface.list`
-- `surface.send_text`, `surface.send_key`, `surface.trigger_flash`
+- `surface.send_text`, `surface.send_key`, `surface.read_text`, `surface.trigger_flash`
 - `markdown.set_content`, `markdown.load_file`
 - `notification.list`, `notification.clear`
 - `sidebar.set_status`, `sidebar.set_progress`, `sidebar.log`, `sidebar.get_state`
 - `browser.*` (via CDP bridge)
 - `agent.spawn`, `agent.spawn_batch`, `agent.status`, `agent.list`, `agent.kill`
 - `hook.event`, `diff.refresh`
-
-**Partially implemented:** `surface.read_text` (stub — needs xterm serializer addon)
 
 ---
 
@@ -363,7 +361,7 @@ wmux split [--down] [--type T] | close-pane | focus-pane | zoom-pane | list-pane
 
 # Terminal I/O
 wmux send <text> | send-key <key> [--ctrl] [--shift] [--alt]
-wmux read-screen [--lines N] | trigger-flash
+wmux read-screen [--lines N] [--surface <id>] | trigger-flash
 
 # Browser (CDP)
 wmux browser open <url> | snapshot | click @eN | type @eN <text>

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -363,7 +363,13 @@ const COMMANDS: Record<string, (args: string[]) => Promise<void> | void> = {
   'send-key': cmdSendKey,
   'read-screen': async (args) => {
     const lines = args.find((a, i) => args[i - 1] === '--lines');
-    print(await sendV2('surface.read_text', { lines: lines ? parseInt(lines) : 50 }));
+    // Same targeting rule as send/send-key: inside a pane the caller's own
+    // surface is the default; cross-pane reads take --surface explicitly.
+    const surfaceId = getFlag(args, '--surface') || process.env.WMUX_SURFACE_ID;
+    print(await sendV2('surface.read_text', {
+      ...(surfaceId ? { surfaceId } : {}),
+      lines: lines ? parseInt(lines) : 50,
+    }));
   },
   'trigger-flash': async (args) => print(await sendV2('surface.trigger_flash', { id: args[1] })),
 
@@ -438,7 +444,7 @@ Surface:    new-surface [--type T] [--color-scheme NAME], close-surface, focus-s
 Pane:       split [--down] [--type T] [--color-scheme NAME], close-pane, focus-pane, zoom-pane, list-panes, tree
             pane new|close|focus|list   (verb form, mirrors issue #4 example)
 Layout:     layout grid --count <N> [--type terminal] [--anchor-surface <id>]
-Terminal:   send <text>, send-key <key>, read-screen, trigger-flash
+Terminal:   send <text>, send-key <key>, read-screen [--lines N] [--surface <id>], trigger-flash
 Browser:    browser open|snapshot|click|type|fill|screenshot|get-text|eval|wait|back|forward|reload
 Agent:      agent spawn|spawn-batch|status|list|kill
 Markdown:   markdown <file>   (open a file in a new markdown view)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -531,9 +531,34 @@ app.whenReady().then(() => {
         break;
       }
       case 'surface.read_text': {
-        // Read screen content — not easily available from PTY buffer directly.
-        // Return a note that this requires xterm.js serializer addon in the renderer.
-        respond({ text: '', note: 'Screen reading requires renderer-side xterm serializer' });
+        // Screen content lives in the renderer (xterm owns the buffer), so
+        // delegate to the __wmux_readScreen bridge global. It reads the ACTIVE
+        // buffer — alt buffer included — so full-screen TUIs return what is
+        // actually visible, as plain text (no ANSI escapes).
+        (async () => {
+          try {
+            const surfaceId = await resolvePtySurface(request.params?.surfaceId || request.params?.id);
+            if (!surfaceId.ok) { respondError(-32000, surfaceId.error); return; }
+            const rawLines = Number(request.params?.lines);
+            const lines = Number.isFinite(rawLines)
+              ? Math.min(Math.max(Math.floor(rawLines), 1), 10000)
+              : 50;
+            // The surface's terminal is mounted in exactly one window; probe
+            // each until one has it, keeping the first miss as the error.
+            let result: { text?: string; error?: string } | null = null;
+            for (const win of BrowserWindow.getAllWindows()) {
+              if (win.isDestroyed()) continue;
+              const r = await win.webContents.executeJavaScript(
+                `window.__wmux_readScreen?.(${JSON.stringify(surfaceId.id)}, ${lines})`
+              );
+              if (r && !r.error) { result = r; break; }
+              if (r && !result) result = r;
+            }
+            if (!result) { respondError(-32000, 'No window'); return; }
+            if (result.error) { respondError(-32000, result.error); return; }
+            respond(result);
+          } catch (err: any) { respondError(-32000, err.message); }
+        })();
         break;
       }
       case 'surface.trigger_flash': {

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -121,6 +121,13 @@ const surfaceMouseEnabled = new Map<string, boolean>();
 const surfaceBufferCache = new Map<string, string>();
 const MAX_BUFFER_CACHE = 32;
 
+// Live xterm instances keyed by surfaceId, so the pipe bridge can read screen
+// content (surface.read_text / `wmux read-screen`) from the active buffer.
+// Module-level like surfaceMouseEnabled: survives remounts; entries are
+// registered on mount and removed on unmount (guarded so a StrictMode
+// setup→cleanup→setup sequence can't delete the replacement instance).
+export const surfaceTerminalRegistry = new Map<string, Terminal>();
+
 // Convert a wheel delta to a line count (sign preserved, magnitude ≥ 1).
 function wheelDeltaToLines(ev: WheelEvent, rows: number): number {
   let amount: number;
@@ -367,6 +374,8 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
 
     // Open terminal in the DOM
     terminal.open(terminalRef.current);
+
+    if (surfaceId) surfaceTerminalRegistry.set(surfaceId, terminal);
 
     // Restore a buffer snapshot captured before a previous unmount (issue #49).
     // Written now — before the PTY reattaches below — so the restored scrollback
@@ -806,6 +815,13 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
         } catch {
           // Serialization failure is non-fatal — just lose the snapshot.
         }
+      }
+
+      // Drop the read-screen registry entry — but only if it still points at
+      // THIS terminal (StrictMode re-setup may already have registered the
+      // replacement instance under the same surfaceId).
+      if (surfaceId && surfaceTerminalRegistry.get(surfaceId) === terminal) {
+        surfaceTerminalRegistry.delete(surfaceId);
       }
 
       // Release the GPU renderer (and its WebGL budget slot) before disposing

--- a/src/renderer/pipe-bridge.ts
+++ b/src/renderer/pipe-bridge.ts
@@ -5,6 +5,7 @@
 import { useStore } from './store';
 import { splitNode, removeLeaf, getAllPaneIds, findLeaf, buildGridLayout } from './store/split-utils';
 import { killSurfacePty } from './store/pty-teardown';
+import { surfaceTerminalRegistry } from './hooks/useTerminal';
 import { PaneId, SurfaceId, WorkspaceId, SurfaceType } from '../shared/types';
 import { v4 as uuid } from 'uuid';
 
@@ -306,6 +307,28 @@ export function initPipeBridge(): void {
     if (!leaf?.surfaces?.length) return null;
     const idx = leaf.activeSurfaceIndex ?? 0;
     return leaf.surfaces[idx]?.id || null;
+  };
+
+  // Read a terminal's screen as plain text (surface.read_text / read-screen).
+  // Reads the ACTIVE xterm buffer — alt buffer included, so a full-screen TUI
+  // returns what is actually visible. `lines` counts back from the bottom of
+  // the buffer (scrollback included); trailing blank lines are trimmed.
+  w.__wmux_readScreen = (surfaceId?: string, lines?: number) => {
+    const id = surfaceId || w.__wmux_getActiveSurfaceId?.();
+    if (!id) return { error: 'No active surface' };
+    const terminal = surfaceTerminalRegistry.get(id);
+    if (!terminal) {
+      return { error: `no terminal for surface ${id} (markdown/browser pane, another window, or closed)` };
+    }
+    const buf = terminal.buffer.active;
+    const count = Math.min(Math.max(Math.floor(lines ?? 50), 1), 10000);
+    const end = buf.length;
+    const out: string[] = [];
+    for (let i = Math.max(0, end - count); i < end; i++) {
+      out.push(buf.getLine(i)?.translateToString(true) ?? '');
+    }
+    while (out.length && out[out.length - 1] === '') out.pop();
+    return { text: out.join('\n'), lines: out.length, surfaceId: id };
   };
 
   // ─── Markdown ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Motivation

We use wmux heavily for multi-agent Claude Code orchestration, and coordinators regularly need to **scrape sibling panes** to verify an agent's actual state — did the prompt submit, is a TUI stuck, what error is on screen. `wmux read-screen` looked like exactly the right tool, but it always returned empty text: the `surface.read_text` V2 handler turned out to be a hardcoded stub that replied `{ text: "", note: "Screen reading requires renderer-side xterm serializer" }` without ever calling into the renderer. This PR wires it up for real.

## Implementation

- **useTerminal**: module-level `surfaceTerminalRegistry` (surfaceId → live xterm `Terminal`), registered right after `terminal.open()`, removed on unmount with a StrictMode-safe guard (only deletes if the entry still points at this instance).
- **pipe-bridge**: new `window.__wmux_readScreen(surfaceId?, lines?)` global. It reads the **active** buffer — alt buffer included, so a pane running a full-screen TUI (Claude Code, vim, tmux) returns what is actually visible — via `translateToString(true)`: plain text, no ANSI escapes, which is what agents want. Returns the last N lines including scrollback with trailing blank lines trimmed, as `{ text, lines, surfaceId }`, or `{ error }` for markdown/browser/closed surfaces.
- **main**: `surface.read_text` now resolves the surface through the existing `resolvePtySurface()` (so callers get the same clear "has no PTY" error as send_text/send_key instead of an empty success), clamps `lines` to 1–10000 (default 50), probes each window for the surface, and returns the renderer result.
- **CLI**: `read-screen [--lines N] [--surface <id>]`, defaulting to `WMUX_SURFACE_ID` — identical targeting semantics to `send`/`send-key`: inside a pane, bare `read-screen` reads your own pane; cross-pane scraping (the orchestration case) uses `--surface`; outside wmux it falls back to the active surface.
- **CLAUDE.md**: `surface.read_text` moved out of "Partially implemented"; CLI reference updated.

## Testing

- `npm run build:main`, `npx vite build`, `npm test` (162/162) all green; no new lint errors.
- Verified live against a dev instance:
  - Read a pane running the full-screen Claude Code TUI → clean plain text of the visible screen, including a marker string we injected via `wmux send` (alt-buffer path).
  - Bare `read-screen` from outside wmux → active-surface fallback.
  - Markdown surface and a bogus surface id → clear "has no PTY" errors, not silent empty output.