### PR TITLE
fix(terminal): Shift+Enter inserts a newline in TUI apps (Claude Code)

### DIFF
--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -692,6 +692,25 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
         })();
         return false; // Prevent default — we handle paste ourselves
       }
+      // Shift+Enter → newline for TUI apps (Claude Code, etc). xterm sends a
+      // plain \r for BOTH Enter and Shift+Enter, so the app can't tell them
+      // apart and treats Shift+Enter as submit. Emit ESC+CR — the same sequence
+      // Alt/Option+Enter produces and that Claude Code's /terminal-setup wires
+      // up — so Shift+Enter inserts a newline instead of submitting. Excludes
+      // Ctrl/Alt/Meta so Ctrl+Shift+Enter (zoom pane) is left untouched.
+      if (
+        event.type === 'keydown' &&
+        event.key === 'Enter' &&
+        event.shiftKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.metaKey
+      ) {
+        if (ptyIdRef.current) {
+          window.wmux.pty.write(ptyIdRef.current, '\x1b\r');
+        }
+        return false;
+      }
       return true;
     });
 


### PR DESCRIPTION
## Problem

In a wmux terminal running Claude Code, **Shift+Enter does not insert a newline** — it submits the prompt instead. This works in cmux but was broken in wmux.

## Root cause

xterm.js emits a plain `\r` (carriage return) for **both** Enter and Shift+Enter, so a TUI app can't distinguish them and treats Shift+Enter as submit. wmux's custom key handler in `useTerminal.ts` had no mapping for Shift+Enter.

Claude Code recognizes `ESC + CR` (`\x1b\r`) as a newline — the same sequence Alt/Option+Enter produces, and exactly what Claude Code's `/terminal-setup` configures for iTerm2/VSCode.

## Fix

Intercept Shift+Enter in the terminal's `attachCustomKeyEventHandler` and write `\x1b\r` to the PTY, returning `false` to suppress xterm's default `\r`.

- Excludes Ctrl/Alt/Meta, so **Ctrl+Shift+Enter (zoom pane)** and Alt+Enter are left untouched.
- No effect on plain Enter (submit) behavior.

## Testing

- `npm run build:renderer` passes.
- Manual: in Claude Code, Shift+Enter now inserts a newline; Enter still submits; Ctrl+Shift+Enter still zooms the pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)