### PR TITLE
perf(sidebar): coalesce the resize drag to one width update per frame

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -430,6 +430,12 @@ export default function App() {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [shortcuts, commandPaletteOpen]);
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
+  // Session writes read the width through this ref, not the state value.
+  // As a dependency, `sidebarWidth` re-subscribed the auto-save listener and
+  // rebuilt the save callback on every intermediate value of a drag; the ref
+  // keeps those stable, so only the settled width matters (issue 07).
+  const sidebarWidthRef = useRef(sidebarWidth);
+  useEffect(() => { sidebarWidthRef.current = sidebarWidth; }, [sidebarWidth]);
 
   // Open tutorial on first launch, unless the welcome screen is disabled in
   // Settings (issue #22). The "seen" flag still prevents re-showing it.
@@ -688,7 +694,7 @@ export default function App() {
         version: 1,
         windows: [{
           bounds: { x: 0, y: 0, width: 0, height: 0 }, // main process fills real bounds
-          sidebarWidth,
+          sidebarWidth: sidebarWidthRef.current,
           activeWorkspaceId: state.activeWorkspaceId,
           workspaces: state.workspaces.map(ws => ({
             id: ws.id,
@@ -706,7 +712,7 @@ export default function App() {
       window.wmux.session.pushAutoSave(data);
     });
     return unsub;
-  }, [sidebarWidth]);
+  }, []);
 
   // Auto-focus first pane whenever the active workspace changes or gains its first pane
   const activeWorkspace = workspaces.find((w) => w.id === activeWorkspaceId) ?? null;
@@ -762,12 +768,12 @@ export default function App() {
         browserUrl: ws.browserUrl || '',
         browserWidth: ws.browserWidth,
       })),
-      sidebarWidth,
+      sidebarWidth: sidebarWidthRef.current,
       terminalPrefs: { ...state.terminalPrefs },
     };
     await window.wmux?.session?.save(session);
     window.wmux?.notification?.fire({ surfaceId: '', text: `Session "${name}" saved`, title: 'wmux' });
-  }, [sidebarWidth]);
+  }, []);
 
   const handleLoadSession = useCallback(async (name: string) => {
     const session = await window.wmux?.session?.load(name);

--- a/src/renderer/components/Sidebar/SidebarResizeHandle.tsx
+++ b/src/renderer/components/Sidebar/SidebarResizeHandle.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { createResizeDrag } from './resize-drag';
 
 interface SidebarResizeHandleProps {
   onWidthChange: (delta: number) => void;
@@ -8,14 +9,14 @@ export default function SidebarResizeHandle({ onWidthChange }: SidebarResizeHand
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
-      const startX = e.clientX;
+      // Coalesced to one width update per frame — see resize-drag.ts for why a
+      // raw mousemove handler is expensive here.
+      const drag = createResizeDrag(e.clientX, onWidthChange);
 
-      const onMouseMove = (ev: MouseEvent) => {
-        const delta = ev.clientX - startX;
-        onWidthChange(delta);
-      };
+      const onMouseMove = (ev: MouseEvent) => drag.move(ev.clientX);
 
       const onMouseUp = () => {
+        drag.stop();
         window.removeEventListener('mousemove', onMouseMove);
         window.removeEventListener('mouseup', onMouseUp);
       };

--- a/src/renderer/components/Sidebar/resize-drag.ts
+++ b/src/renderer/components/Sidebar/resize-drag.ts
@@ -1,0 +1,69 @@
+/**
+ * Frame-coalesced sidebar drag (issue 07).
+ *
+ * A raw `mousemove` handler fires ~60 times a second, and every sidebar width
+ * change relayouts the workspace — so each one wakes every terminal's
+ * ResizeObserver, calls `fit()` and `pty.resize()`, and makes ConPTY re-emit
+ * the visible screen as a Repaint. One drag was doing sixty rounds of that.
+ *
+ * The scheduler is injected rather than calling `requestAnimationFrame`
+ * directly so the coalescing is testable in Node (there is no DOM in the unit
+ * suite).
+ */
+
+export interface FrameScheduler {
+  request: (cb: () => void) => number;
+  cancel: (handle: number) => void;
+}
+
+export const rafScheduler: FrameScheduler = {
+  request: (cb) => requestAnimationFrame(cb),
+  cancel: (handle) => cancelAnimationFrame(handle),
+};
+
+export interface ResizeDrag {
+  /** Record a pointer position; at most one `emit` lands per frame. */
+  move: (clientX: number) => void;
+  /** End the drag, delivering the final position immediately. */
+  stop: () => void;
+}
+
+/**
+ * Collect pointer positions and emit the drag delta at most once per frame.
+ * `stop()` flushes a position still waiting for its frame, so the width settles
+ * where the cursor was released rather than a frame behind it.
+ */
+export function createResizeDrag(
+  startX: number,
+  emit: (delta: number) => void,
+  scheduler: FrameScheduler = rafScheduler,
+): ResizeDrag {
+  let frame: number | null = null;
+  let latestX: number | null = null;
+  let stopped = false;
+
+  const flush = (): void => {
+    frame = null;
+    if (latestX === null) return;
+    const delta = latestX - startX;
+    latestX = null;
+    emit(delta);
+  };
+
+  return {
+    move(clientX: number): void {
+      if (stopped) return;
+      latestX = clientX;
+      if (frame === null) frame = scheduler.request(flush);
+    },
+    stop(): void {
+      if (stopped) return;
+      stopped = true;
+      if (frame !== null) {
+        scheduler.cancel(frame);
+        frame = null;
+      }
+      flush();
+    },
+  };
+}

--- a/tests/unit/sidebar-resize-drag.test.ts
+++ b/tests/unit/sidebar-resize-drag.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createResizeDrag, FrameScheduler } from '../../src/renderer/components/Sidebar/resize-drag';
+
+/** Hand-cranked rAF: frames only run when the test says so. */
+function fakeFrames() {
+  const queued = new Map<number, () => void>();
+  let next = 1;
+  const scheduler: FrameScheduler = {
+    request: (cb) => { const h = next++; queued.set(h, cb); return h; },
+    cancel: (h) => { queued.delete(h); },
+  };
+  return {
+    scheduler,
+    pending: () => queued.size,
+    run: () => { const cbs = [...queued.values()]; queued.clear(); cbs.forEach(cb => cb()); },
+  };
+}
+
+describe('createResizeDrag', () => {
+  it('coalesces a burst of mousemoves into one update per frame', () => {
+    const emit = vi.fn();
+    const frames = fakeFrames();
+    const drag = createResizeDrag(100, emit, frames.scheduler);
+
+    // A ~1s drag at 60Hz used to be 60 width updates, each one resizing every
+    // PTY in the window (issue 07).
+    for (let x = 101; x <= 160; x++) drag.move(x);
+    expect(emit).not.toHaveBeenCalled();
+    expect(frames.pending()).toBe(1);
+
+    frames.run();
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith(60); // the LAST position, not the first
+  });
+
+  it('emits again on the next frame, so the width still tracks the cursor', () => {
+    const emit = vi.fn();
+    const frames = fakeFrames();
+    const drag = createResizeDrag(100, emit, frames.scheduler);
+
+    drag.move(110);
+    frames.run();
+    drag.move(130);
+    frames.run();
+
+    expect(emit.mock.calls).toEqual([[10], [30]]);
+  });
+
+  it('flushes the pending position on stop so the settled width is where the cursor was released', () => {
+    const emit = vi.fn();
+    const frames = fakeFrames();
+    const drag = createResizeDrag(100, emit, frames.scheduler);
+
+    drag.move(140);
+    drag.stop();
+
+    expect(emit).toHaveBeenCalledExactlyOnceWith(40);
+    expect(frames.pending()).toBe(0); // the frame was cancelled, not left to fire
+  });
+
+  it('stops emitting once the drag is over', () => {
+    const emit = vi.fn();
+    const frames = fakeFrames();
+    const drag = createResizeDrag(100, emit, frames.scheduler);
+
+    drag.move(140);
+    drag.stop();
+    emit.mockClear();
+
+    drag.move(200);
+    frames.run();
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('emits nothing when the pointer never moved', () => {
+    const emit = vi.fn();
+    const frames = fakeFrames();
+    const drag = createResizeDrag(100, emit, frames.scheduler);
+
+    drag.stop();
+    expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('does not re-emit a position already delivered by its frame', () => {
+    const emit = vi.fn();
+    const frames = fakeFrames();
+    const drag = createResizeDrag(100, emit, frames.scheduler);
+
+    drag.move(140);
+    frames.run();
+    drag.stop();
+
+    expect(emit).toHaveBeenCalledExactlyOnceWith(40);
+  });
+});


### PR DESCRIPTION
One sidebar drag does far more work than it needs to. Not a user-visible break on its own — this is churn, not correctness.

## Cause

`SidebarResizeHandle.tsx` handles `mousemove` raw, with no throttle or rAF coalescing:

```ts
const onMouseMove = (ev: MouseEvent) => {
  const delta = ev.clientX - startX;
  onWidthChange(delta);
};
```

So ~60 width updates a second while dragging. Each one sets `sidebarWidth` in `App.tsx`, which relayouts the workspace — which wakes **every** terminal's `ResizeObserver` (`useTerminal.ts:858`), calls `fit()` and `pty.resize()`, and makes ConPTY re-emit its visible screen. A one-second drag is sixty rounds of that across every open terminal.

`sidebarWidth` is also a dependency of the auto-save listener effect and of `handleSaveSession`, so every intermediate value tears down and re-registers the listener and rebuilds the callback.

## Fix

`createResizeDrag` collects pointer positions and emits at most one delta per frame. `stop()` flushes a position still waiting for its frame, so the width settles where the cursor was released rather than a frame behind it.

The frame scheduler is injected rather than calling `requestAnimationFrame` directly. That's the one design decision worth pointing at: it's what makes the coalescing testable in the existing node-environment unit suite, with no DOM and no new test dependency.

`App.tsx` reads the width through a ref instead of taking it as an effect/callback dependency, so only the settled width matters.

The rAF shape matches what `useTerminal.ts` already does at `:860` and `:980`.

## Behaviour

Unchanged from the user's side — the width tracks the cursor, and dragging below 80px still auto-collapses. The difference is one update per frame instead of one per event.

## Verification

- 7 unit tests drive the coalescing with a hand-cranked scheduler: burst-collapses-to-one, next frame emits again, `stop()` flushes the pending position, `stop()` cancels the frame, no emit when the pointer never moved, no double-emit.
- `npm test` → 550 passed. The 3 failures (`pty-manager`, `shell-context-menu`) are present identically on unmodified `master` — both need native Windows.