### PR TITLE
feat(surface-label): show folder name in terminal tab labels via currentCwd

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -154,9 +154,22 @@ function applyShellState(cmd: any, ws: WorkspaceInfo, deps: MetaDeps): void {
 /** Dispatch a surface-scoped metadata command to the owning workspace. */
 function handleSurfaceMetadata(cmd: any, ws: WorkspaceInfo, deps: MetaDeps): void {
   switch (cmd.command) {
-    case 'report_pwd':
-      deps.updateWorkspaceMetadata(ws.id, { cwd: cmd.args?.[0] });
+    case 'report_pwd': {
+      const pwd = cmd.args?.[0];
+      deps.updateWorkspaceMetadata(ws.id, { cwd: pwd });
+      // Also store cwd at the surface level so the tab label can show the project folder.
+      if (pwd && cmd.surfaceId) {
+        const { updateSurface } = useStore.getState();
+        for (const paneId of getAllPaneIds(ws.splitTree)) {
+          const leaf = findLeaf(ws.splitTree, paneId);
+          if (leaf?.surfaces.some((s) => s.id === cmd.surfaceId)) {
+            updateSurface(ws.id, paneId, cmd.surfaceId, { currentCwd: pwd });
+            break;
+          }
+        }
+      }
       break;
+    }
     case 'report_git_branch':
       deps.updateWorkspaceMetadata(ws.id, { gitBranch: cmd.args?.[0], gitDirty: cmd.args?.[1] === 'dirty' });
       break;

--- a/src/renderer/components/SplitPane/surface-label.ts
+++ b/src/renderer/components/SplitPane/surface-label.ts
@@ -13,13 +13,23 @@ export function getShellLabel(shell?: string): string | null {
   return normalized.replace(/\.exe$/i, '').replace(/[-_]/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
+/** Extract the last path segment from a cwd string for use as a tab label. */
+function cwdFolderName(cwd: string): string | null {
+  const normalized = cwd.replace(/\\/g, '/').replace(/\/$/, '');
+  const lastSegment = normalized.split('/').pop();
+  return lastSegment || null;
+}
+
 export function getSurfaceLabel(surface: SurfaceRef, agentLabel?: string, workspaceShell?: string): string {
   if (surface.customTitle) return surface.customTitle;
   if (agentLabel) return agentLabel;
 
   switch (surface.type) {
-    case 'terminal':
+    case 'terminal': {
+      const folder = surface.currentCwd ? cwdFolderName(surface.currentCwd) : null;
+      if (folder) return folder;
       return getShellLabel(surface.shell || workspaceShell) || 'Terminal';
+    }
     case 'browser':
       return 'Browser';
     case 'markdown':

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -20,6 +20,8 @@ export interface SurfaceRef {
   colorScheme?: string;
   /** Per-surface working directory override (quick-launch profiles — issue #32). */
   cwd?: string;
+  /** Live working directory updated by shell integration on every prompt. */
+  currentCwd?: string;
   /** Commands run once after the terminal PTY spawns (quick-launch profiles — issue #32). */
   startupCommands?: string[];
   /** Initial URL for a browser surface created from a quick-launch profile (issue #32). */

--- a/tests/unit/surface-label.test.ts
+++ b/tests/unit/surface-label.test.ts
@@ -44,4 +44,32 @@ describe('surface labels', () => {
     expect(getSurfaceLabel(surface('surf-markdown', { type: 'markdown' }))).toBe('Markdown');
     expect(getSurfaceLabel(surface('surf-diff', { type: 'diff' }))).toBe('Diff');
   });
+
+  it('shows the folder name from currentCwd for terminal labels', () => {
+    expect(
+      getSurfaceLabel(
+        surface('surf-1', { currentCwd: 'C:\\Users\\me\\coding\\wmux' }),
+        undefined,
+        'pwsh.exe',
+      ),
+    ).toBe('wmux');
+  });
+
+  it('falls back to shell name when currentCwd is empty', () => {
+    expect(
+      getSurfaceLabel(
+        surface('surf-1', { currentCwd: '' }),
+        undefined,
+        'pwsh.exe',
+      ),
+    ).toBe('PowerShell');
+  });
+
+  it('prefers custom title over currentCwd', () => {
+    expect(
+      getSurfaceLabel(
+        surface('surf-1', { customTitle: 'My Tab', currentCwd: 'C:\\Users\\me\\coding\\wmux' }),
+      ),
+    ).toBe('My Tab');
+  });
 });


### PR DESCRIPTION
Displays the current folder name in terminal tab labels using the reported current working directory (currentCwd).\n\nCloses surface labeling gap for PowerShell and other shells that report cwd via wmux integration.