### PR TITLE
fix(orchestration): write the status vocabulary the app counts (fixes #99)

### DIFF
--- a/resources/wmux-orchestrator/scripts/json-tool.js
+++ b/resources/wmux-orchestrator/scripts/json-tool.js
@@ -205,7 +205,7 @@ function cmdQuery(file, queryName, ...args) {
         break;
       }
       const agents = data.waves[waveIdx].agents || [];
-      const allDone = agents.every(a => a.status === 'completed' || a.status === 'failed');
+      const allDone = agents.every(a => a.status === 'exited' || a.status === 'failed');
       process.stdout.write(allDone ? 'true' : 'false');
       process.stdout.write('\n');
       break;
@@ -329,7 +329,7 @@ function cmdDashboard(file) {
   for (const wave of waves) {
     for (const agent of (wave.agents || [])) {
       totalAgents++;
-      if (agent.status === 'completed') completedAgents++;
+      if (agent.status === 'exited') completedAgents++;
       else if (agent.status === 'running') runningAgents++;
       else if (agent.status === 'failed') failedAgents++;
     }

--- a/resources/wmux-orchestrator/scripts/on-agent-stop.sh
+++ b/resources/wmux-orchestrator/scripts/on-agent-stop.sh
@@ -19,7 +19,7 @@ EXIT_CODE="${CLAUDE_EXIT_CODE:-0}"
 NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 if [ "$EXIT_CODE" = "0" ]; then
-  update_agent "$ORCH_DIR" "$AGENT_ID" "status=completed" "exitCode=0" "finishedAt=$NOW"
+  update_agent "$ORCH_DIR" "$AGENT_ID" "status=exited" "exitCode=0" "finishedAt=$NOW"
 else
   update_agent "$ORCH_DIR" "$AGENT_ID" "status=failed" "exitCode=$EXIT_CODE" "finishedAt=$NOW"
 fi
@@ -27,7 +27,7 @@ fi
 WAVE_IDX=$(node "$JSON_TOOL" query "$ORCH_DIR/state.json" wave-of-agent "$AGENT_ID" 2>/dev/null)
 
 if [ -n "$WAVE_IDX" ] && wave_complete "$ORCH_DIR" "$WAVE_IDX"; then
-  update_state "$ORCH_DIR" ".waves[$WAVE_IDX].status" "completed"
+  update_state "$ORCH_DIR" ".waves[$WAVE_IDX].status" "complete"
 
   if all_waves_done "$ORCH_DIR"; then
     REVIEWER_STATUS=$(read_state "$ORCH_DIR" '.reviewer.status')
@@ -37,7 +37,7 @@ if [ -n "$WAVE_IDX" ] && wave_complete "$ORCH_DIR" "$WAVE_IDX"; then
         wmux notify "All agents complete. Starting reviewer..." 2>/dev/null || true
       fi
     else
-      update_state "$ORCH_DIR" '.status' 'completed'
+      update_state "$ORCH_DIR" '.status' 'complete'
     fi
   else
     NEXT_WAVE=$(next_pending_wave "$ORCH_DIR")

--- a/tests/unit/orchestration-status-vocab.test.ts
+++ b/tests/unit/orchestration-status-vocab.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { OrchAgentStatus, OrchWaveStatus, OrchRunStatus } from '../../src/shared/types';
+
+const SCRIPTS = path.resolve(__dirname, '../../resources/wmux-orchestrator/scripts');
+const HOOK = path.join(SCRIPTS, 'on-agent-stop.sh');
+const JSON_TOOL = path.join(SCRIPTS, 'json-tool.js');
+
+// The only status words the app understands. Typed against src/shared/types.ts so
+// these arrays stop compiling if either union changes without this test noticing.
+const AGENT_STATUSES: OrchAgentStatus[] = ['pending', 'running', 'exited', 'failed'];
+const WAVE_STATUSES: OrchWaveStatus[] = ['pending', 'running', 'complete', 'failed'];
+const RUN_STATUSES: OrchRunStatus[] = ['pending', 'running', 'complete', 'failed'];
+
+let tmp: string;
+let orchDir: string;
+
+const readState = () => JSON.parse(fs.readFileSync(path.join(orchDir, 'state.json'), 'utf8'));
+
+function writeState(overrides: Record<string, unknown> = {}): void {
+  fs.writeFileSync(
+    path.join(orchDir, 'state.json'),
+    JSON.stringify({
+      id: 'test',
+      task: 'test run',
+      status: 'running',
+      dashboardSurfaceId: null,
+      waves: [{ status: 'running', agents: [{ id: 'a1', status: 'running', task: 'do a thing' }] }],
+      ...overrides,
+    }),
+  );
+}
+
+// find_active_orch() scans $TMPDIR for wmux-orch-*/ dirs whose state.json is "running".
+function runHook(agentId = 'a1', exitCode = '0'): void {
+  execFileSync('bash', [HOOK], {
+    env: { ...process.env, TMPDIR: tmp, WMUX_AGENT_ID: agentId, CLAUDE_EXIT_CODE: exitCode },
+    encoding: 'utf8',
+  });
+}
+
+const query = (...args: string[]): string =>
+  execFileSync('node', [JSON_TOOL, 'query', path.join(orchDir, 'state.json'), ...args], {
+    encoding: 'utf8',
+  }).trim();
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-vocab-'));
+  orchDir = path.join(tmp, 'wmux-orch-test');
+  fs.mkdirSync(orchDir);
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('on-agent-stop.sh status vocabulary (#99)', () => {
+  it('marks a successful agent "exited" — the word the sidebar counts, not "completed"', () => {
+    writeState();
+    runHook();
+
+    const agent = readState().waves[0].agents[0];
+    expect(agent.status).toBe('exited');
+    expect(agent.exitCode).toBe(0);
+    expect(AGENT_STATUSES).toContain(agent.status);
+  });
+
+  it('marks the finished wave "complete", not "completed"', () => {
+    writeState();
+    runHook();
+
+    const wave = readState().waves[0];
+    expect(wave.status).toBe('complete');
+    expect(WAVE_STATUSES).toContain(wave.status);
+  });
+
+  it('marks the finished run "complete" once every wave is done', () => {
+    writeState();
+    runHook();
+
+    const state = readState();
+    expect(state.status).toBe('complete');
+    expect(RUN_STATUSES).toContain(state.status);
+  });
+
+  it('still records a failing agent as "failed" with its exit code', () => {
+    writeState();
+    runHook('a1', '3');
+
+    const agent = readState().waves[0].agents[0];
+    expect(agent.status).toBe('failed');
+    expect(agent.exitCode).toBe(3);
+    expect(AGENT_STATUSES).toContain(agent.status);
+  });
+
+  it('leaves an unfinished wave running while another agent is still going', () => {
+    writeState({
+      waves: [
+        {
+          status: 'running',
+          agents: [
+            { id: 'a1', status: 'running', task: 'one' },
+            { id: 'a2', status: 'running', task: 'two' },
+          ],
+        },
+      ],
+    });
+    runHook('a1');
+
+    const state = readState();
+    expect(state.waves[0].agents[0].status).toBe('exited');
+    expect(state.waves[0].status).toBe('running');
+    expect(state.status).toBe('running');
+  });
+});
+
+describe('json-tool.js reads the same vocabulary it is written (#99)', () => {
+  it('wave-complete treats "exited" agents as done', () => {
+    writeState({
+      waves: [{ status: 'running', agents: [{ id: 'a1', status: 'exited', exitCode: 0 }] }],
+    });
+    expect(query('wave-complete', '0')).toBe('true');
+  });
+
+  it('wave-complete treats a mix of "exited" and "failed" as done', () => {
+    writeState({
+      waves: [
+        {
+          status: 'running',
+          agents: [
+            { id: 'a1', status: 'exited', exitCode: 0 },
+            { id: 'a2', status: 'failed', exitCode: 1 },
+          ],
+        },
+      ],
+    });
+    expect(query('wave-complete', '0')).toBe('true');
+  });
+
+  it('wave-complete is false while an agent is still running', () => {
+    writeState({
+      waves: [
+        {
+          status: 'running',
+          agents: [
+            { id: 'a1', status: 'exited', exitCode: 0 },
+            { id: 'a2', status: 'running' },
+          ],
+        },
+      ],
+    });
+    expect(query('wave-complete', '0')).toBe('false');
+  });
+});
+
+describe('no orchestrator script writes the pre-#99 "completed" status', () => {
+  it('has no "status=completed" or bare "completed" status writes left', () => {
+    const dir = SCRIPTS;
+    const offenders: string[] = [];
+    for (const file of fs.readdirSync(dir)) {
+      if (!/\.(sh|js)$/.test(file)) continue;
+      const body = fs.readFileSync(path.join(dir, file), 'utf8');
+      body.split('\n').forEach((line, i) => {
+        if (line.trim().startsWith('#')) return;
+        if (/status=completed|status === 'completed'|"status"\s*:\s*"completed"/.test(line)) {
+          offenders.push(`${file}:${i + 1}`);
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #99.

In degraded mode (native subagents, where the `SubagentStop` hook drives wave transitions), `on-agent-stop.sh` marked finished agents `completed` and finished waves/runs `completed`. Neither word exists in the app's vocabulary — `src/shared/types.ts:348-349` defines agents as `exited` and waves/runs as `complete`, and the sidebar counts `exited` (`OrchestrationPanel.tsx:39`). So the cockpit sat at 0/N forever even though every agent had finished.

`skills/orchestrate/SKILL.md:446` already documents the correct vocabulary and explicitly warns against `completed`, and `dashboard-text.js` had already migrated — the script just never followed its own doc.

## Why this touches `json-tool.js` too

`json-tool.js` read `completed` back in two places, which made it self-consistent with the broken script:

- `:208` — `wave-complete`, which backs `wave_complete()`
- `:332` — the markdown dashboard counter

Fixing only the shell script would have left `wave-complete` never returning true, stopping wave transitions altogether — worse than the display bug. Both files have to move together, so they're in one commit.

## Changes

| File | Change |
|---|---|
| `on-agent-stop.sh:22` | agent `completed` → `exited` |
| `on-agent-stop.sh:30` | wave `completed` → `complete` |
| `on-agent-stop.sh:40` | run `completed` → `complete` |
| `json-tool.js:208` | read `exited` |
| `json-tool.js:332` | read `exited` |

## Tests

`tests/unit/orchestration-status-vocab.test.ts` runs the real `on-agent-stop.sh` end-to-end against a temp orchestration dir (via `TMPDIR`, the same discovery path `find_active_orch()` uses) and asserts the resulting `state.json`. The expected status arrays are typed against `OrchAgentStatus` / `OrchWaveStatus` / `OrchRunStatus`, so they stop compiling if the unions change — the shell and TypeScript layers can't drift apart silently again. There's also a guard test that no script reintroduces a `status=completed` write.

7 of the 9 tests fail on `master` and all 9 pass with this change. Full suite is green.

## One thing worth flagging

`CLAUDE.md` notes the orchestrator plugin is also published standalone at `amirlehmam/wmux-orchestrator`. The same mismatch is presumably there, and this PR doesn't reach it — flagging in case it needs a companion fix.

Happy to adjust anything here, including splitting the tests out or trimming them down if they're heavier than you'd like for this.
