### PR TITLE
fix(cdp): don't crash the main process when port 9222 is already taken

### DIFF
--- a/src/main/cdp-proxy.ts
+++ b/src/main/cdp-proxy.ts
@@ -194,16 +194,27 @@ export class CDPProxy {
       console.log('[wmux] CDP proxy: client connected');
     });
 
-    // Safety net: prevent 'error' events from becoming uncaught exceptions
+    // Safety nets: never let an 'error' event become an uncaught exception.
+    // BOTH emitters need one. `ws` forwards the http server's 'error' events
+    // onto the WebSocketServer, so without a wss listener the failed listen()
+    // below (port busy — the common case when a second wmux instance starts and
+    // the first already holds 9222) is re-emitted on the wss as an unhandled
+    // 'error'. That crashes the main process with Electron's modal error dialog,
+    // which in turn blocks the event loop and wedges the whole instance.
     this.server.on('error', () => {});
+    this.wss.on('error', () => {});
 
     // Try ports 9222-9230
     for (let p = DEFAULT_PORT; p <= MAX_PORT; p++) {
       try {
         await new Promise<void>((resolve, reject) => {
-          this.server!.once('error', reject);
+          const onListenError = (err: Error): void => reject(err);
+          this.server!.once('error', onListenError);
           this.server!.listen(p, '127.0.0.1', () => {
-            this.server!.removeAllListeners('error');
+            // Drop only THIS probe's listener. removeAllListeners('error') would
+            // also strip the safety net above and ws's own forwarder, leaving a
+            // post-bind server error with no handler — uncaught again.
+            this.server!.removeListener('error', onListenError);
             this.port = p;
             resolve();
           });

--- a/tests/unit/cdp-proxy.test.ts
+++ b/tests/unit/cdp-proxy.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import net from 'net';
 
 // cdp-proxy.ts imports `electron` at module scope; stub it so the pure
 // host-check function can be tested without an Electron runtime.
@@ -6,7 +7,7 @@ vi.mock('electron', () => ({
   webContents: { fromId: () => undefined },
 }));
 
-import { isAllowedCdpHost, isAllowedCdpOrigin } from '../../src/main/cdp-proxy';
+import { CDPProxy, isAllowedCdpHost, isAllowedCdpOrigin } from '../../src/main/cdp-proxy';
 
 describe('isAllowedCdpHost (DNS-rebinding guard)', () => {
   it('allows loopback literals with the proxy port', () => {
@@ -60,5 +61,44 @@ describe('isAllowedCdpOrigin (browser-origin guard)', () => {
     expect(isAllowedCdpOrigin('https://evil.com')).toBe(false);
     expect(isAllowedCdpOrigin('null')).toBe(false);
     expect(isAllowedCdpOrigin('file://')).toBe(false);
+  });
+});
+
+const DEFAULT_PORT = 9222;
+const MAX_PORT = 9230;
+
+describe('CDPProxy.start (port fallback when a first instance holds 9222)', () => {
+  it('falls back to a free port instead of raising an uncaught error', async () => {
+    // Occupy the default port to reproduce the second-instance condition. If it
+    // is already taken (a real wmux is running), that serves the same purpose.
+    const blocker = net.createServer();
+    const blocked = await new Promise<boolean>((resolve) => {
+      blocker.once('error', () => resolve(false));
+      blocker.listen(DEFAULT_PORT, '127.0.0.1', () => resolve(true));
+    });
+
+    const proxy = new CDPProxy();
+    try {
+      // Before the fix this rejected/crashed: `ws` re-emits the http server's
+      // EADDRINUSE onto the WebSocketServer, which had no 'error' listener, so
+      // the failed listen() surfaced as an uncaught exception rather than
+      // advancing the fallback loop.
+      await proxy.start();
+
+      const port = proxy.getPort();
+      expect(port).not.toBe(DEFAULT_PORT);
+      expect(port).toBeGreaterThan(DEFAULT_PORT);
+      expect(port).toBeLessThanOrEqual(MAX_PORT);
+
+      // Both emitters must still carry an 'error' handler after a successful
+      // bind — the old removeAllListeners('error') stripped the safety net and
+      // ws's forwarder, so any later server error became uncaught again.
+      const internals = proxy as unknown as { server: net.Server; wss: { listenerCount(e: string): number } };
+      expect(internals.server.listenerCount('error')).toBeGreaterThan(0);
+      expect(internals.wss.listenerCount('error')).toBeGreaterThan(0);
+    } finally {
+      proxy.stop();
+      if (blocked) await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
   });
 });


### PR DESCRIPTION
## The bug

Start a second wmux instance while a first one is running and the new instance dies at startup with Electron's modal error dialog:

```
A JavaScript error occurred in the main process
Uncaught Exception:
Error: listen EADDRINUSE: address already in use 127.0.0.1:9222
    at Server.setupListenHandle [as _listen2] (node:net:2009:16)
    ...
```

It's worse than a failed feature: the modal **blocks the main-process event loop**, so the named pipe stops accepting connections. From the outside the app looks completely dead — the pipe file exists but every `connect()` hangs — and the instance only exits once the dialog is dismissed.

Easiest repro: run wmux, then start another instance (a dev build, or a second install). The first instance holds 9222, the second one dies on it.

## Why it happens

`CDPProxy.start()` already *tries* to be resilient — it walks ports 9222→9230 and has a safety net so listen failures don't escalate:

```ts
this.server.on('error', () => {});   // safety net (http server only)

for (let p = DEFAULT_PORT; p <= MAX_PORT; p++) {
  try {
    await new Promise<void>((resolve, reject) => {
      this.server!.once('error', reject);
      this.server!.listen(p, '127.0.0.1', () => { ... });
    });
    return;
  } catch { continue; }   // fall through to the next port
}
```

The gap is that the `WebSocketServer` is constructed over that same http server *before* the bind loop runs, and `ws` **forwards the http server's `'error'` events onto the wss** ([`websocket-server.js`](https://github.com/websockets/ws/blob/master/lib/websocket-server.js): `error: this.emit.bind(this, 'error')`). The wss has no `'error'` listener, so Node's default kicks in and the EADDRINUSE is **rethrown as an uncaught exception** — before the `catch { continue; }` ever gets to advance to 9223.

So the fallback loop never actually worked; it only ever looked like it did, because the first instance always wins 9222.

## The fix

Give the wss an error handler alongside the http server's:

```ts
this.server.on('error', () => {});
this.wss.on('error', () => {});
```

I also fixed a second, related hole in the same block: on a **successful** bind the loop called `removeAllListeners('error')`, which wipes not just the probe's `reject` listener but *also* the safety net above **and ws's forwarder** — leaving the server with zero error handlers, so any post-bind server error would be uncaught all over again. Now only the probe's own listener is removed:

```ts
const onListenError = (err: Error): void => reject(err);
this.server!.once('error', onListenError);
this.server!.listen(p, '127.0.0.1', () => {
  this.server!.removeListener('error', onListenError);   // not removeAllListeners
  ...
});
```

Net effect: the 9222→9230 fallback does what it was always meant to do, and the proxy can't take down the main process.

## Testing

**New regression test** in `tests/unit/cdp-proxy.test.ts` that occupies 9222, starts a `CDPProxy`, and asserts it lands on a free port with both error handlers still attached. It genuinely reproduces the bug — on `master` it fails with the raw error, and passes with the fix:

```
# without the fix
 × falls back to a free port instead of raising an uncaught error
   Error: listen EADDRINUSE: address already in use 127.0.0.1:9222
 Tests  1 failed | 9 passed (10)

# with the fix
 Tests  10 passed (10)
```

(The test occupies 9222 itself, or accepts it already being held, so it's deterministic whether or not a wmux is running on the machine.)

**Full suite:** 168 tests green, build clean, no new lint findings.

**Verified live:** with a real wmux holding 9222, a second instance built from this branch starts cleanly —

```
wmux pipe server listening on \.\pipe\wmux-cdpfix
[wmux] CDP proxy listening on localhost:9223
```

— no dialog, pipe responsive (`ping` → `pong`, `list-panes` works), and its CDP proxy answers on 9223 (`/json/version` → `Chrome/150.0.7871.46`) while the first instance keeps 9222. Before the fix, the same launch reproduced the dialog and the wedged pipe every time.

Found while testing the xterm 6 upgrade (#84) in a side-by-side instance.