### PR TITLE
fix(pty): fall back to a real directory when the cwd no longer exists (spawn error 267)

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -129,6 +129,30 @@ function isPosixPath(p: string): boolean {
   return p.startsWith('/') && !p.startsWith('//');
 }
 
+// Resolve the working dir handed to pty.spawn, guaranteeing it is a directory
+// that exists — otherwise CreateProcess fails with error 267 (ERROR_DIRECTORY)
+// and the pane dies with an opaque "Cannot create process, error code: 267".
+// Returns undefined (node-pty's own default) when there is nothing usable.
+export function resolveSpawnCwd(cwd: string | undefined): string | undefined {
+  if (!cwd) return undefined;
+
+  const fallback = process.env.USERPROFILE || 'C:\\';
+
+  // POSIX/WSL cwd: not a valid Win32 working dir at all (issue #60).
+  if (isPosixPath(cwd)) return fallback;
+
+  // Win32 cwd that no longer exists (deleted git worktree) or does not exist
+  // yet (spawn ordered before `git worktree add` finished). Also rejects a path
+  // that exists but is a FILE — CreateProcess wants a directory.
+  try {
+    if (fs.statSync(cwd).isDirectory()) return cwd;
+    console.warn(`[wmux] cwd is not a directory, falling back to ${fallback}: ${cwd}`);
+  } catch {
+    console.warn(`[wmux] cwd does not exist, falling back to ${fallback}: ${cwd}`);
+  }
+  return fallback;
+}
+
 // Build the launch args for a shell and mutate `env` with shell-specific vars.
 // Kept out of create() so that hot path stays under the cognitive-complexity
 // budget. `env` is mutated in place (integration script paths, WSLENV, etc.).
@@ -315,11 +339,18 @@ export class PtyManager {
       startupCommandsConsumed = true;
     }
 
-    // A POSIX/WSL cwd (restored from session.json — issue #60) is never a valid
-    // Win32 process working dir and triggers spawn error 267. Fall back to a real
-    // Windows dir; WSL itself is still sent to the POSIX path via --cd (above).
-    const spawnCwd =
-      options.cwd && isPosixPath(options.cwd) ? (process.env.USERPROFILE || 'C:\\') : options.cwd;
+    // CreateProcess fails with error 267 (ERROR_DIRECTORY) when the working dir
+    // isn't a real directory, and node-pty surfaces that as an opaque "Cannot
+    // create process, error code: 267" — the pane just dies. Two ways to get
+    // there, both fixed by falling back to a directory that exists:
+    //
+    //  - a POSIX/WSL cwd restored from session.json (issue #60) is never a valid
+    //    Win32 working dir. WSL itself still reaches the POSIX path via --cd above.
+    //  - a Win32 cwd that has since been deleted, or has not been created yet:
+    //    an agent spawned into a git worktree that was removed after its wave, or
+    //    ordered before `git worktree add` finished. The cwd comes from session
+    //    state / CLI args, so it must not be trusted to still exist at spawn time.
+    const spawnCwd = resolveSpawnCwd(options.cwd);
 
     const spawnOptions: pty.IWindowsPtyForkOptions = {
       name: 'xterm-256color',

--- a/tests/unit/pty-manager.test.ts
+++ b/tests/unit/pty-manager.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { PtyManager, parseShellSpec } from '../../src/main/pty-manager';
+import { PtyManager, parseShellSpec, resolveSpawnCwd } from '../../src/main/pty-manager';
 
 const TEST_SHELL = 'cmd.exe';
 const TEST_ENV = Object.fromEntries(
@@ -180,5 +180,55 @@ describe('parseShellSpec (issue #78 — shell command lines with args)', () => {
       command: 'C:\\some path\\tool.exe',
       args: ['--flag'],
     });
+  });
+});
+
+/**
+ * CreateProcess fails with error 267 (ERROR_DIRECTORY) when handed a working
+ * dir that isn't a real directory, and node-pty surfaces it as an opaque
+ * "Failed to create terminal: Cannot create process, error code: 267" — the
+ * pane just dies. The cwd comes from session state / CLI args (e.g. an agent
+ * spawned into a git worktree that was deleted after its wave, or ordered
+ * before `git worktree add` finished), so it cannot be trusted to still exist.
+ */
+describe('resolveSpawnCwd', () => {
+  const home = process.env.USERPROFILE || 'C:\\';
+
+  it('keeps a cwd that exists', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-cwd-'));
+    try {
+      expect(resolveSpawnCwd(dir)).toBe(dir);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back when the cwd was deleted (the worktree case → error 267)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-cwd-'));
+    fs.rmSync(dir, { recursive: true, force: true });
+    expect(resolveSpawnCwd(dir)).toBe(home);
+  });
+
+  it('falls back when the cwd never existed', () => {
+    expect(resolveSpawnCwd('C:\\definitely\\not\\here\\wmux-test')).toBe(home);
+  });
+
+  it('falls back when the cwd is a file, not a directory', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-cwd-'));
+    const file = path.join(dir, 'not-a-dir.txt');
+    fs.writeFileSync(file, 'x');
+    try {
+      expect(resolveSpawnCwd(file)).toBe(home);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back for a POSIX/WSL cwd (issue #60)', () => {
+    expect(resolveSpawnCwd('/home/user/project')).toBe(home);
+  });
+
+  it('passes undefined through (node-pty default)', () => {
+    expect(resolveSpawnCwd(undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
A pane dies with an opaque native error when its working directory does not exist:

```
Failed to create terminal: Cannot create process, error code: 267
```

267 is `ERROR_DIRECTORY` — CreateProcess was handed a working dir that is not a real directory. node-pty surfaces it verbatim, with a native stack trace and no indication of which path was at fault.

## Cause

`pty-manager` already guarded **one** route to 267 — a POSIX/WSL cwd restored from session.json (issue #60):

```ts
const spawnCwd =
  options.cwd && isPosixPath(options.cwd) ? (process.env.USERPROFILE || "C:\\") : options.cwd;
```

But a plain Win32 cwd was passed straight through, unchecked. It arrives from session state and CLI args, so it cannot be trusted to still exist at spawn time. Hit this repeatedly during a long orchestration run: agents are spawned into git worktrees, and a worktree that was removed after its wave — or whose `git worktree add` had not finished yet — leaves the spawn pointing at a directory that is not there.

The existing `catch` compounds it: on failure it retries with `useConptyDll: false`, a fallback meant for conpty **load** failures. With a bad cwd that retry hits the same missing directory, throws 267 again, and this time nothing catches it.

## Fix

Resolve the cwd before spawning (`resolveSpawnCwd`): keep it when it is a directory that exists, otherwise fall back to `USERPROFILE` and warn with the offending path. Folds the existing issue-#60 POSIX case into the same helper, and also rejects a cwd that exists but is a file.

A pane that would have died now opens in the home directory with a clear reason in the log.

## Verification

- 6 new cases in `tests/unit/pty-manager.test.ts`: cwd that exists, deleted cwd (the worktree case), never-existed cwd, cwd that is a file, POSIX/WSL cwd, and `undefined` passthrough.
- `npm test` → 195 passing (25 files). `tsc` clean. No new lint problems (4 pre-existing warnings in `pty-manager.ts`, unchanged).