### PR TITLE
feat(browser): configurable dev-server ports + fix auto-open selection

### DIFF
--- a/src/main/user-config.ts
+++ b/src/main/user-config.ts
@@ -27,6 +27,10 @@
  *   [appearance]
  *   ui-theme = "light"   # light | dark | system (issue #67)
  *
+ *   [browser]
+ *   dev-ports = [8501, 4321]   # extra dev-server ports, merged with built-in defaults
+ *   auto-open = true           # auto-navigate the browser to a newly-detected dev port
+ *
  * File-wins-at-startup, app-wins-at-runtime: this data seeds the store
  * on boot; users can still tweak via the Settings UI afterwards.
  * A `wmux reload-config` command re-applies the file over runtime state.
@@ -61,6 +65,13 @@ export interface UserConfig {
   /** App UI theme (issue #67) — separate from the terminal color scheme. */
   appearance?: {
     uiTheme?: UiTheme;
+  };
+  /** Browser surface behavior — dev-server port detection & auto-navigation. */
+  browser?: {
+    /** Extra ports (merged with the built-in defaults) that count as dev servers. */
+    devPorts?: number[];
+    /** Auto-navigate the workspace browser to a newly-detected dev port (default true). */
+    autoOpen?: boolean;
   };
   /** Absolute path the config was read from (for diagnostics). */
   path?: string;
@@ -123,6 +134,15 @@ function asStringArray(v: TomlValue | undefined): string[] | undefined {
   const out: string[] = [];
   for (const item of v) {
     if (typeof item === 'string') out.push(item);
+  }
+  return out.length ? out : undefined;
+}
+
+function asNumberArray(v: TomlValue | undefined): number[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out: number[] = [];
+  for (const item of v) {
+    if (typeof item === 'number' && Number.isFinite(item)) out.push(item);
   }
   return out.length ? out : undefined;
 }
@@ -218,6 +238,34 @@ function mapAppearanceSection(root: TomlTable, errors: string[]): NonNullable<Us
   return undefined;
 }
 
+// Browser dev-port detection: `[browser] dev-ports = [...]`, `auto-open = bool`.
+function mapBrowserSection(root: TomlTable, errors: string[]): NonNullable<UserConfig['browser']> | undefined {
+  const browser = asTable(root.browser);
+  if (!browser) return undefined;
+
+  const out: NonNullable<UserConfig['browser']> = {};
+
+  const devPortsRaw = browser['dev-ports'] ?? browser.devPorts;
+  if (devPortsRaw !== undefined) {
+    const nums = asNumberArray(devPortsRaw);
+    if (nums) {
+      // Keep integer ports in the valid TCP range; drop the rest with a warning.
+      const valid = nums.filter(p => Number.isInteger(p) && p >= 1 && p <= 65535);
+      if (valid.length) out.devPorts = valid;
+      if (valid.length !== nums.length) {
+        errors.push('browser.dev-ports: dropped entries outside 1-65535 or non-integer');
+      }
+    } else {
+      errors.push('browser.dev-ports: expected an array of port numbers');
+    }
+  }
+
+  const autoOpen = asBool(browser['auto-open'] ?? browser.autoOpen);
+  if (autoOpen !== undefined) out.autoOpen = autoOpen;
+
+  return Object.keys(out).length ? out : undefined;
+}
+
 function mapToConfig(root: TomlTable, errors: string[]): UserConfig {
   const out: UserConfig = {};
 
@@ -226,6 +274,9 @@ function mapToConfig(root: TomlTable, errors: string[]): UserConfig {
 
   const appearance = mapAppearanceSection(root, errors);
   if (appearance) out.appearance = appearance;
+
+  const browser = mapBrowserSection(root, errors);
+  if (browser) out.browser = browser;
 
   return out;
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,6 +4,7 @@ import { useStore } from './store';
 import { PaneId, SurfaceId, WorkspaceId, WorkspaceInfo, SplitNode } from '../shared/types';
 import SplitContainer from './components/SplitPane/SplitContainer';
 import { updateRatio, getAllPaneIds, findLeaf, replaceSoleTerminalSurface } from './store/split-utils';
+import { DEFAULT_DEV_PORTS, mergeDevPorts, matchDevPorts, firstNewDevPort } from './dev-ports';
 import { aggregateProgress } from './store/progress-slice';
 import Sidebar from './components/Sidebar/Sidebar';
 import Titlebar from './components/Titlebar/Titlebar';
@@ -71,7 +72,19 @@ function findBottomPane(node: SplitNode): PaneId | null {
 // adds the in-app bell entry and raises the OS toast (via the renderer → main
 // NOTIFICATION_FIRE chokepoint).
 
-const DEV_PORTS = [3000, 3001, 4000, 4200, 5000, 5173, 5174, 8000, 8080, 8888];
+// Effective runtime values — seeded from the built-in defaults, then widened/
+// toggled by ~/.wmux/config.toml at startup and on `wmux reload-config`.
+let activeDevPorts: number[] = DEFAULT_DEV_PORTS;
+let autoOpenDevPort = true;
+
+/** Apply `~/.wmux/config.toml`'s `[browser]` section: dev-port detection + auto-open. */
+function applyUserConfigBrowser(browser: any): void {
+  if (!browser) return;
+  if (Array.isArray(browser.devPorts) && browser.devPorts.length) {
+    activeDevPorts = mergeDevPorts(DEFAULT_DEV_PORTS, browser.devPorts);
+  }
+  if (typeof browser.autoOpen === 'boolean') autoOpenDevPort = browser.autoOpen;
+}
 
 type StoreAction = (...args: any[]) => void;
 type MetaDeps = {
@@ -144,13 +157,17 @@ function handlePortsUpdate(cmd: any, updateWorkspaceMetadata: StoreAction): void
   try {
     const portsByPid = JSON.parse(cmd.args?.[0] || '{}');
     const allPorts = Object.values(portsByPid).flat() as number[];
-    const devPorts = allPorts.filter((p: number) => DEV_PORTS.includes(p));
+    const devPorts = matchDevPorts(allPorts, activeDevPorts);
     if (devPorts.length > 0) {
       const currentWs = useStore.getState().activeWorkspaceId;
       const ws = useStore.getState().workspaces.find(w => w.id === currentWs);
-      // Only auto-navigate the browser to a NEW dev port.
-      if (currentWs && !(ws?.ports || []).includes(devPorts[0])) {
-        window.wmux?.browser?.navigate?.(`browser-${currentWs}`, `http://localhost:${devPorts[0]}`);
+      // Auto-navigate to a newly-appeared dev port — one this workspace hasn't seen
+      // yet — rather than blindly devPorts[0]. Otherwise a freshly-started server
+      // never opens when other recognized ports are already listening (netstat order
+      // is arbitrary), and the guard permanently suppresses navigation thereafter.
+      const newPort = firstNewDevPort(devPorts, ws?.ports || []);
+      if (autoOpenDevPort && currentWs && newPort !== undefined) {
+        window.wmux?.browser?.navigate?.(`browser-${currentWs}`, `http://localhost:${newPort}`);
       }
     }
     for (const ws of useStore.getState().workspaces) {
@@ -484,6 +501,7 @@ export default function App() {
     const apply = (result: any) => {
       const state = useStore.getState();
       applyUserConfigTerminal(state, result?.terminal);
+      applyUserConfigBrowser(result?.browser);
 
       // App UI theme override (issue #67): `[appearance] ui-theme = "..."`.
       const uiTheme = result?.appearance?.uiTheme;

--- a/src/renderer/dev-ports.ts
+++ b/src/renderer/dev-ports.ts
@@ -1,0 +1,38 @@
+/**
+ * dev-ports.ts — Pure helpers for dev-server port detection.
+ *
+ * wmux auto-navigates a workspace's browser to a detected dev-server port. The
+ * recognized set is the built-in defaults plus any the user adds via
+ * `[browser] dev-ports = [...]` in ~/.wmux/config.toml. Kept separate from
+ * App.tsx so the logic is unit-testable without the React/Electron surface.
+ */
+
+/** Built-in dev-server ports that trigger browser auto-navigation. */
+export const DEFAULT_DEV_PORTS = [3000, 3001, 4000, 4200, 5000, 5173, 5174, 8000, 8080, 8888];
+
+/**
+ * Merge user-configured dev ports with the built-in defaults.
+ * Additive and de-duped: configured ports JOIN the defaults (order preserved,
+ * defaults first) rather than replacing them, so adding one port never drops
+ * the sensible built-ins. An empty/absent config leaves the defaults untouched.
+ */
+export function mergeDevPorts(defaults: number[], configured?: number[] | null): number[] {
+  if (!Array.isArray(configured) || configured.length === 0) return defaults;
+  return Array.from(new Set([...defaults, ...configured]));
+}
+
+/** Filter a set of detected ports down to those recognized as dev-server ports. */
+export function matchDevPorts(allPorts: number[], activeDevPorts: number[]): number[] {
+  return allPorts.filter((p) => activeDevPorts.includes(p));
+}
+
+/**
+ * Pick which recognized dev port to auto-open: the first one the workspace hasn't
+ * seen yet. Diffing the whole set against the known ports — rather than blindly
+ * taking index 0 — means a freshly-started server opens even when other recognized
+ * ports are already listening (netstat order is arbitrary). Returns undefined when
+ * nothing is new, so an already-open port never re-navigates the browser.
+ */
+export function firstNewDevPort(devPorts: number[], knownPorts: number[]): number | undefined {
+  return devPorts.find((p) => !knownPorts.includes(p));
+}

--- a/tests/unit/dev-ports.test.ts
+++ b/tests/unit/dev-ports.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_DEV_PORTS, mergeDevPorts, matchDevPorts, firstNewDevPort } from '../../src/renderer/dev-ports';
+
+describe('mergeDevPorts', () => {
+  it('returns the defaults unchanged when no config is given', () => {
+    expect(mergeDevPorts(DEFAULT_DEV_PORTS)).toBe(DEFAULT_DEV_PORTS);
+    expect(mergeDevPorts(DEFAULT_DEV_PORTS, [])).toBe(DEFAULT_DEV_PORTS);
+    expect(mergeDevPorts(DEFAULT_DEV_PORTS, null)).toBe(DEFAULT_DEV_PORTS);
+  });
+
+  it('adds a configured port on top of the defaults (additive, not replacing)', () => {
+    const merged = mergeDevPorts(DEFAULT_DEV_PORTS, [8501]);
+    // Every default is still present...
+    for (const p of DEFAULT_DEV_PORTS) expect(merged).toContain(p);
+    // ...plus the new one.
+    expect(merged).toContain(8501);
+    expect(merged.length).toBe(DEFAULT_DEV_PORTS.length + 1);
+  });
+
+  it('de-dupes a configured port that overlaps a default', () => {
+    const merged = mergeDevPorts(DEFAULT_DEV_PORTS, [3000, 8501]);
+    expect(merged.filter((p) => p === 3000).length).toBe(1);
+    expect(merged).toContain(8501);
+    expect(merged.length).toBe(DEFAULT_DEV_PORTS.length + 1);
+  });
+});
+
+describe('matchDevPorts', () => {
+  it('matches a configured custom port once it is merged in (the 8501 case)', () => {
+    const active = mergeDevPorts(DEFAULT_DEV_PORTS, [8501]);
+    expect(matchDevPorts([8501], active)).toEqual([8501]);
+  });
+
+  it('does NOT match a custom port against the bare defaults', () => {
+    expect(matchDevPorts([8501], DEFAULT_DEV_PORTS)).toEqual([]);
+  });
+
+  it('filters a mixed set down to only recognized dev ports', () => {
+    const active = mergeDevPorts(DEFAULT_DEV_PORTS, [8501]);
+    expect(matchDevPorts([22, 443, 5173, 8501, 61000], active)).toEqual([5173, 8501]);
+  });
+
+  it('returns empty when nothing matches', () => {
+    expect(matchDevPorts([22, 443, 61000], DEFAULT_DEV_PORTS)).toEqual([]);
+  });
+});
+
+describe('firstNewDevPort', () => {
+  it('returns the first recognized port the workspace has not seen yet', () => {
+    expect(firstNewDevPort([3000, 3001, 8501], [3000, 3001])).toBe(8501);
+  });
+
+  // Regression: on a busy machine several recognized ports are already listening,
+  // so netstat lists a pre-existing one first. Blindly using index 0 meant a
+  // freshly-started server (8501) never opened. It must still be picked.
+  it('opens a newly-appeared port even when other dev ports already listen', () => {
+    expect(firstNewDevPort([3001, 3000, 8000, 8501], [3001, 3000, 8000])).toBe(8501);
+  });
+
+  it('returns undefined when every detected port is already known (no re-navigation)', () => {
+    expect(firstNewDevPort([3000, 8501], [3000, 8501])).toBeUndefined();
+  });
+
+  it('on a cold workspace (nothing known yet) returns the first detected port', () => {
+    expect(firstNewDevPort([5173, 8501], [])).toBe(5173);
+  });
+});

--- a/tests/unit/user-config.test.ts
+++ b/tests/unit/user-config.test.ts
@@ -100,6 +100,39 @@ describe('loadUserConfig', () => {
     expect(out.errors?.some((e) => e.includes('cursor-style'))).toBe(true);
   });
 
+  it('maps the [browser] section: dev-ports + auto-open', () => {
+    tmpPath = writeTmp(`
+      [browser]
+      dev-ports = [8501, 4321, 9000]
+      auto-open = false
+    `);
+    const out = loadUserConfig(tmpPath);
+    expect(out.errors).toEqual([]);
+    expect(out.browser?.devPorts).toEqual([8501, 4321, 9000]);
+    expect(out.browser?.autoOpen).toBe(false);
+  });
+
+  it('accepts camelCase browser keys and drops out-of-range ports', () => {
+    tmpPath = writeTmp(`
+      [browser]
+      devPorts = [3000, 70000, 0, 5173]
+      autoOpen = true
+    `);
+    const out = loadUserConfig(tmpPath);
+    expect(out.browser?.devPorts).toEqual([3000, 5173]);
+    expect(out.browser?.autoOpen).toBe(true);
+    expect(out.errors?.some((e) => e.includes('dev-ports'))).toBe(true);
+  });
+
+  it('leaves browser undefined when the section is absent', () => {
+    tmpPath = writeTmp(`
+      [terminal]
+      font-size = 13
+    `);
+    const out = loadUserConfig(tmpPath);
+    expect(out.browser).toBeUndefined();
+  });
+
   it('clamps palette to 16 entries', () => {
     const big = Array.from({ length: 20 }, (_, i) => `"#0000${(i % 16).toString(16)}0"`).join(',');
     tmpPath = writeTmp(`


### PR DESCRIPTION
## What

Adds a `[browser]` section to `~/.wmux/config.toml` so users can extend the set of dev-server ports that trigger browser auto-navigation, and toggle the auto-open behavior:

```toml
[browser]
dev-ports = [8501, 4321]   # merged with the built-in defaults, de-duped
auto-open = true           # set false to disable browser auto-navigation
```

### Why

The recognized dev-port set was a hardcoded array in `App.tsx`, so a server on any other port (Streamlit's 8501, FastAPI on 8001, etc.) was silently never picked up, with no way to change it short of editing source.

- Ports are **additive** — configured ports join the built-in defaults rather than replacing them — so adding one never drops the sensible defaults.
- `auto-open = false` keeps port detection but stops the browser from auto-navigating, for users who find it disruptive.

Follows the existing `~/.wmux/config.toml` pattern (`[terminal]`, `[appearance]`): same kebab/camelCase key aliasing and non-fatal validation warnings.

## Also fixes a pre-existing auto-open bug

While testing on a machine with several dev servers already running, the browser never opened the newly-started one. Root cause in `handlePortsUpdate`: it always navigated to `matchDevPorts(...)[0]` — whichever recognized port `netstat` happened to list first — then wrote the full recognized set into `ws.ports`, so the "is this a new port?" guard permanently suppressed navigation afterward. Net effect: it opened the first-seen dev port once, then went silent.

It now opens the first recognized port the workspace hasn't seen yet, so a freshly-started server opens even when other dev ports are already listening.

## Changes

- `src/main/user-config.ts` — parse the `[browser]` section (`dev-ports` validated to 1–65535 integers, `auto-open` bool).
- `src/renderer/dev-ports.ts` *(new)* — pure helpers `mergeDevPorts` / `matchDevPorts` / `firstNewDevPort`, extracted so the logic is unit-testable.
- `src/renderer/App.tsx` — config drives the active port set; auto-open targets the newly-appeared port.
- Tests — `tests/unit/dev-ports.test.ts` *(new, 11 cases)* + the `[browser]` cases in `tests/unit/user-config.test.ts`.

## Testing

- `npm test` green (19 assertions across the two files; full suite passes).
- Verified live on Windows with a real dev server: config-driven detection of a custom port (8501) and the auto-open fix both confirmed, including the busy-machine scenario the fix targets.
