### PR TITLE
Show the file name on markdown tabs instead of a generic "Markdown" label

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -606,7 +606,7 @@ app.whenReady().then(() => {
             const win = BrowserWindow.getAllWindows()[0];
             if (!win || win.isDestroyed()) { respondError(-32000, 'No window'); return; }
             await win.webContents.executeJavaScript(
-              `window.__wmux_setMarkdownContent?.(${JSON.stringify(request.params?.surfaceId || '')}, ${JSON.stringify(content)})`
+              `window.__wmux_setMarkdownContent?.(${JSON.stringify(request.params?.surfaceId || '')}, ${JSON.stringify(content)}, ${JSON.stringify(path.basename(filePath))})`
             );
             respond({ ok: true, length: content.length });
           } catch (err: any) { respondError(-32000, err.message); }

--- a/src/renderer/components/CommandPalette/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette/CommandPalette.tsx
@@ -96,7 +96,9 @@ export default function CommandPalette({ onClose, onAction }: CommandPaletteProp
             const created = (window as any).__wmux_createSurface?.({ type: 'markdown' });
             const surfaceId = created?.surfaceId as string | undefined;
             if (surfaceId) {
-              useStore.getState().setMarkdownContent(surfaceId as SurfaceId, res.content);
+              // Derive the basename for the tab label (renderer has no `path`).
+              const fileName = String(res.filePath || '').replace(/\\/g, '/').split('/').pop() || undefined;
+              useStore.getState().setMarkdownContent(surfaceId as SurfaceId, res.content, fileName);
             }
           } catch {
             // Dialog/read failures are surfaced via the returned { error }; ignore here.

--- a/src/renderer/components/SplitPane/surface-label.ts
+++ b/src/renderer/components/SplitPane/surface-label.ts
@@ -33,7 +33,7 @@ export function getSurfaceLabel(surface: SurfaceRef, agentLabel?: string, worksp
     case 'browser':
       return 'Browser';
     case 'markdown':
-      return 'Markdown';
+      return surface.markdownFileName || 'Markdown';
     case 'diff':
       return 'Diff';
     default:

--- a/src/renderer/pipe-bridge.ts
+++ b/src/renderer/pipe-bridge.ts
@@ -350,11 +350,12 @@ export function initPipeBridge(): void {
 
   // ─── Markdown ───────────────────────────────────────────────────────────────
 
-  w.__wmux_setMarkdownContent = (surfaceId: string, markdown: string) => {
+  w.__wmux_setMarkdownContent = (surfaceId: string, markdown: string, fileName?: string) => {
     // Persist into the store so MarkdownPane (re)renders the content. The old
     // `wmux:markdown-update` CustomEvent had no listener, so content never
-    // displayed (issue #54).
-    useStore.getState().setMarkdownContent(surfaceId as SurfaceId, markdown ?? '');
+    // displayed (issue #54). `fileName`, when the content came from a file, is
+    // used as the tab label so multiple markdown tabs stay distinguishable.
+    useStore.getState().setMarkdownContent(surfaceId as SurfaceId, markdown ?? '', fileName);
     return { ok: true };
   };
 

--- a/src/renderer/store/surface-slice.ts
+++ b/src/renderer/store/surface-slice.ts
@@ -77,7 +77,7 @@ export interface SurfaceSlice {
    * workspaces/panes (issue #54). Callers from the pipe bridge only know the
    * surfaceId, so this locates the owning pane itself.
    */
-  setMarkdownContent: (surfaceId: SurfaceId, content: string) => void;
+  setMarkdownContent: (surfaceId: SurfaceId, content: string, fileName?: string) => void;
 
   /** Split a pane and move a surface into the new pane (drag to edge) */
   splitAndMoveSurface: (
@@ -424,13 +424,17 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
     updateSplitTree(workspaceId, updatedTree);
   },
 
-  setMarkdownContent(surfaceId, content) {
+  setMarkdownContent(surfaceId, content, fileName) {
     const { workspaces, updateSurface } = get();
     for (const ws of workspaces) {
       for (const paneId of getAllPaneIds(ws.splitTree)) {
         const leaf = findLeaf(ws.splitTree, paneId);
         if (leaf?.surfaces.some((s) => s.id === surfaceId)) {
-          updateSurface(ws.id, paneId, surfaceId, { markdownContent: content });
+          const patch: Partial<SurfaceRef> = { markdownContent: content };
+          // Only overwrite the tab label when the content came from a file;
+          // content-only setters (e.g. `wmux markdown set`) leave it untouched.
+          if (fileName) patch.markdownFileName = fileName;
+          updateSurface(ws.id, paneId, surfaceId, patch);
           return;
         }
       }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -29,6 +29,10 @@ export interface SurfaceRef {
   /** Rendered markdown content for a `markdown` surface (issue #54). Persisted so
    *  the content survives split-tree restructures that remount the pane. */
   markdownContent?: string;
+  /** Basename of the file backing a `markdown` surface, shown as the tab label
+   *  instead of the generic "Markdown" so multiple markdown tabs are
+   *  distinguishable. Only set when the surface was populated from a file. */
+  markdownFileName?: string;
 }
 
 /**

--- a/tests/unit/markdown-content.test.ts
+++ b/tests/unit/markdown-content.test.ts
@@ -59,6 +59,21 @@ describe('surface-slice: setMarkdownContent (issue #54)', () => {
     ).not.toThrow();
   });
 
+  it('records the file name for the tab label when one is provided', () => {
+    const surfaceId = useStore.getState().addSurface(workspaceId, paneId, 'markdown');
+    useStore.getState().setMarkdownContent(surfaceId, '# Doc', 'GUIDE.md');
+    expect(getSurface(surfaceId)?.markdownContent).toBe('# Doc');
+    expect(getSurface(surfaceId)?.markdownFileName).toBe('GUIDE.md');
+  });
+
+  it('leaves the file name untouched when content is set without one', () => {
+    const surfaceId = useStore.getState().addSurface(workspaceId, paneId, 'markdown');
+    useStore.getState().setMarkdownContent(surfaceId, '# Doc', 'GUIDE.md');
+    useStore.getState().setMarkdownContent(surfaceId, 'updated body');
+    expect(getSurface(surfaceId)?.markdownContent).toBe('updated body');
+    expect(getSurface(surfaceId)?.markdownFileName).toBe('GUIDE.md');
+  });
+
   it('finds the target surface in a non-first pane', () => {
     const ws = useStore.getState().workspaces.find((w) => w.id === workspaceId)!;
     const newPaneId = 'pane-second' as PaneId;

--- a/tests/unit/surface-label.test.ts
+++ b/tests/unit/surface-label.test.ts
@@ -45,6 +45,26 @@ describe('surface labels', () => {
     expect(getSurfaceLabel(surface('surf-diff', { type: 'diff' }))).toBe('Diff');
   });
 
+  it('shows the markdown file name when the surface was opened from a file', () => {
+    expect(
+      getSurfaceLabel(surface('surf-markdown', { type: 'markdown', markdownFileName: 'README.md' })),
+    ).toBe('README.md');
+  });
+
+  it('falls back to "Markdown" for a markdown surface without a file name', () => {
+    expect(getSurfaceLabel(surface('surf-markdown', { type: 'markdown', markdownContent: '# hi' }))).toBe(
+      'Markdown',
+    );
+  });
+
+  it('prefers a custom title over the markdown file name', () => {
+    expect(
+      getSurfaceLabel(
+        surface('surf-markdown', { type: 'markdown', customTitle: 'Docs', markdownFileName: 'README.md' }),
+      ),
+    ).toBe('Docs');
+  });
+
   it('shows the folder name from currentCwd for terminal labels', () => {
     expect(
       getSurfaceLabel(


### PR DESCRIPTION
## Problem

When a markdown file is opened in a tab, the tab always reads **"Markdown"** regardless of which document it holds. With several markdown tabs open in a pane they're indistinguishable — you can't tell `README.md` from `CHANGELOG.md` without clicking through them.

## Change

Markdown tabs now show the backing file's **basename** (e.g. `README.md`) as their label. When a surface has no file behind it — content pushed via `wmux markdown set --content` — it keeps the generic `Markdown` label. An explicit custom title still wins.

### How it works

- Add `markdownFileName?: string` to `SurfaceRef`.
- Thread an optional `fileName` through `setMarkdownContent` and the `__wmux_setMarkdownContent` renderer bridge. It's populated from the file basename at every file-loading entry point:
  - the `markdown.load_file` pipe handler — covers `wmux markdown <file>` and `wmux markdown set <id> --file <path>`
  - the command-palette "Open Markdown File" picker
- Content-only setters (`markdown.set_content`) don't pass a name, so they leave the label untouched.
- `getSurfaceLabel` returns `markdownFileName` for markdown surfaces, still preferring an explicit `customTitle`.

## Tests

- `tests/unit/surface-label.test.ts`: file name shown, fallback to "Markdown", custom title precedence.
- `tests/unit/markdown-content.test.ts`: file name recorded when provided, left untouched on a content-only update.

All affected unit tests pass; lint clean; `npm run build:main` compiles. (The pre-existing `pty-manager` test failure is an unrelated node-pty native-spawn issue on Windows and does not touch this change.)