### PR TITLE
fix(cli): resolve pipe replies immediately instead of waiting out the 5s timer

### DIFF
--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -61,10 +61,17 @@ function sendV1(command: string): Promise<string> {
       client.write(line + '\n');
     });
     let data = '';
-    client.on('data', (chunk) => { data += chunk.toString(); });
-    client.on('end', () => resolve(data.trim()));
-    client.on('error', (err) => reject(err));
-    setTimeout(() => { client.end(); resolve(data.trim()); }, 5000);
+    const timer = setTimeout(() => { client.end(); resolve(data.trim()); }, 5000);
+    const finish = () => { clearTimeout(timer); resolve(data.trim()); };
+    client.on('data', (chunk) => {
+      data += chunk.toString();
+      // V1 replies are a single newline-terminated line (pong/ok/unauthorized).
+      // Resolve as soon as it arrives instead of blocking on the server closing
+      // the socket (it doesn't) — otherwise every call waited the full 5s timer.
+      if (data.includes('\n')) { client.end(); finish(); }
+    });
+    client.on('end', finish);
+    client.on('error', (err) => { clearTimeout(timer); reject(err); });
   });
 }
 
@@ -81,9 +88,11 @@ function sendV2(method: string, params: Record<string, any> = {}): Promise<any> 
       client.write(request + '\n');
     });
     let data = '';
+    const timer = setTimeout(() => { client.end(); reject(new Error('timeout')); }, 5000);
     client.on('data', (chunk) => {
       data += chunk.toString();
       if (data.includes('\n')) {
+        clearTimeout(timer);
         client.end();
         try {
           const response = JSON.parse(data.trim());
@@ -92,8 +101,7 @@ function sendV2(method: string, params: Record<string, any> = {}): Promise<any> 
         } catch { resolve(data.trim()); }
       }
     });
-    client.on('error', (err) => reject(err));
-    setTimeout(() => { client.end(); reject(new Error('timeout')); }, 5000);
+    client.on('error', (err) => { clearTimeout(timer); reject(err); });
   });
 }
 


### PR DESCRIPTION
## Problem

Every `wmux <cmd>` lingers ~5 seconds. It isn't the network, the pipe, or node start-up — it's two things in the CLI's pipe client (`src/cli/wmux.ts`):

1. **`sendV1` only resolved on the socket's `'end'` event**, but the pipe server replies with `socket.write()` and never half-closes the connection (`pipe-server.ts` `ping`/`ok`/`unauthorized` and the V2 responders all `write`, never `end`). So a V1 call — `ping`, and every shell-integration state report — blocked until the 5000 ms fallback timer fired.
2. **That fallback `setTimeout` was never cleared on resolve.** So even `sendV2` (which does resolve on the reply newline) left a pending 5 s timer holding the Node event loop open — the process printed its result immediately but didn't *exit* for 5 s.

## Fix

Client-side only, no server change (so there's no risk to a batched or multi-reply V1 sender):

- `sendV1` now resolves as soon as the newline-terminated reply arrives, mirroring what `sendV2` already does, instead of waiting for the server to close.
- Both `sendV1` and `sendV2` capture the timer handle and `clearTimeout` it on every settle path.

No protocol change; the `PUBLIC_V2_METHODS` allowlist and auth are untouched.

## Verification

Measured against a mock server that reproduces the exact reply behavior (writes the reply line, never closes the socket):

| | before | after |
|---|---|---|
| `wmux ping` (V1) | **4.99 s** | **0.02 s** |
| `wmux identify` (V2) | lingered ~5 s before exit | **0.02 s** |

`npm run build:main` clean; full test suite green (the one unrelated `pty-manager` failure is a native-module issue in a non-Windows CI sandbox).

Happy to adjust naming/scope or add a committed regression test (a subprocess-vs-mock-server harness) if you'd like one.
