### PR TITLE
Add rename-surface CLI command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,7 @@ The pipe server in `index.ts` handles V2 JSON-RPC methods. Most delegate to the 
 - `system.identify`, `system.capabilities`, `system.tree`
 - `workspace.create`, `workspace.close`, `workspace.select`, `workspace.rename`, `workspace.list`
 - `pane.split`, `pane.close`, `pane.focus`, `pane.zoom`, `pane.list`
-- `surface.create`, `surface.close`, `surface.focus`, `surface.list`
+- `surface.create`, `surface.close`, `surface.focus`, `surface.rename`, `surface.list`
 - `surface.send_text`, `surface.send_key`, `surface.read_text`, `surface.trigger_flash`
 - `markdown.set_content`, `markdown.load_file`
 - `notification.list`, `notification.clear`
@@ -360,7 +360,7 @@ wmux --remote host[:port] --token T <any command>   # on the client (through `ss
 
 # Surfaces (tabs within a pane)
 wmux new-surface [--type terminal|browser|markdown]
-wmux close-surface | focus-surface | list-surfaces
+wmux close-surface | focus-surface | rename-surface | list-surfaces
 
 # Panes
 wmux split [--down] [--type T] | close-pane | focus-pane | zoom-pane | list-panes | tree

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -429,6 +429,17 @@ const COMMANDS: Record<string, (args: string[]) => Promise<void> | void> = {
     print(await sendV2('surface.create', { type, ...(colorScheme ? { colorScheme } : {}) }));
   },
   'close-surface': async (args) => print(await sendV2('surface.close', { id: args[1] })),
+  // `rename-surface <id> <title>`, or `rename-surface <title>` from inside a
+  // pane (renames the current surface via WMUX_SURFACE_ID).
+  'rename-surface': async (args) => {
+    let id = args[1];
+    let title = args[2];
+    if (title === undefined && process.env.WMUX_SURFACE_ID) {
+      title = id;
+      id = process.env.WMUX_SURFACE_ID;
+    }
+    print(await sendV2('surface.rename', { id, title }));
+  },
   'focus-surface': async (args) => print(await sendV2('surface.focus', { id: args[1] })),
   'list-surfaces': async (args) => print(await sendV2('surface.list', { paneId: getFlag(args, '--pane') })),
   'set-color-scheme': cmdSetColorScheme,
@@ -574,6 +585,7 @@ Remote:     ssh [ssh options] <user@host> [--title T]   (remote terminal in a ne
 Global:     --remote host[:port] --token <T>   (drive a REMOTE wmux through an SSH tunnel;
             env equivalents: WMUX_REMOTE, WMUX_REMOTE_TOKEN)
 Surface:    new-surface [--type T] [--color-scheme NAME], close-surface, focus-surface, list-surfaces
+            rename-surface [surfaceId] <title>   (renames the current surface when run inside a pane)
             set-color-scheme [surfaceId] <scheme>, clear-color-scheme [surfaceId], list-themes
 Pane:       split [--down] [--type T] [--color-scheme NAME], close-pane, focus-pane, zoom-pane, list-panes, tree
             pane new|close|focus|list   (verb form, mirrors issue #4 example)

--- a/src/main/v2-bridge.ts
+++ b/src/main/v2-bridge.ts
@@ -77,6 +77,9 @@ const SPECS: Record<string, BridgeSpec> = {
   'surface.focus': {
     js: (p) => `window.__wmux_focusSurface?.(${S(p?.id || p?.surfaceId)}, ${S(p?.workspaceId)})`,
   },
+  'surface.rename': {
+    js: (p) => `window.__wmux_renameSurface?.(${S(p?.id || p?.surfaceId)}, ${S(p?.title || '')}, ${S(p?.workspaceId)})`,
+  },
   'surface.list': {
     js: (p) => `window.__wmux_listSurfaces?.(${S(p?.workspaceId)})`,
     shape: (r) => ({ surfaces: r || [] }),

--- a/src/renderer/pipe-bridge.ts
+++ b/src/renderer/pipe-bridge.ts
@@ -252,6 +252,23 @@ export function initPipeBridge(): void {
     }
   };
 
+  w.__wmux_renameSurface = (surfaceId: string, title: string, workspaceId?: string) => {
+    const store = useStore.getState();
+    const wsId = (workspaceId || store.activeWorkspaceId) as WorkspaceId;
+    if (!wsId) return { ok: false, error: 'No active workspace' };
+    const ws = store.workspaces.find(w => w.id === wsId);
+    if (!ws) return { ok: false, error: 'Workspace not found' };
+    const paneIds = getAllPaneIds(ws.splitTree);
+    for (const pid of paneIds) {
+      const leaf = findLeaf(ws.splitTree, pid);
+      if (leaf?.surfaces?.some(s => s.id === surfaceId)) {
+        store.renameSurface(wsId, pid, surfaceId as SurfaceId, title ?? '');
+        return { ok: true };
+      }
+    }
+    return { ok: false, error: 'Surface not found' };
+  };
+
   w.__wmux_focusSurface = (surfaceId: string, workspaceId?: string) => {
     const store = useStore.getState();
     const wsId = (workspaceId || store.activeWorkspaceId) as WorkspaceId;


### PR DESCRIPTION
The CLI can rename workspaces (`rename-workspace`) but there was no equivalent for tabs. This adds a `surface.rename` pipe method and a `rename-surface` CLI command.

```
wmux rename-surface <surfaceId> <title>
wmux rename-surface <title>            # renames the current surface when run inside a pane
```

Follows the existing table-driven pipe-bridge pattern used by the other surface commands.