### PR TITLE
feat(agent): --replace-tab on agent spawn — no more orphaned idle tabs in orchestration panes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,7 +377,7 @@ wmux browser fill @eN <value> | get-text | screenshot | eval <js>
 wmux browser back | forward | reload
 
 # Agents
-wmux agent spawn [--cmd C] [--label L] [--cwd D] [--pane P]
+wmux agent spawn [--cmd C] [--label L] [--cwd D] [--pane P] [--replace-tab]
 wmux agent spawn-batch --json '[...]' [--strategy distribute|stack|split]
 wmux agent status <id> | list | kill <id>
 

--- a/resources/wmux-orchestrator/scripts/spawn-agents.sh
+++ b/resources/wmux-orchestrator/scripts/spawn-agents.sh
@@ -84,11 +84,14 @@ while IFS= read -r agent; do
 
   # launch-agent.js uses execFileSync with '--' separator to pass the prompt
   # as a positional arg — full interactive TUI, user can watch and intervene.
+  # --replace-tab: the agent surface takes over the grid pane's default idle
+  # terminal tab instead of being appended next to it (single-tab agent panes).
   SPAWN_RESULT=$(wmux agent spawn \
     --cmd "node \"$LAUNCHER\" \"$PROMPT_FILE\"" \
     --label "$AGENT_LABEL" \
     --cwd "$CWD" \
-    --pane "$PANE_ID" 2>&1)
+    --pane "$PANE_ID" \
+    --replace-tab 2>&1)
 
   SPAWNED_AGENT_ID=$(parse_json "$SPAWN_RESULT" '.agentId')
   SPAWNED_SURFACE_ID=$(parse_json "$SPAWN_RESULT" '.surfaceId')

--- a/resources/wmux-orchestrator/skills/orchestrate/SKILL.md
+++ b/resources/wmux-orchestrator/skills/orchestrate/SKILL.md
@@ -362,7 +362,7 @@ CLI's sharp edges (eval scoping, ref format, framework-specific input recipes).
 
 **IMPORTANT: Work in the CURRENT workspace. Do NOT create or close workspaces — that hides agent panes from the user.**
 
-The spawn script (`spawn-agents.sh`) automatically creates panes via `wmux split`.
+The spawn script (`spawn-agents.sh`) automatically creates panes via `wmux layout grid` (one atomic split-tree mutation for the whole wave).
 
 **Pane hygiene — start each orchestration from a single coordinator pane.** Re-gridding a window
 that already has extra panes (a previous run's agents, stray splits) does NOT reuse them: the old
@@ -382,8 +382,8 @@ bash "$PLUGIN_ROOT/scripts/spawn-agents.sh" "[orch-dir]" 0
 ```
 
 This script:
-1. Creates a pane per agent via `wmux split`
-2. Runs `node launch-agent.js <prompt-file>` in each pane
+1. Creates a pane per agent via `wmux layout grid --count <agents+1>` (orchestrator keeps the anchor cell)
+2. Runs `node launch-agent.js <prompt-file>` in each pane via `wmux agent spawn --replace-tab`, so the agent TUI replaces the grid pane's default terminal tab (agent panes end with a single tab)
 3. `launch-agent.js` uses `execFileSync` with `'--'` separator to pass the full prompt as a positional argument — this bypasses all shell quoting issues
 4. Claude starts in **interactive mode with full TUI** — the prompt auto-submits and Claude begins working immediately
 5. The user can watch agents in real-time by clicking their pane tabs, and can type into any agent to intervene

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -138,12 +138,17 @@ async function cmdBrowser(args: string[]): Promise<void> {
 
 function agentSpawn(args: string[]): Promise<any> {
   const params: any = {};
-  for (let i = 2; i < args.length; i += 2) {
-    if (args[i] === '--cmd') params.cmd = args[i + 1];
-    if (args[i] === '--label') params.label = args[i + 1];
-    if (args[i] === '--cwd') params.cwd = args[i + 1];
-    if (args[i] === '--pane') params.paneId = args[i + 1];
-    if (args[i] === '--workspace') params.workspaceId = args[i + 1];
+  // Valueless flags must be stripped before the pairwise --flag value loop.
+  const rest = args.slice(2).filter((a) => {
+    if (a === '--replace-tab') { params.replaceTab = true; return false; }
+    return true;
+  });
+  for (let i = 0; i < rest.length; i += 2) {
+    if (rest[i] === '--cmd') params.cmd = rest[i + 1];
+    if (rest[i] === '--label') params.label = rest[i + 1];
+    if (rest[i] === '--cwd') params.cwd = rest[i + 1];
+    if (rest[i] === '--pane') params.paneId = rest[i + 1];
+    if (rest[i] === '--workspace') params.workspaceId = rest[i + 1];
   }
   if (!params.cmd) { console.error('--cmd is required'); process.exit(1); }
   if (!params.label) params.label = params.cmd.split(/\s+/)[0];
@@ -575,7 +580,7 @@ Pane:       split [--down] [--type T] [--color-scheme NAME], close-pane, focus-p
 Layout:     layout grid --count <N> [--type terminal] [--anchor-surface <id>]
 Terminal:   send <text>, send-key <key>, read-screen [--lines N] [--surface <id>], trigger-flash
 Browser:    browser open|snapshot|click|type|fill|screenshot|get-text|eval|wait|back|forward|reload
-Agent:      agent spawn|spawn-batch|status|list|kill
+Agent:      agent spawn [--cmd C] [--label L] [--cwd D] [--pane P] [--replace-tab] | spawn-batch|status|list|kill
 Markdown:   markdown <file>   (open a file in a new markdown view)
             markdown set <id> --content <text> | --file <path>
 Diff:       diff [--file <path>]

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -770,7 +770,7 @@ app.whenReady().then(() => {
             if (win && !win.isDestroyed()) setupAgentPtyForwarding(result.surfaceId, win);
 
             BrowserWindow.getAllWindows().forEach(w => {
-              if (!w.isDestroyed()) w.webContents.send(IPC_CHANNELS.AGENT_UPDATE, { type: 'spawned', ...result, paneId, workspaceId, label: params.label });
+              if (!w.isDestroyed()) w.webContents.send(IPC_CHANNELS.AGENT_UPDATE, { type: 'spawned', ...result, paneId, workspaceId, label: params.label, replaceTab: !!params.replaceTab });
             });
             respond(result);
           } catch (err: any) { respondError(-32000, err.message); }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -3,7 +3,7 @@ import { v4 as uuid } from 'uuid';
 import { useStore } from './store';
 import { PaneId, SurfaceId, WorkspaceId, WorkspaceInfo, SplitNode } from '../shared/types';
 import SplitContainer from './components/SplitPane/SplitContainer';
-import { updateRatio, getAllPaneIds, findLeaf } from './store/split-utils';
+import { updateRatio, getAllPaneIds, findLeaf, replaceSoleTerminalSurface } from './store/split-utils';
 import Sidebar from './components/Sidebar/Sidebar';
 import Titlebar from './components/Titlebar/Titlebar';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -415,6 +415,28 @@ export default function App() {
         const state = useStore.getState();
         const ws = state.workspaces.find((w) => w.id === workspaceId);
         if (!ws) return;
+
+        // --replace-tab: swap the pane's sole idle default terminal for the
+        // agent surface instead of appending, so orchestration panes don't
+        // keep an unused shell tab. Guards: exactly one surface, terminal
+        // type (enforced in the helper), and not itself an agent surface.
+        if (event.replaceTab) {
+          const leaf = findLeaf(ws.splitTree, paneId);
+          const sole = leaf?.surfaces.length === 1 ? leaf.surfaces[0] : undefined;
+          if (sole && !state.agentMeta.get(sole.id)) {
+            const { tree, replacedSurfaceId } = replaceSoleTerminalSurface(
+              ws.splitTree, paneId, { id: surfaceId, type: 'terminal' },
+            );
+            if (replacedSurfaceId) {
+              state.updateSplitTree(workspaceId, tree);
+              setAgentMeta(surfaceId, { agentId: event.agentId, label, status: 'running' });
+              // Intentionally not pushed onto the reopen-closed stack — the
+              // replaced surface is an idle default shell, not user work.
+              window.wmux?.pty?.kill(replacedSurfaceId);
+              return;
+            }
+          }
+        }
 
         const addSurfaceToLeaf = (node: SplitNode): SplitNode => {
           if (node.type === 'leaf' && node.paneId === paneId) {

--- a/src/renderer/store/split-utils.ts
+++ b/src/renderer/store/split-utils.ts
@@ -177,6 +177,40 @@ export function collectActiveTerminalSurfaceIds(tree: SplitNode): SurfaceId[] {
   ];
 }
 
+// ─── replaceSoleTerminalSurface (agent spawn --replace-tab) ──────────────────
+// Swap a pane's single default terminal tab for `newSurface`, so an agent can
+// occupy a freshly-gridded pane without leaving the idle shell behind as a
+// dead tab. Only fires when the leaf has EXACTLY one surface and it's a
+// terminal — anything else (user tabs, browser/markdown surfaces) falls back
+// to append semantics. Returns the replaced surface id so the caller can kill
+// its PTY; `replacedSurfaceId: null` means the tree is unchanged.
+
+export function replaceSoleTerminalSurface(
+  tree: SplitNode,
+  paneId: PaneId,
+  newSurface: { id: SurfaceId; type: SurfaceType },
+): { tree: SplitNode; replacedSurfaceId: SurfaceId | null } {
+  const leaf = findLeaf(tree, paneId);
+  if (!leaf || leaf.surfaces.length !== 1 || leaf.surfaces[0].type !== 'terminal') {
+    return { tree, replacedSurfaceId: null };
+  }
+  const replacedSurfaceId = leaf.surfaces[0].id;
+
+  const replaceInNode = (node: SplitNode): SplitNode => {
+    if (node.type === 'leaf') {
+      if (node.paneId !== paneId) return node;
+      return { ...node, surfaces: [newSurface], activeSurfaceIndex: 0 };
+    }
+    const [left, right] = node.children;
+    const newLeft = replaceInNode(left);
+    const newRight = replaceInNode(right);
+    if (newLeft === left && newRight === right) return node;
+    return { ...node, children: [newLeft, newRight] };
+  };
+
+  return { tree: replaceInNode(tree), replacedSurfaceId };
+}
+
 // ─── buildGridLayout ──────────────────────────────────────────────────────────
 // Replace the ENTIRE workspace split tree with a balanced grid of `count` cells.
 //

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -151,6 +151,8 @@ export interface AgentSpawnParams {
   env?: Record<string, string>;
   paneId?: PaneId;
   workspaceId?: WorkspaceId;
+  /** Replace the target pane's sole idle default terminal tab instead of appending. */
+  replaceTab?: boolean;
 }
 
 export interface AgentBatchParams {

--- a/tests/unit/split-tree.test.ts
+++ b/tests/unit/split-tree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createLeaf, splitNode, removeLeaf, findLeaf, updateRatio, getAllPaneIds, buildGridLayout } from '../../src/renderer/store/split-utils';
+import { createLeaf, splitNode, removeLeaf, findLeaf, updateRatio, getAllPaneIds, buildGridLayout, replaceSoleTerminalSurface } from '../../src/renderer/store/split-utils';
 
 describe('split-tree', () => {
   it('creates a leaf node', () => {
@@ -151,5 +151,63 @@ describe('buildGridLayout', () => {
     for (const pid of result.newPaneIds) {
       expect(findLeaf(result.tree, pid)).toBeDefined();
     }
+  });
+});
+
+describe('replaceSoleTerminalSurface (agent spawn --replace-tab)', () => {
+  const agentSurface = { id: 'surf-agent' as any, type: 'terminal' as const };
+
+  it('replaces a sole terminal surface and reports the replaced id', () => {
+    let tree: any = createLeaf('pane-1' as any, 'terminal');
+    tree = splitNode(tree, 'pane-1' as any, 'pane-2' as any, 'terminal', 'horizontal');
+    const defaultSurfaceId = findLeaf(tree, 'pane-2' as any)!.surfaces[0].id;
+
+    const result = replaceSoleTerminalSurface(tree, 'pane-2' as any, agentSurface);
+    expect(result.replacedSurfaceId).toBe(defaultSurfaceId);
+
+    const leaf = findLeaf(result.tree, 'pane-2' as any)!;
+    expect(leaf.surfaces.length).toBe(1);
+    expect(leaf.surfaces[0].id).toBe('surf-agent');
+    expect(leaf.activeSurfaceIndex).toBe(0);
+    // Other panes untouched
+    expect(findLeaf(result.tree, 'pane-1' as any)!.surfaces[0].id)
+      .toBe(findLeaf(tree, 'pane-1' as any)!.surfaces[0].id);
+  });
+
+  it('refuses when the leaf has more than one surface', () => {
+    const leaf = createLeaf('pane-1' as any, 'terminal');
+    const tree: any = {
+      ...leaf,
+      surfaces: [...leaf.surfaces, { id: 'surf-user' as any, type: 'terminal' as const }],
+    };
+    const result = replaceSoleTerminalSurface(tree, 'pane-1' as any, agentSurface);
+    expect(result.replacedSurfaceId).toBeNull();
+    expect(result.tree).toBe(tree);
+  });
+
+  it('refuses when the sole surface is not a terminal', () => {
+    const tree = createLeaf('pane-1' as any, 'browser');
+    const result = replaceSoleTerminalSurface(tree, 'pane-1' as any, agentSurface);
+    expect(result.replacedSurfaceId).toBeNull();
+    expect(result.tree).toBe(tree);
+  });
+
+  it('is a no-op for an unknown paneId', () => {
+    const tree = createLeaf('pane-1' as any, 'terminal');
+    const result = replaceSoleTerminalSurface(tree, 'pane-nope' as any, agentSurface);
+    expect(result.replacedSurfaceId).toBeNull();
+    expect(result.tree).toBe(tree);
+  });
+
+  it('works on a leaf nested inside branches (grid pane)', () => {
+    const base = createLeaf('pane-1' as any, 'terminal');
+    const grid = buildGridLayout(base, 'pane-1' as any, 4);
+    const target = grid.newPaneIds[2];
+    const result = replaceSoleTerminalSurface(grid.tree, target, agentSurface);
+    expect(result.replacedSurfaceId).not.toBeNull();
+    expect(findLeaf(result.tree, target)!.surfaces[0].id).toBe('surf-agent');
+    // Anchor untouched
+    expect(findLeaf(result.tree, 'pane-1' as any)!.surfaces[0].id)
+      .toBe(base.surfaces[0].id);
   });
 });


### PR DESCRIPTION
Fixes the orphaned-tab clutter that every orchestration run leaves behind in agent panes.

## The problem

`wmux layout grid --count N` creates N panes, each with a default terminal surface (an idle shell). `wmux agent spawn --pane <p>` then **appends** the agent's surface to that pane. So every agent pane ends up with **two tabs**: the untouched idle grid shell, plus the agent's Claude TUI.

That idle shell is pure noise — nothing ever runs in it, it holds a live PTY, and it survives `agent kill` (killing the agent reaps its process but leaves the dead surface as a tab). After a few waves the panes are cluttered with inert shells, and the tab bar makes it genuinely hard to tell which tab is the live agent.

## The fix

New `--replace-tab` flag on `wmux agent spawn`. When the target pane has **exactly one surface**, that surface is a **terminal**, and it is **not itself an agent surface**, the spawned agent surface *replaces* it (the idle shell's PTY is killed) instead of being appended. The pane ends with a single tab: the agent.

Any other pane state — multiple tabs, a non-terminal surface, an existing agent surface — falls back to the current append behavior, so this can't clobber a pane a user is actually working in. The flag is opt-in; without it, behavior is byte-for-byte what it is today.

The bundled `wmux-orchestrator` `spawn-agents.sh` now passes `--replace-tab`, so orchestration panes are single-tab out of the box.

## Changes

- `src/cli/wmux.ts` — `--replace-tab` flag on `agent spawn`
- `src/shared/types.ts` — plumb the option through the spawn payload
- `src/main/index.ts` — pass it to the renderer bridge
- `src/renderer/App.tsx` — apply replace-vs-append at spawn time
- `src/renderer/store/split-utils.ts` — `replaceSurfaceInLeaf` helper (immutable, consistent with the rest of the split-tree mutations)
- `tests/unit/split-tree.test.ts` — coverage for the replace path and for each guard that falls back to append
- `resources/wmux-orchestrator/` — `spawn-agents.sh` passes the flag; skill doc updated

## Testing

- `npm test` green (172 tests, including the new split-tree cases covering the replace path and every fallback guard).
- Verified live on a packaged build with a 3-agent orchestration: from a single-pane start, `spawn-agents.sh` produced a clean 2×2 with **every agent pane at 1 tab** (previously 2 — grid shell + agent TUI), coordinator pane untouched at 1 tab, zero orphans. Full cycle exercised: spawn → agents run and report → `agent kill` (all agents `exited`, PIDs confirmed dead) → `close-pane` → collapse back to the single pane.
- Confirmed the guards: panes with multiple tabs / non-terminal surfaces / existing agent surfaces still append as before.

## Note for anyone on an older build

`agentSpawn` parses flags as `--flag value` pairs, so passing `--replace-tab` (a valueless flag) to a CLI that doesn't know it will shift the pairing and silently swallow the next flag. Only pass it to a build that has this change — worth knowing if the orchestrator plugin is ever updated independently of the app.