### PR TITLE
Add duplicate tab option

### DIFF
--- a/src/renderer/components/SplitPane/PaneWrapper.tsx
+++ b/src/renderer/components/SplitPane/PaneWrapper.tsx
@@ -49,6 +49,7 @@ export default function PaneWrapper({
   const addSurface = useStore((s) => s.addSurface);
   const updateSurface = useStore((s) => s.updateSurface);
   const closeSurface = useStore((s) => s.closeSurface);
+  const duplicateSurface = useStore((s) => s.duplicateSurface);
   const selectSurface = useStore((s) => s.selectSurface);
   const moveSurface = useStore((s) => s.moveSurface);
   const splitAndMoveSurface = useStore((s) => s.splitAndMoveSurface);
@@ -350,6 +351,13 @@ export default function PaneWrapper({
     }
   };
 
+  const handleDuplicateSurface = () => {
+    const active = surfaces[activeSurfaceIndex];
+    if (activeWorkspaceId && active) {
+      duplicateSurface(activeWorkspaceId, paneId, active.id);
+    }
+  };
+
   const handleSplitRight = () => {
     if (!activeWorkspaceId) return;
     const { workspaces, updateSplitTree } = useStore.getState();
@@ -525,6 +533,7 @@ export default function PaneWrapper({
         activeSurfaceIndex={activeSurfaceIndex}
         onSelect={handleSelectSurface}
         onClose={handleCloseSurface}
+        onDuplicate={handleDuplicateSurface}
         onNew={handleNewSurface}
         onNewTyped={handleNewSurfaceTyped}
         shells={availableShells}

--- a/src/renderer/components/SplitPane/SurfaceTabBar.tsx
+++ b/src/renderer/components/SplitPane/SurfaceTabBar.tsx
@@ -16,6 +16,8 @@ interface SurfaceTabBarProps {
   onSelect: (index: number) => void;
   onClose: (surfaceId: SurfaceId) => void;
   onNew: () => void;
+  /** Open a copy of the active tab in this pane (`+` dropdown). */
+  onDuplicate?: () => void;
   onNewTyped?: (type: 'terminal' | 'browser' | 'markdown') => void;
   /** Detected shells surfaced in the `+` caret dropdown (PR #43). */
   shells?: ShellInfo[];
@@ -56,6 +58,7 @@ export default function SurfaceTabBar({
   onSelect,
   onClose,
   onNew,
+  onDuplicate,
   onNewTyped,
   shells,
   onNewShell,
@@ -193,6 +196,11 @@ export default function SurfaceTabBar({
     if (onNewTyped) onNewTyped(type);
     else onNew();
   }, [onNewTyped, onNew]);
+
+  const pickDuplicate = useCallback(() => {
+    setOpenMenu(null);
+    onDuplicate?.();
+  }, [onDuplicate]);
 
   const pickShell = useCallback((shell: ShellInfo) => {
     setOpenMenu(null);
@@ -433,6 +441,14 @@ export default function SurfaceTabBar({
         >
           {openMenu === 'new' ? (
             <>
+              {onDuplicate && (
+                <>
+                  <button role="menuitem" onClick={pickDuplicate}>
+                    <span className="surface-tab-menu__icon">⧉</span> Duplicate tab
+                  </button>
+                  <div className="surface-tab-menu__sep" role="separator" />
+                </>
+              )}
               {shells && shells.length > 0 ? (
                 <>
                   {shells.map((shell) => (

--- a/src/renderer/store/surface-slice.ts
+++ b/src/renderer/store/surface-slice.ts
@@ -30,6 +30,13 @@ export interface SurfaceSlice {
   /** Close a surface; if it's the last one in the pane, the pane is removed */
   closeSurface: (workspaceId: WorkspaceId, paneId: PaneId, surfaceId: SurfaceId) => void;
 
+  /**
+   * Open a copy of a surface in the same pane: same type, shell, color and
+   * (current) directory, but a fresh instance. Returns the new SurfaceId, or
+   * null if the source no longer exists.
+   */
+  duplicateSurface: (workspaceId: WorkspaceId, paneId: PaneId, surfaceId: SurfaceId) => SurfaceId | null;
+
   /** Advance to the next surface in the pane (wraps around) */
   nextSurface: (workspaceId: WorkspaceId, paneId: PaneId) => void;
 
@@ -145,6 +152,28 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
 
     updateSplitTree(workspaceId, updatedTree);
     return surfaceId;
+  },
+
+  duplicateSurface(workspaceId, paneId, surfaceId) {
+    const { workspaces } = get();
+    const ws = workspaces.find((w) => w.id === workspaceId);
+    if (!ws) return null;
+
+    const leaf = findLeaf(ws.splitTree, paneId);
+    if (!leaf) return null;
+
+    const src = leaf.surfaces.find((s) => s.id === surfaceId);
+    if (!src) return null;
+
+    // Copy the tab's config, preferring its live directory so the new terminal
+    // opens where the source currently is. Startup commands are intentionally
+    // NOT replayed — duplicating an agent tab shouldn't relaunch the agent.
+    return get().addSurface(workspaceId, paneId, src.type, {
+      shell: src.shell,
+      cwd: src.currentCwd || src.cwd,
+      colorScheme: src.colorScheme,
+      url: src.url,
+    });
   },
 
   closeSurface(workspaceId, paneId, surfaceId) {

--- a/tests/unit/surface-duplicate.test.ts
+++ b/tests/unit/surface-duplicate.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { create } from 'zustand';
+import { createWorkspaceSlice, WorkspaceSlice } from '../../src/renderer/store/workspace-slice';
+import { createSurfaceSlice, SurfaceSlice } from '../../src/renderer/store/surface-slice';
+import { WorkspaceId, PaneId, SurfaceId, SplitNode } from '../../src/shared/types';
+
+type TestStore = WorkspaceSlice & SurfaceSlice;
+
+function makeStore() {
+  return create<TestStore>()((...args) => ({
+    ...createWorkspaceSlice(...args),
+    ...createSurfaceSlice(...args),
+  }));
+}
+
+function leafOf(tree: SplitNode, paneId: PaneId) {
+  if (tree.type === 'leaf') return tree.paneId === paneId ? tree : null;
+  return leafOf(tree.children[0], paneId) ?? leafOf(tree.children[1], paneId);
+}
+
+describe('duplicateSurface', () => {
+  let useStore: ReturnType<typeof makeStore>;
+  let workspaceId: WorkspaceId;
+  let paneId: PaneId;
+
+  beforeEach(() => {
+    useStore = makeStore();
+    workspaceId = useStore.getState().createWorkspace({ title: 'Test WS' });
+    const tree = useStore.getState().workspaces[0].splitTree;
+    paneId = (tree as Extract<SplitNode, { type: 'leaf' }>).paneId;
+  });
+
+  function currentLeaf() {
+    const ws = useStore.getState().workspaces.find((w) => w.id === workspaceId)!;
+    return leafOf(ws.splitTree, paneId)!;
+  }
+
+  it('adds a new surface copying type, shell and colorScheme', () => {
+    const srcId = currentLeaf().surfaces[0].id;
+    useStore.getState().updateSurface(workspaceId, paneId, srcId, {
+      shell: 'pwsh',
+      cwd: 'C:/one',
+      colorScheme: 'prod',
+    });
+
+    const newId = useStore.getState().duplicateSurface(workspaceId, paneId, srcId);
+
+    const surfaces = currentLeaf().surfaces;
+    expect(surfaces).toHaveLength(2);
+    const dup = surfaces.find((s) => s.id === newId)!;
+    expect(dup.id).not.toBe(srcId);
+    expect(dup.type).toBe('terminal');
+    expect(dup.shell).toBe('pwsh');
+    expect(dup.cwd).toBe('C:/one');
+    expect(dup.colorScheme).toBe('prod');
+  });
+
+  it('uses the source live directory (currentCwd) when present', () => {
+    const srcId = currentLeaf().surfaces[0].id;
+    useStore.getState().updateSurface(workspaceId, paneId, srcId, {
+      cwd: 'C:/start',
+      currentCwd: 'C:/start/sub',
+    });
+
+    const newId = useStore.getState().duplicateSurface(workspaceId, paneId, srcId);
+    const dup = currentLeaf().surfaces.find((s) => s.id === newId)!;
+    expect(dup.cwd).toBe('C:/start/sub');
+  });
+
+  it('makes the duplicate the active surface', () => {
+    const srcId = currentLeaf().surfaces[0].id;
+    const newId = useStore.getState().duplicateSurface(workspaceId, paneId, srcId);
+    const leaf = currentLeaf();
+    expect(leaf.surfaces[leaf.activeSurfaceIndex].id).toBe(newId);
+  });
+
+  it('returns null when the source surface does not exist', () => {
+    const newId = useStore.getState().duplicateSurface(workspaceId, paneId, 'surf-missing' as SurfaceId);
+    expect(newId).toBeNull();
+    expect(currentLeaf().surfaces).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Adds a **Duplicate tab** item to the new-tab (`+`) dropdown.

It opens a copy of the current tab in the same pane, reusing its type, shell, color scheme and current working directory, so you get a fresh shell right where you already are. Startup commands are not replayed, so duplicating an agent tab won't relaunch the agent.

Added a `duplicateSurface` store action with unit tests.