### PR TITLE
Add close tabs to the right

### DIFF
--- a/src/renderer/components/SplitPane/PaneWrapper.tsx
+++ b/src/renderer/components/SplitPane/PaneWrapper.tsx
@@ -50,6 +50,7 @@ export default function PaneWrapper({
   const updateSurface = useStore((s) => s.updateSurface);
   const closeSurface = useStore((s) => s.closeSurface);
   const closeOtherSurfaces = useStore((s) => s.closeOtherSurfaces);
+  const closeSurfacesToRight = useStore((s) => s.closeSurfacesToRight);
   const selectSurface = useStore((s) => s.selectSurface);
   const moveSurface = useStore((s) => s.moveSurface);
   const splitAndMoveSurface = useStore((s) => s.splitAndMoveSurface);
@@ -357,6 +358,12 @@ export default function PaneWrapper({
     }
   };
 
+  const handleCloseSurfacesToRight = (surfaceId: SurfaceId) => {
+    if (activeWorkspaceId) {
+      closeSurfacesToRight(activeWorkspaceId, paneId, surfaceId);
+    }
+  };
+
   const handleSplitRight = () => {
     if (!activeWorkspaceId) return;
     const { workspaces, updateSplitTree } = useStore.getState();
@@ -533,6 +540,7 @@ export default function PaneWrapper({
         onSelect={handleSelectSurface}
         onClose={handleCloseSurface}
         onCloseOthers={handleCloseOtherSurfaces}
+        onCloseToRight={handleCloseSurfacesToRight}
         onNew={handleNewSurface}
         onNewTyped={handleNewSurfaceTyped}
         shells={availableShells}

--- a/src/renderer/components/SplitPane/PaneWrapper.tsx
+++ b/src/renderer/components/SplitPane/PaneWrapper.tsx
@@ -49,6 +49,7 @@ export default function PaneWrapper({
   const addSurface = useStore((s) => s.addSurface);
   const updateSurface = useStore((s) => s.updateSurface);
   const closeSurface = useStore((s) => s.closeSurface);
+  const closeOtherSurfaces = useStore((s) => s.closeOtherSurfaces);
   const selectSurface = useStore((s) => s.selectSurface);
   const moveSurface = useStore((s) => s.moveSurface);
   const splitAndMoveSurface = useStore((s) => s.splitAndMoveSurface);
@@ -350,6 +351,12 @@ export default function PaneWrapper({
     }
   };
 
+  const handleCloseOtherSurfaces = (surfaceId: SurfaceId) => {
+    if (activeWorkspaceId) {
+      closeOtherSurfaces(activeWorkspaceId, paneId, surfaceId);
+    }
+  };
+
   const handleSplitRight = () => {
     if (!activeWorkspaceId) return;
     const { workspaces, updateSplitTree } = useStore.getState();
@@ -525,6 +532,7 @@ export default function PaneWrapper({
         activeSurfaceIndex={activeSurfaceIndex}
         onSelect={handleSelectSurface}
         onClose={handleCloseSurface}
+        onCloseOthers={handleCloseOtherSurfaces}
         onNew={handleNewSurface}
         onNewTyped={handleNewSurfaceTyped}
         shells={availableShells}

--- a/src/renderer/components/SplitPane/SurfaceTabBar.tsx
+++ b/src/renderer/components/SplitPane/SurfaceTabBar.tsx
@@ -15,6 +15,8 @@ interface SurfaceTabBarProps {
   activeSurfaceIndex: number;
   onSelect: (index: number) => void;
   onClose: (surfaceId: SurfaceId) => void;
+  /** Close every tab in this pane except the given one (tab context menu). */
+  onCloseOthers?: (surfaceId: SurfaceId) => void;
   onNew: () => void;
   onNewTyped?: (type: 'terminal' | 'browser' | 'markdown') => void;
   /** Detected shells surfaced in the `+` caret dropdown (PR #43). */
@@ -55,6 +57,7 @@ export default function SurfaceTabBar({
   activeSurfaceIndex,
   onSelect,
   onClose,
+  onCloseOthers,
   onNew,
   onNewTyped,
   shells,
@@ -78,6 +81,9 @@ export default function SurfaceTabBar({
   const [insertIndex, setInsertIndex] = useState<number | null>(null);
   const [renamingId, setRenamingId] = useState<SurfaceId | null>(null);
   const [renameValue, setRenameValue] = useState('');
+  // Right-click tab context menu (Rename / Close / Close others).
+  const [ctxMenu, setCtxMenu] = useState<{ surfaceId: SurfaceId; x: number; y: number } | null>(null);
+  const ctxMenuRef = useRef<HTMLDivElement>(null);
   // Which control-cluster dropdown is open, and where to anchor it (issue #34).
   // Menus render through a portal to document.body so the tab bar's
   // `overflow: hidden` can no longer clip them (the old caret-dropdown bug).
@@ -135,6 +141,35 @@ export default function SurfaceTabBar({
     setRenamingId(null);
     setRenameValue('');
   }, []);
+
+  // Start rename for a specific surface (used by the tab context menu)
+  const startRenameFor = useCallback((surfaceId: SurfaceId) => {
+    const surface = surfaces.find((s) => s.id === surfaceId);
+    if (!surface) return;
+    setRenamingId(surface.id);
+    setRenameValue(surface.customTitle || '');
+  }, [surfaces]);
+
+  // Dismiss the tab context menu on outside click, Escape, or viewport change.
+  useEffect(() => {
+    if (!ctxMenu) return;
+    const onDown = (e: MouseEvent) => {
+      if (ctxMenuRef.current?.contains(e.target as Node)) return;
+      setCtxMenu(null);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setCtxMenu(null); };
+    const onViewportChange = () => setCtxMenu(null);
+    document.addEventListener('mousedown', onDown);
+    document.addEventListener('keydown', onKey);
+    window.addEventListener('resize', onViewportChange);
+    window.addEventListener('scroll', onViewportChange, true);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      document.removeEventListener('keydown', onKey);
+      window.removeEventListener('resize', onViewportChange);
+      window.removeEventListener('scroll', onViewportChange, true);
+    };
+  }, [ctxMenu]);
 
   // Listen for keyboard shortcut rename event (only when focused)
   useEffect(() => {
@@ -290,6 +325,11 @@ export default function SurfaceTabBar({
               onDoubleClick={() => {
                 setRenamingId(surface.id);
                 setRenameValue(surface.customTitle || '');
+              }}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setCtxMenu({ surfaceId: surface.id, x: e.clientX, y: e.clientY });
               }}
               draggable={!isRenaming}
               onDragStart={(e) => {
@@ -491,6 +531,44 @@ export default function SurfaceTabBar({
                 </button>
               )}
             </>
+          )}
+        </div>,
+        document.body,
+      )}
+
+      {ctxMenu && createPortal(
+        <div
+          ref={ctxMenuRef}
+          className="ctx-menu"
+          role="menu"
+          style={{
+            left: Math.min(ctxMenu.x, window.innerWidth - 200),
+            top: Math.min(ctxMenu.y, window.innerHeight - 120),
+          }}
+        >
+          <div
+            className="ctx-menu__item"
+            role="menuitem"
+            onClick={() => { startRenameFor(ctxMenu.surfaceId); setCtxMenu(null); }}
+          >
+            Rename
+          </div>
+          <div className="ctx-menu__separator" />
+          <div
+            className="ctx-menu__item ctx-menu__item--danger"
+            role="menuitem"
+            onClick={() => { onClose(ctxMenu.surfaceId); setCtxMenu(null); }}
+          >
+            Close
+          </div>
+          {surfaces.length > 1 && (
+            <div
+              className="ctx-menu__item ctx-menu__item--danger"
+              role="menuitem"
+              onClick={() => { onCloseOthers?.(ctxMenu.surfaceId); setCtxMenu(null); }}
+            >
+              Close others
+            </div>
           )}
         </div>,
         document.body,

--- a/src/renderer/components/SplitPane/SurfaceTabBar.tsx
+++ b/src/renderer/components/SplitPane/SurfaceTabBar.tsx
@@ -17,6 +17,8 @@ interface SurfaceTabBarProps {
   onClose: (surfaceId: SurfaceId) => void;
   /** Close every tab in this pane except the given one (tab context menu). */
   onCloseOthers?: (surfaceId: SurfaceId) => void;
+  /** Close every tab positioned after the given one (tab context menu). */
+  onCloseToRight?: (surfaceId: SurfaceId) => void;
   onNew: () => void;
   onNewTyped?: (type: 'terminal' | 'browser' | 'markdown') => void;
   /** Detected shells surfaced in the `+` caret dropdown (PR #43). */
@@ -58,6 +60,7 @@ export default function SurfaceTabBar({
   onSelect,
   onClose,
   onCloseOthers,
+  onCloseToRight,
   onNew,
   onNewTyped,
   shells,
@@ -568,6 +571,15 @@ export default function SurfaceTabBar({
               onClick={() => { onCloseOthers?.(ctxMenu.surfaceId); setCtxMenu(null); }}
             >
               Close others
+            </div>
+          )}
+          {surfaces.findIndex((s) => s.id === ctxMenu.surfaceId) < surfaces.length - 1 && (
+            <div
+              className="ctx-menu__item ctx-menu__item--danger"
+              role="menuitem"
+              onClick={() => { onCloseToRight?.(ctxMenu.surfaceId); setCtxMenu(null); }}
+            >
+              Close to the right
             </div>
           )}
         </div>,

--- a/src/renderer/store/surface-slice.ts
+++ b/src/renderer/store/surface-slice.ts
@@ -30,6 +30,9 @@ export interface SurfaceSlice {
   /** Close a surface; if it's the last one in the pane, the pane is removed */
   closeSurface: (workspaceId: WorkspaceId, paneId: PaneId, surfaceId: SurfaceId) => void;
 
+  /** Close every other surface in the pane, keeping only `keepSurfaceId` */
+  closeOtherSurfaces: (workspaceId: WorkspaceId, paneId: PaneId, keepSurfaceId: SurfaceId) => void;
+
   /** Advance to the next surface in the pane (wraps around) */
   nextSurface: (workspaceId: WorkspaceId, paneId: PaneId) => void;
 
@@ -185,6 +188,33 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
       activeSurfaceIndex: newActiveIndex,
     });
 
+    updateSplitTree(workspaceId, updatedTree);
+  },
+
+  closeOtherSurfaces(workspaceId, paneId, keepSurfaceId) {
+    const { workspaces, updateSplitTree } = get();
+    const ws = workspaces.find((w) => w.id === workspaceId);
+    if (!ws) return;
+
+    const leaf = findLeaf(ws.splitTree, paneId);
+    if (!leaf) return;
+
+    const keep = leaf.surfaces.find((s) => s.id === keepSurfaceId);
+    if (!keep) return;
+    if (leaf.surfaces.length === 1) return;
+
+    // Reap the shells we're dropping and remember them for Ctrl+Shift+T,
+    // mirroring the bookkeeping in closeSurface (issues #64, #65).
+    for (const s of leaf.surfaces) {
+      if (s.id === keepSurfaceId) continue;
+      pushClosedSurface(s);
+      killSurfacePty(s);
+    }
+
+    const updatedTree = patchLeaf(ws.splitTree, paneId, {
+      surfaces: [keep],
+      activeSurfaceIndex: 0,
+    });
     updateSplitTree(workspaceId, updatedTree);
   },
 

--- a/src/renderer/store/surface-slice.ts
+++ b/src/renderer/store/surface-slice.ts
@@ -33,6 +33,9 @@ export interface SurfaceSlice {
   /** Close every other surface in the pane, keeping only `keepSurfaceId` */
   closeOtherSurfaces: (workspaceId: WorkspaceId, paneId: PaneId, keepSurfaceId: SurfaceId) => void;
 
+  /** Close every surface positioned after `fromSurfaceId` in the pane */
+  closeSurfacesToRight: (workspaceId: WorkspaceId, paneId: PaneId, fromSurfaceId: SurfaceId) => void;
+
   /** Advance to the next surface in the pane (wraps around) */
   nextSurface: (workspaceId: WorkspaceId, paneId: PaneId) => void;
 
@@ -214,6 +217,33 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
     const updatedTree = patchLeaf(ws.splitTree, paneId, {
       surfaces: [keep],
       activeSurfaceIndex: 0,
+    });
+    updateSplitTree(workspaceId, updatedTree);
+  },
+
+  closeSurfacesToRight(workspaceId, paneId, fromSurfaceId) {
+    const { workspaces, updateSplitTree } = get();
+    const ws = workspaces.find((w) => w.id === workspaceId);
+    if (!ws) return;
+
+    const leaf = findLeaf(ws.splitTree, paneId);
+    if (!leaf) return;
+
+    const idx = leaf.surfaces.findIndex((s) => s.id === fromSurfaceId);
+    if (idx === -1 || idx === leaf.surfaces.length - 1) return;
+
+    // Reap the shells to the right and remember them for Ctrl+Shift+T,
+    // mirroring the bookkeeping in closeSurface (issues #64, #65).
+    for (const s of leaf.surfaces.slice(idx + 1)) {
+      pushClosedSurface(s);
+      killSurfacePty(s);
+    }
+
+    const newSurfaces = leaf.surfaces.slice(0, idx + 1);
+    const newActiveIndex = Math.min(leaf.activeSurfaceIndex, newSurfaces.length - 1);
+    const updatedTree = patchLeaf(ws.splitTree, paneId, {
+      surfaces: newSurfaces,
+      activeSurfaceIndex: newActiveIndex,
     });
     updateSplitTree(workspaceId, updatedTree);
   },

--- a/tests/unit/surface-slice.test.ts
+++ b/tests/unit/surface-slice.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { create } from 'zustand';
+import { createWorkspaceSlice, WorkspaceSlice } from '../../src/renderer/store/workspace-slice';
+import { createSurfaceSlice, SurfaceSlice } from '../../src/renderer/store/surface-slice';
+import { WorkspaceId, PaneId, SurfaceId, SplitNode } from '../../src/shared/types';
+
+type TestStore = WorkspaceSlice & SurfaceSlice;
+
+function makeStore() {
+  return create<TestStore>()((...args) => ({
+    ...createWorkspaceSlice(...args),
+    ...createSurfaceSlice(...args),
+  }));
+}
+
+function leafOf(tree: SplitNode, paneId: PaneId) {
+  if (tree.type === 'leaf') return tree.paneId === paneId ? tree : null;
+  return leafOf(tree.children[0], paneId) ?? leafOf(tree.children[1], paneId);
+}
+
+describe('surface-slice', () => {
+  let useStore: ReturnType<typeof makeStore>;
+  let workspaceId: WorkspaceId;
+  let paneId: PaneId;
+
+  beforeEach(() => {
+    useStore = makeStore();
+    workspaceId = useStore.getState().createWorkspace({ title: 'Test WS' });
+    const tree = useStore.getState().workspaces[0].splitTree;
+    paneId = (tree as Extract<SplitNode, { type: 'leaf' }>).paneId;
+  });
+
+  function currentLeaf() {
+    const ws = useStore.getState().workspaces.find((w) => w.id === workspaceId)!;
+    return leafOf(ws.splitTree, paneId)!;
+  }
+
+  describe('renameSurface', () => {
+    it('sets customTitle on the target surface', () => {
+      const id = currentLeaf().surfaces[0].id;
+      useStore.getState().renameSurface(workspaceId, paneId, id, 'My Tab');
+      expect(currentLeaf().surfaces[0].customTitle).toBe('My Tab');
+    });
+
+    it('clears customTitle when given an empty string', () => {
+      const id = currentLeaf().surfaces[0].id;
+      useStore.getState().renameSurface(workspaceId, paneId, id, 'X');
+      useStore.getState().renameSurface(workspaceId, paneId, id, '');
+      expect(currentLeaf().surfaces[0].customTitle).toBeUndefined();
+    });
+  });
+
+  describe('closeOtherSurfaces', () => {
+    it('keeps only the target surface and drops the rest', () => {
+      const keep = currentLeaf().surfaces[0].id;
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      expect(currentLeaf().surfaces).toHaveLength(3);
+
+      useStore.getState().closeOtherSurfaces(workspaceId, paneId, keep);
+
+      const surfaces = currentLeaf().surfaces;
+      expect(surfaces).toHaveLength(1);
+      expect(surfaces[0].id).toBe(keep);
+      expect(currentLeaf().activeSurfaceIndex).toBe(0);
+    });
+
+    it('is a no-op when the target is the only surface', () => {
+      const only = currentLeaf().surfaces[0].id;
+      useStore.getState().closeOtherSurfaces(workspaceId, paneId, only);
+      expect(currentLeaf().surfaces).toHaveLength(1);
+      expect(currentLeaf().surfaces[0].id).toBe(only);
+    });
+
+    it('does nothing when the target surface does not exist', () => {
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      expect(currentLeaf().surfaces).toHaveLength(2);
+      useStore.getState().closeOtherSurfaces(workspaceId, paneId, 'surf-missing' as SurfaceId);
+      expect(currentLeaf().surfaces).toHaveLength(2);
+    });
+  });
+});

--- a/tests/unit/surface-slice.test.ts
+++ b/tests/unit/surface-slice.test.ts
@@ -79,4 +79,38 @@ describe('surface-slice', () => {
       expect(currentLeaf().surfaces).toHaveLength(2);
     });
   });
+
+  describe('closeSurfacesToRight', () => {
+    it('closes only the surfaces after the target', () => {
+      const first = currentLeaf().surfaces[0].id;
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      const second = currentLeaf().surfaces[1].id;
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      expect(currentLeaf().surfaces).toHaveLength(4);
+
+      useStore.getState().closeSurfacesToRight(workspaceId, paneId, second);
+
+      const ids = currentLeaf().surfaces.map((s) => s.id);
+      expect(ids).toEqual([first, second]);
+    });
+
+    it('is a no-op when the target is the last surface', () => {
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      const last = currentLeaf().surfaces[1].id;
+      useStore.getState().closeSurfacesToRight(workspaceId, paneId, last);
+      expect(currentLeaf().surfaces).toHaveLength(2);
+    });
+
+    it('clamps the active index to a surface that still exists', () => {
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      const first = currentLeaf().surfaces[0].id;
+      // active index is 2 (last added); closing to the right of the first drops it
+      useStore.getState().closeSurfacesToRight(workspaceId, paneId, first);
+      const leaf = currentLeaf();
+      expect(leaf.surfaces).toHaveLength(1);
+      expect(leaf.activeSurfaceIndex).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
Adds a **Close to the right** item to the tab context menu. It closes every tab positioned after the one you clicked, and only shows when there are tabs to the right.

Added a `closeSurfacesToRight` store action with unit tests.

Note: this builds on the tab context menu from #103, so it's best merged after that PR.