### PR TITLE
fix: stop notifying on every shell prompt redraw (ConEmu OSC 9 subcommands)

### DIFF
--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -566,6 +566,11 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
     // Register OSC notification handlers
     // OSC 9: basic notification (iTerm2 style)
     terminal.parser.registerOscHandler(9, (data) => {
+      // ConEmu/Windows Terminal overload OSC 9 with numeric subcommands:
+      // "9;<cwd>" (cwd report — our own cmd integration and the standard WT
+      // PowerShell prompt snippet emit this on EVERY prompt redraw) and
+      // "4;<state>;<n>" (progress). Only bare text is an iTerm2 notification.
+      if (/^\d+;/.test(data)) return true;
       window.wmux.notification.fire({
         surfaceId: ptyIdRef.current || '',
         text: data,


### PR DESCRIPTION
## Problem

wmux fires a notification every time a command is run at a shell prompt — extremely noisy alongside the (desired) agent notifications.

## Root cause

The OSC 9 handler in `useTerminal.ts` treats **every** OSC 9 payload as an iTerm2-style notification (`OSC 9;<text>`). But OSC 9 is overloaded: ConEmu/Windows Terminal use numeric subcommands — `OSC 9;9;<cwd>` (cwd report) and `OSC 9;4;<state>;<n>` (progress). wmux's own `wmux-cmd-integration.cmd` embeds `9;9;$P` in the cmd prompt, and the standard Windows Terminal PowerShell profile snippet does the same — so every prompt redraw after every command raised a bogus notification with text like `9;C:\path`.

## Fix

One guard in the OSC 9 handler: payloads starting with a numeric subcommand (`/^\d+;/`) are swallowed instead of raised. Bare-text notifications, `wmux notify`, and the Claude Code Stop/Notification hook path are unaffected.

## Testing

Verified in a dev instance:
- `ESC ]9;9;C:\fake BEL` and `ESC ]9;4;1;50 BEL` → silent (previously each fired a notification)
- `ESC ]9;hello BEL` → still notifies
- cmd tab: pressing Enter repeatedly no longer fires notifications
- `wmux notify` and agent Stop-hook notifications still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)