### PR TITLE
test: let the orchestrator status-vocab suite run on native Windows

### DIFF
--- a/tests/helpers/bash-path.ts
+++ b/tests/helpers/bash-path.ts
@@ -1,0 +1,54 @@
+/**
+ * Windows path → a path the `bash` on PATH can actually open.
+ *
+ * `path.resolve()` on native Windows yields `C:\dev\wmux\…`. Handing that to
+ * bash loses the separators (bash reads `\d` as an escape), so the script
+ * arrives as `C:devwmux…` and is never found — which is why the orchestrator
+ * suites could not run on the platform wmux ships for.
+ *
+ * There is no single right answer: Git Bash mounts the drive at `/c`, WSL at
+ * `/mnt/c`, Cygwin at `/cygdrive/c`. Rather than guess which bash is installed,
+ * we generate every spelling and let the caller probe with the bash that is
+ * actually on PATH (`bashExists` below).
+ */
+import { spawnSync } from 'node:child_process';
+
+/** Every spelling of `p` a bash flavour might mount, most likely first. */
+export function bashPathCandidates(p: string): string[] {
+  const slashed = p.replace(/\\/g, '/');
+  const drive = /^([A-Za-z]):\/(.*)$/.exec(slashed);
+  if (!drive) return [slashed];
+  const letter = drive[1].toLowerCase();
+  const rest = drive[2];
+  return [`/${letter}/${rest}`, `/mnt/${letter}/${rest}`, `/cygdrive/${letter}/${rest}`];
+}
+
+/**
+ * First candidate spelling `exists` accepts, else the first candidate.
+ *
+ * Order matters beyond mere likelihood: Git Bash (`/c`) is preferred because it
+ * runs in the Windows process tree and can execute the `node` the scripts call,
+ * whereas WSL bash would need a second toolchain installed inside the distro.
+ */
+export function toBashPath(p: string, exists: (candidate: string) => boolean): string {
+  const candidates = bashPathCandidates(p);
+  if (candidates.length === 1) return candidates[0];
+  return candidates.find(exists) ?? candidates[0];
+}
+
+/** True when `candidate` names an existing path to the bash on PATH. */
+export function bashExists(candidate: string): boolean {
+  const probe = spawnSync('bash', ['-c', 'test -e "$1"', 'bash', candidate], { stdio: 'ignore' });
+  return !probe.error && probe.status === 0;
+}
+
+/** True when a usable bash is on PATH at all (Windows boxes without Git for Windows have none). */
+export function hasBash(): boolean {
+  const probe = spawnSync('bash', ['-c', 'exit 0'], { stdio: 'ignore' });
+  return !probe.error && probe.status === 0;
+}
+
+/** Convenience: `toBashPath` bound to the real bash probe. */
+export function forBash(p: string): string {
+  return toBashPath(p, bashExists);
+}

--- a/tests/unit/bash-path.test.ts
+++ b/tests/unit/bash-path.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { bashPathCandidates, toBashPath } from '../helpers/bash-path';
+
+describe('bashPathCandidates', () => {
+  it('offers the Git Bash, WSL and Cygwin spellings of a Windows drive path', () => {
+    expect(bashPathCandidates('C:\\dev\\wmux\\scripts')).toEqual([
+      '/c/dev/wmux/scripts',
+      '/mnt/c/dev/wmux/scripts',
+      '/cygdrive/c/dev/wmux/scripts',
+    ]);
+  });
+
+  it('lower-cases the drive letter, the way every bash flavour mounts it', () => {
+    expect(bashPathCandidates('D:/Temp/x')[0]).toBe('/d/Temp/x');
+  });
+
+  it('leaves a POSIX path alone', () => {
+    expect(bashPathCandidates('/home/u/wmux')).toEqual(['/home/u/wmux']);
+  });
+
+  it('slash-converts a driveless Windows path without inventing a mount point', () => {
+    expect(bashPathCandidates('\\\\server\\share\\x')).toEqual(['//server/share/x']);
+  });
+});
+
+describe('toBashPath', () => {
+  it('picks the spelling the probe says the bash on PATH can see', () => {
+    const wslOnly = (p: string) => p.startsWith('/mnt/');
+    expect(toBashPath('C:\\dev\\wmux', wslOnly)).toBe('/mnt/c/dev/wmux');
+  });
+
+  it('prefers Git Bash when both spellings resolve — it inherits the Windows env', () => {
+    expect(toBashPath('C:\\dev\\wmux', () => true)).toBe('/c/dev/wmux');
+  });
+
+  it('falls back to the first candidate when nothing probes true', () => {
+    expect(toBashPath('C:\\dev\\wmux', () => false)).toBe('/c/dev/wmux');
+  });
+
+  it('never probes a path that has no drive letter to translate', () => {
+    const probe = (): boolean => { throw new Error('should not probe'); };
+    expect(toBashPath('/home/u/wmux', probe)).toBe('/home/u/wmux');
+  });
+});

--- a/tests/unit/orchestration-status-vocab.test.ts
+++ b/tests/unit/orchestration-status-vocab.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { forBash, hasBash } from '../helpers/bash-path';
 import type { OrchAgentStatus, OrchWaveStatus, OrchRunStatus } from '../../src/shared/types';
 
 const SCRIPTS = path.resolve(__dirname, '../../resources/wmux-orchestrator/scripts');
@@ -35,11 +36,30 @@ function writeState(overrides: Record<string, unknown> = {}): void {
 }
 
 // find_active_orch() scans $TMPDIR for wmux-orch-*/ dirs whose state.json is "running".
+//
+// Both paths go through forBash(): on native Windows `path.resolve` yields
+// `C:\dev\wmux\…`, and bash reads those backslashes as escapes, so the script
+// arrived as `C:devwmux…` and was never found (5 failures on the only platform
+// wmux ships for). No-op on Linux/macOS, where the path is already POSIX.
+//
+// The env vars are set in the bash command line rather than through `env:`
+// because a WSL bash launched from Windows does not inherit the Windows
+// environment unless WSLENV names each variable — assigning them inside the
+// shell works for every flavour.
 function runHook(agentId = 'a1', exitCode = '0'): void {
-  execFileSync('bash', [HOOK], {
-    env: { ...process.env, TMPDIR: tmp, WMUX_AGENT_ID: agentId, CLAUDE_EXIT_CODE: exitCode },
-    encoding: 'utf8',
-  });
+  execFileSync(
+    'bash',
+    [
+      '-c',
+      'TMPDIR="$1" WMUX_AGENT_ID="$2" CLAUDE_EXIT_CODE="$3" exec bash "$4"',
+      'bash',
+      forBash(tmp),
+      agentId,
+      exitCode,
+      forBash(HOOK),
+    ],
+    { encoding: 'utf8' },
+  );
 }
 
 const query = (...args: string[]): string =>
@@ -57,7 +77,9 @@ afterEach(() => {
   fs.rmSync(tmp, { recursive: true, force: true });
 });
 
-describe('on-agent-stop.sh status vocabulary (#99)', () => {
+// A Windows box without Git for Windows has no bash at all — nothing to convert
+// a path FOR. Skipping is explicit and loud rather than a silent green.
+describe.skipIf(!hasBash())('on-agent-stop.sh status vocabulary (#99)', () => {
   it('marks a successful agent "exited" — the word the sidebar counts, not "completed"', () => {
     writeState();
     runHook();


### PR DESCRIPTION
`tests/unit/orchestration-status-vocab.test.ts` fails on native Windows — 5 tests, on a clean checkout of `master`. wmux is a Windows-only app, so the suite currently can't run on its own platform.

## Cause

The suite shells out to `bash` with a path from `path.resolve()`:

```ts
const SCRIPTS = path.resolve(__dirname, '../../resources/wmux-orchestrator/scripts');
execFileSync('bash', [HOOK], { env: { ...process.env, TMPDIR: tmp, … } });
```

On Windows that's `C:\dev\wmux\resources\…`. bash reads `\d`, `\r` etc. as escapes, so the path arrives as `C:devwmuxresources…` and the hook script is never found. `find_active_orch()` then returns nothing, the hook exits 0 without touching state, and every assertion about `status=exited` / `complete` fails.

The `execFileSync('node', …)` call on the next line is fine — only the `bash` one breaks.

## Fix

There's no single correct conversion: Git Bash mounts the drive at `/c`, WSL at `/mnt/c`, Cygwin at `/cygdrive/c`. Rather than assume which bash is installed, `tests/helpers/bash-path.ts` generates every spelling and probes with the bash actually on `PATH`:

```ts
bashPathCandidates('C:\\dev\\wmux')
// → ['/c/dev/wmux', '/mnt/c/dev/wmux', '/cygdrive/c/dev/wmux']
```

Git Bash wins ties deliberately: it runs in the Windows process tree and can execute the `node` that `on-agent-stop.sh` shells out to, whereas WSL bash would need a second toolchain installed inside the distro.

**A second Windows-only trap turned up while fixing the first.** A WSL bash launched from Windows does not inherit the Windows environment unless `WSLENV` names each variable — so `TMPDIR`, `WMUX_AGENT_ID` and `CLAUDE_EXIT_CODE` would silently vanish even with a correct path. They're now assigned on the bash command line instead of through `env:`, which works for every flavour.

## Scope

- No-op on Linux and macOS — the path is already POSIX and `bashPathCandidates` returns it unchanged.
- No production code touched. Tests and one test helper only.
- `tests/unit/` was swept for the same `execFileSync('bash', …)` shape; this was the only occurrence (`renderer-typecheck` spawns `npx`, `shell-context-menu` only mentions bash in a comment).
- A Windows box with no bash at all skips with an explicit `describe.skipIf(!hasBash())` rather than passing silently.

## Verification

- Linux/WSL: `npm test` → 552 passed. The 3 failures (`pty-manager`, `shell-context-menu`) are present identically on unmodified `master` — both need native Windows.
- 8 unit tests cover the path conversion itself, including the driveless/UNC case and the probe-ordering rule.
- Native Windows: the 5 previously-failing tests pass.