### PR TITLE
feat(shortcuts): add Ctrl+Shift+G to open the diff panel on demand

### DIFF
--- a/src/renderer/components/CheatSheet/ShortcutCheatSheet.tsx
+++ b/src/renderer/components/CheatSheet/ShortcutCheatSheet.tsx
@@ -27,7 +27,7 @@ const CATEGORY: Partial<Record<ShortcutAction, string>> = {
   togglePinWorkspace: 'Workspaces', markWorkspaceRead: 'Workspaces', openFolder: 'Workspaces',
   newWindow: 'Workspaces', closeWindow: 'Workspaces',
   newSurface: 'Tabs', nextSurface: 'Tabs', prevSurface: 'Tabs', reopenClosedSurface: 'Tabs',
-  renameSurface: 'Tabs', openMarkdownPanel: 'Tabs',
+  renameSurface: 'Tabs', openMarkdownPanel: 'Tabs', openDiffPanel: 'Tabs',
   splitRight: 'Panes', splitDown: 'Panes', splitBrowserRight: 'Panes', splitBrowserDown: 'Panes',
   focusLeft: 'Panes', focusRight: 'Panes', focusUp: 'Panes', focusDown: 'Panes',
   resizePaneLeft: 'Panes', resizePaneRight: 'Panes', resizePaneUp: 'Panes', resizePaneDown: 'Panes',

--- a/src/renderer/components/Settings/KeyboardSettings.tsx
+++ b/src/renderer/components/Settings/KeyboardSettings.tsx
@@ -43,6 +43,7 @@ export const ACTION_LABELS: Record<ShortcutAction, string> = {
   openSettings: 'Open settings',
   commandPalette: 'Command palette',
   openMarkdownPanel: 'Open markdown panel',
+  openDiffPanel: 'Open diff panel',
   reopenClosedSurface: 'Reopen closed tab',
   findNext: 'Find next',
   findPrevious: 'Find previous',

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -315,6 +315,18 @@ export function useKeyboardShortcuts(
       fontSizeReset: () => useStore.getState().setTerminalPrefs({ fontSize: 13 }),
       openSettings: () => onOpenSettings?.(true),
       openMarkdownPanel: () => { if (activeWorkspaceId && focusedPaneId) addSurface(activeWorkspaceId, focusedPaneId, 'markdown'); },
+      // Focus-or-create: the diff panel is a singleton view of the working tree,
+      // so if the focused pane already has a diff tab, jump to it rather than
+      // stacking a duplicate (the auto-open hook in App.tsx dedups the same way).
+      openDiffPanel: () => {
+        if (!activeWorkspaceId || !focusedPaneId) return;
+        const st = useStore.getState();
+        const ws = st.workspaces.find((w) => w.id === activeWorkspaceId);
+        const leaf = ws && findLeaf(ws.splitTree, focusedPaneId);
+        const existingIdx = leaf ? leaf.surfaces.findIndex((s) => s.type === 'diff') : -1;
+        if (leaf && existingIdx >= 0) st.selectSurface(activeWorkspaceId, focusedPaneId, existingIdx);
+        else st.addSurface(activeWorkspaceId, focusedPaneId, 'diff');
+      },
       // commandPalette is opened by App.tsx's own listener; keep a no-op so we
       // still preventDefault on the combo. find/copyMode are short-circuited above.
       commandPalette: () => {},

--- a/src/renderer/store/settings-slice.ts
+++ b/src/renderer/store/settings-slice.ts
@@ -158,6 +158,7 @@ export type ShortcutAction =
   | 'openSettings'
   | 'commandPalette'
   | 'openMarkdownPanel'
+  | 'openDiffPanel'
   // ─── issue #64: high-value additions ──────────────────────────────────────
   | 'reopenClosedSurface'
   | 'findNext'
@@ -213,6 +214,7 @@ export const DEFAULT_SHORTCUTS: Record<ShortcutAction, ShortcutBinding> = {
   openSettings:      { key: ',', ctrl: true },
   commandPalette:    { key: 'p', ctrl: true, shift: true },
   openMarkdownPanel: { key: 'm', ctrl: true, shift: true },
+  openDiffPanel:     { key: 'g', ctrl: true, shift: true },
   // ─── issue #64 ──────────────────────────────────────────────────────────────
   // Defaults collision-checked against the bindings above. All use Shift/Alt or
   // function keys, so isSafeToIntercept() forwards bare-Ctrl combos to the


### PR DESCRIPTION
## Motivation

The diff panel is one of the most useful surfaces in wmux, but today a user has **no way to open it on demand** — no menu entry, no keystroke, no command-palette action. It only appears when the auto-diff hook opens it during agent activity under specific conditions (and #65/#66 added an opt-out for that). If you close the tab, or you simply want to review your working tree while editing by hand, you're stuck waiting for an agent to trigger it.

This adds a global keyboard shortcut — **Ctrl+Shift+G** (G for git, mirroring VS Code's source-control view) — that opens the diff panel in the focused pane at any time.

## Implementation

Follows the exact pattern of the existing `openMarkdownPanel` (Ctrl+Shift+M) shortcut:

- `settings-slice.ts`: new `openDiffPanel` action, default `Ctrl+Shift+G` — rebindable in Settings → Keyboard like every other shortcut.
- `useKeyboardShortcuts.ts`: focus-or-create handler — the diff panel is a singleton view of the working tree, so if the focused pane already has a diff tab it jumps to it instead of stacking a duplicate (same dedup the auto-open hook in App.tsx uses); otherwise it adds a diff surface to the focused pane.
- `KeyboardSettings.tsx` / `ShortcutCheatSheet.tsx`: listed and rebindable in the settings UI and the cheat sheet.

Ctrl+Shift+G is unused by any existing default binding.

## Testing

- `npm run build:main`, `npx vite build`, `npm test` (162/162) green on top of current master.
- Verified live: Ctrl+Shift+G opens a diff tab in the focused pane; pressing it again with the diff tab present focuses it instead of duplicating; rebinding via Settings works; running it in a pane that already auto-opened a diff jumps to that tab.