### PR TITLE
feat(sidebar): self-healing workspace status + set-status --workspace verb

### DIFF
--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -486,7 +486,25 @@ const COMMANDS: Record<string, (args: string[]) => Promise<void> | void> = {
   'clear-notifications': async (args) => print(await sendV2('notification.clear', { id: args[1] })),
 
   // Sidebar
-  'set-status': async (args) => print(await sendV2('sidebar.set_status', { key: args[1], value: args[2] })),
+  'set-status': async (args) => {
+    // `set-status --workspace <id> --state <idle|running|interrupted> [--text "<label>"]`
+    // sets a named workspace's sidebar status from anywhere (works outside a
+    // pane, unlike the surface-scoped shell integration). Without --workspace it
+    // falls back to the legacy positional `set-status <key> <value>` form.
+    const workspaceId = getFlag(args, '--workspace');
+    if (workspaceId) {
+      const state = getFlag(args, '--state');
+      const valid = ['idle', 'running', 'interrupted'];
+      if (!state || !valid.includes(state)) {
+        console.error(`set-status --workspace requires --state <${valid.join('|')}>`);
+        process.exit(1);
+      }
+      const text = getFlag(args, '--text');
+      print(await sendV2('workspace.set_status', { workspaceId, state, ...(text ? { text } : {}) }));
+      return;
+    }
+    print(await sendV2('sidebar.set_status', { key: args[1], value: args[2] }));
+  },
   'set-progress': async (args) => {
     const label = args.find((a, i) => args[i - 1] === '--label');
     print(await sendV2('sidebar.set_progress', { value: parseFloat(args[1]), label }));

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -666,6 +666,24 @@ app.whenReady().then(() => {
         break;
       }
 
+      // ─── Workspace status handler ─────────────────────────────────────────
+      case 'workspace.set_status': {
+        // Set a named workspace's sidebar status by id (e.g. an orchestration
+        // coordinator marking a workspace idle when all waves finish). Keyed on
+        // workspaceId, not surfaceId, so it works from outside any pane.
+        BrowserWindow.getAllWindows().forEach(w => {
+          if (!w.isDestroyed()) {
+            w.webContents.send(IPC_CHANNELS.METADATA_UPDATE, {
+              command: 'set_workspace_status',
+              workspaceId: request.params?.workspaceId,
+              args: [request.params?.state || '', request.params?.text || ''],
+            });
+          }
+        });
+        respond({ ok: true });
+        break;
+      }
+
       // ─── Sidebar V2 handlers ──────────────────────────────────────────────
       case 'sidebar.set_status': {
         // Forward as metadata update to renderer

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -441,6 +441,19 @@ export default function App() {
       // ports_update and notify have no (required) surfaceId — handle globally.
       if (cmd.command === 'ports_update') { handlePortsUpdate(cmd, updateWorkspaceMetadata); return; }
       if (cmd.command === 'notify') { handleNotifyCommand(cmd, addNotification); return; }
+      // set_workspace_status is keyed on workspaceId (not surfaceId) — a
+      // coordinator setting a named workspace's status via `wmux set-status
+      // --workspace`. Handle before the surfaceId guard below.
+      if (cmd.command === 'set_workspace_status') {
+        const [state, text] = cmd.args || [];
+        if (state === 'idle' || state === 'running' || state === 'interrupted') {
+          const target = useStore.getState().workspaces.find((w) => w.id === cmd.workspaceId);
+          if (target) {
+            updateWorkspaceMetadata(target.id, { shellState: state, notificationText: text || undefined });
+          }
+        }
+        return;
+      }
 
       if (!cmd.surfaceId) return;
       const ws = workspaceForSurface(cmd.surfaceId);

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -638,6 +638,20 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
       // Wire PTY exit → inform user
       const unsubExit = window.wmux.pty.onExit(id, (_code: number) => {
         terminal.writeln('\r\n\x1b[2m[process exited]\x1b[0m');
+        // Auto-heal a stuck "Running" badge. shellState is a single
+        // last-writer-wins workspace field, written only by the in-pane shell
+        // integration (report_shell_state). A shell that emits "running" but is
+        // killed before returning to its prompt (e.g. an orchestration agent TUI
+        // reaped at teardown) never emits the matching "idle", stranding the
+        // sidebar on "Running". A PTY that has exited cannot be the running
+        // command, so clear it here.
+        try {
+          const store = useStore.getState();
+          const ws = store.workspaces.find((w) => treeHasSurface(w.splitTree, id));
+          if (ws && ws.shellState === 'running') {
+            store.updateWorkspaceMetadata(ws.id, { shellState: 'idle' });
+          }
+        } catch { /* best-effort: badge reset is non-critical */ }
       });
 
       cleanupFnsRef.current.push(unsubData, unsubExit);


### PR DESCRIPTION
## Problem

The sidebar workspace status is driven by `shellState`, which is written only by the in-pane shell integration (`report_shell_state`: `running` on command start, `idle` when the prompt returns). A shell that emits `running` but is killed before returning to its prompt — e.g. an agent's interactive TUI reaped at teardown — never emits the matching `idle`. Once the workspace has only non-terminal surfaces left (markdown/browser), nothing can clear it, so the row stays stuck on **"Running"** indefinitely. An idle-but-open Claude session hits the same wall when the PTY observer doesn't catch the completion marker.

Separately, there's no way for a driver outside a pane (e.g. an orchestration coordinator) to set a *named* workspace's status — `set-status`/`set-progress`/`log` carry no surface target and are dropped in the renderer.

## Changes

1. **Auto-heal a stuck "Running".** When a shell PTY exits (`useTerminal` `onExit`), reset the owning workspace's `shellState` to `idle` if it was still `running` — a shell whose PTY has exited can't be the running command. Clears the badge the moment a pane/agent is torn down.
2. **`wmux set-status --workspace <id> --state <idle|running|interrupted> [--text "<label>"]`.** Sets a named workspace's status from anywhere, including outside a pane (keyed on `workspaceId`, not `surfaceId`). `--text` renders as `Done: <label>` (green). Wiring: CLI verb → `workspace.set_status` broadcast in main → a renderer branch that resolves by `workspaceId` and updates `{ shellState, notificationText }`. The pre-existing positional `set-status <key> <value>` form is unchanged.

## Testing

- `npm run build` clean; `npm test` green.
- Verified on a local build: a workspace stuck on "Running" flipped to "Idle" the instant its agents' PTYs were reaped, and `set-status --workspace … --state idle --text "…"` painted the row `Done: …` from a separate terminal.