### PR TITLE
fix(pipe): report the real app version from system.identify

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -398,7 +398,7 @@ app.whenReady().then(() => {
 
     switch (request.method) {
       case 'system.identify':
-        respond({ name: 'wmux', version: '0.5.0', platform: 'win32' });
+        respond({ name: 'wmux', version: app.getVersion(), platform: 'win32' });
         break;
       case 'system.capabilities':
         respond({ protocols: ['v1', 'v2'], features: ['workspaces', 'splits', 'notifications'] });


### PR DESCRIPTION
## Problem

`system.identify` returns a hardcoded `version: '0.5.0'` (`src/main/index.ts`), which is ~22 releases stale against the current `0.27.2`. Any client that keys on the handshake version — instance detection, and cmux-ecosystem tooling that reads `system.identify` — sees the wrong number.

## Fix

Return `app.getVersion()` — already the source of truth used elsewhere in the same file (e.g. `handleVersionChange(app.getVersion())` at `index.ts:335`, and the `SYSTEM_GET_VERSION` IPC handler). One line, no new imports (`app` is already imported).

`npm run build:main` clean.
