### PR TITLE
fix(diff): keep the app responsive when a diff pane watches a non-git cwd

### DIFF
--- a/src/main/diff-provider.ts
+++ b/src/main/diff-provider.ts
@@ -40,7 +40,16 @@ async function isGitRepo(cwd: string): Promise<boolean> {
 // When there's no git repo, we take a snapshot of file contents on first load
 // and diff against it on subsequent polls.
 
-const snapshots = new Map<string, Map<string, string>>(); // cwd → (relPath → content)
+interface SnapshotEntry {
+  content: string;
+  mtimeMs: number;
+  size: number;
+}
+
+const snapshots = new Map<string, Map<string, SnapshotEntry>>(); // cwd → (relPath → entry)
+// One scan per directory at a time: a slow scan coalesces concurrent callers
+// instead of piling up (a home-dir scan can outlast the renderer's poll interval).
+const scansInFlight = new Map<string, Promise<ChangedFile[]>>();
 const SNAPSHOT_EXTENSIONS = new Set([
   '.ts', '.tsx', '.js', '.jsx', '.json', '.py', '.rb', '.go', '.rs',
   '.java', '.c', '.cpp', '.h', '.hpp', '.cs', '.swift', '.kt',
@@ -58,15 +67,15 @@ function shouldSnapshotFile(filePath: string): boolean {
   return SNAPSHOT_EXTENSIONS.has(ext);
 }
 
-function walkDir(dir: string, base: string, files: string[], depth = 0): void {
+async function walkDir(dir: string, base: string, files: string[], depth = 0): Promise<void> {
   if (depth > 5 || files.length >= MAX_SNAPSHOT_FILES) return;
   let entries: fs.Dirent[];
-  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  try { entries = await fs.promises.readdir(dir, { withFileTypes: true }); } catch { return; }
   for (const entry of entries) {
     if (files.length >= MAX_SNAPSHOT_FILES) return;
     if (entry.isDirectory()) {
       if (!SNAPSHOT_IGNORE.has(entry.name) && !entry.name.startsWith('.')) {
-        walkDir(path.join(dir, entry.name), base, files, depth + 1);
+        await walkDir(path.join(dir, entry.name), base, files, depth + 1);
       }
     } else if (entry.isFile() && shouldSnapshotFile(entry.name)) {
       const rel = path.relative(base, path.join(dir, entry.name)).replace(/\\/g, '/');
@@ -75,34 +84,38 @@ function walkDir(dir: string, base: string, files: string[], depth = 0): void {
   }
 }
 
-function takeSnapshot(cwd: string): Map<string, string> {
-  const snap = new Map<string, string>();
+/** Resolve `rel` inside `cwd`, or null if it escapes the directory. */
+function resolveWithin(cwd: string, rel: string): string | null {
+  const resolved = path.resolve(path.join(cwd, rel));
+  return resolved.startsWith(path.resolve(cwd)) ? resolved : null;
+}
+
+async function readSnapshotEntry(abs: string): Promise<SnapshotEntry | null> {
+  try {
+    const stat = await fs.promises.stat(abs);
+    if (stat.size > MAX_SNAPSHOT_FILE) return null;
+    const buf = await fs.promises.readFile(abs);
+    if (buf.includes(0)) return null; // skip binary
+    return { content: buf.toString('utf-8'), mtimeMs: stat.mtimeMs, size: stat.size };
+  } catch { return null; /* skip unreadable */ }
+}
+
+async function takeSnapshot(cwd: string): Promise<Map<string, SnapshotEntry>> {
+  const snap = new Map<string, SnapshotEntry>();
   const files: string[] = [];
-  walkDir(cwd, cwd, files);
+  await walkDir(cwd, cwd, files);
   for (const rel of files) {
-    try {
-      const abs = path.join(cwd, rel);
-      const stat = fs.statSync(abs);
-      if (stat.size > MAX_SNAPSHOT_FILE) continue;
-      const buf = fs.readFileSync(abs);
-      if (buf.includes(0)) continue; // skip binary
-      snap.set(rel, buf.toString('utf-8'));
-    } catch { /* skip unreadable */ }
+    const entry = await readSnapshotEntry(path.join(cwd, rel));
+    if (entry) snap.set(rel, entry);
   }
   return snap;
 }
 
-function readCurrentFile(cwd: string, rel: string): string | null {
-  try {
-    const abs = path.join(cwd, rel);
-    const resolved = path.resolve(abs);
-    if (!resolved.startsWith(path.resolve(cwd))) return null;
-    const stat = fs.statSync(resolved);
-    if (stat.size > MAX_SNAPSHOT_FILE) return null;
-    const buf = fs.readFileSync(resolved);
-    if (buf.includes(0)) return null;
-    return buf.toString('utf-8');
-  } catch { return null; }
+async function readCurrentFile(cwd: string, rel: string): Promise<string | null> {
+  const resolved = resolveWithin(cwd, rel);
+  if (!resolved) return null;
+  const entry = await readSnapshotEntry(resolved);
+  return entry ? entry.content : null;
 }
 
 function generateUnifiedDiff(filePath: string, oldContent: string, newContent: string): string {
@@ -182,22 +195,34 @@ function generateUnifiedDiff(filePath: string, oldContent: string, newContent: s
 
 async function getSnapshotChangedFiles(cwd: string): Promise<ChangedFile[]> {
   if (!snapshots.has(cwd)) {
-    snapshots.set(cwd, takeSnapshot(cwd));
+    snapshots.set(cwd, await takeSnapshot(cwd));
     return []; // First call: snapshot taken, no changes yet
   }
   const snap = snapshots.get(cwd)!;
   const changed: ChangedFile[] = [];
 
-  // Check existing files for modifications
-  for (const [rel, oldContent] of snap) {
-    const current = readCurrentFile(cwd, rel);
-    if (current === null) {
-      // File was deleted
-      const lines = oldContent.split('\n').length;
+  // Check existing files for modifications. Stat first and only read content
+  // when mtime/size moved — in the steady state this skips every read.
+  for (const [rel, entry] of snap) {
+    const resolved = resolveWithin(cwd, rel);
+    let stat: fs.Stats | null = null;
+    if (resolved) {
+      try { stat = await fs.promises.stat(resolved); } catch { /* deleted */ }
+    }
+    if (!stat) {
+      const lines = entry.content.split('\n').length;
       changed.push({ path: rel, status: 'deleted', additions: 0, deletions: lines });
-    } else if (current !== oldContent) {
+      continue;
+    }
+    if (stat.mtimeMs === entry.mtimeMs && stat.size === entry.size) continue; // unchanged
+    const current = await readCurrentFile(cwd, rel);
+    if (current === null) {
+      // Grew past the size cap or turned binary — treat as gone, like before
+      const lines = entry.content.split('\n').length;
+      changed.push({ path: rel, status: 'deleted', additions: 0, deletions: lines });
+    } else if (current !== entry.content) {
       // File was modified
-      const oldLines = oldContent.split('\n');
+      const oldLines = entry.content.split('\n');
       const newLines = current.split('\n');
       let additions = 0, deletions = 0;
       const max = Math.max(oldLines.length, newLines.length);
@@ -210,15 +235,19 @@ async function getSnapshotChangedFiles(cwd: string): Promise<ChangedFile[]> {
         }
       }
       changed.push({ path: rel, status: 'modified', additions, deletions });
+    } else {
+      // Content identical, only metadata moved (e.g. touch) — refresh the
+      // stored stat so the next poll goes back to the cheap skip path.
+      snap.set(rel, { content: entry.content, mtimeMs: stat.mtimeMs, size: stat.size });
     }
   }
 
   // Check for new files
   const currentFiles: string[] = [];
-  walkDir(cwd, cwd, currentFiles);
+  await walkDir(cwd, cwd, currentFiles);
   for (const rel of currentFiles) {
     if (!snap.has(rel)) {
-      const content = readCurrentFile(cwd, rel);
+      const content = await readCurrentFile(cwd, rel);
       if (content !== null) {
         changed.push({ path: rel, status: 'added', additions: content.split('\n').length, deletions: 0 });
       }
@@ -228,12 +257,21 @@ async function getSnapshotChangedFiles(cwd: string): Promise<ChangedFile[]> {
   return changed;
 }
 
-function getSnapshotFileDiff(cwd: string, file: string): string {
+/** Serialize/coalesce snapshot scans per directory. */
+function getSnapshotChangedFilesCoalesced(cwd: string): Promise<ChangedFile[]> {
+  const inFlight = scansInFlight.get(cwd);
+  if (inFlight) return inFlight;
+  const scan = getSnapshotChangedFiles(cwd).finally(() => scansInFlight.delete(cwd));
+  scansInFlight.set(cwd, scan);
+  return scan;
+}
+
+async function getSnapshotFileDiff(cwd: string, file: string): Promise<string> {
   const snap = snapshots.get(cwd);
   if (!snap) return '';
 
-  const oldContent = snap.get(file);
-  const current = readCurrentFile(cwd, file);
+  const oldContent = snap.get(file)?.content;
+  const current = await readCurrentFile(cwd, file);
 
   if (oldContent === undefined && current !== null) {
     // New file
@@ -312,7 +350,7 @@ export async function getChangedFiles(cwd: string): Promise<ChangedFile[]> {
   }
 
   // No git — use snapshot system
-  return getSnapshotChangedFiles(cwd);
+  return getSnapshotChangedFilesCoalesced(cwd);
 }
 
 export async function getFileDiff(cwd: string, file: string): Promise<string> {

--- a/src/renderer/components/Diff/DiffPane.tsx
+++ b/src/renderer/components/Diff/DiffPane.tsx
@@ -121,26 +121,39 @@ export default function DiffPane({ surfaceId, cwd }: DiffPaneProps) {
     }
   }, [cwd]);
 
-  // Poll git status every 2 seconds (~50ms per git status call)
-  // This replaces the old mount-only load — ensures diffs always stay fresh
+  // Poll every 2 seconds (~50ms per git status call). The non-git snapshot
+  // fallback can take much longer than the interval on big trees, so schedule
+  // the next poll only after the previous one finishes (never overlap) and
+  // stretch the delay when a pass runs longer than the interval itself.
   useEffect(() => {
     lastFilesKeyRef.current = '';
     lastDiffRawRef.current = '';
     setLoading(true);
 
+    const POLL_MS = 2000;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
     const poll = async () => {
+      const started = Date.now();
       const loaded = await loadFiles();
+      if (cancelled) return;
       if (loaded.length > 0 && !selectedFileRef.current) {
         setSelectedFile(loaded[0].path);
       }
       if (selectedFileRef.current) {
-        loadDiff(selectedFileRef.current);
+        await loadDiff(selectedFileRef.current);
       }
+      if (cancelled) return;
+      const elapsed = Date.now() - started;
+      timer = setTimeout(poll, Math.max(POLL_MS, elapsed));
     };
 
     poll();
-    const id = setInterval(poll, 2000);
-    return () => clearInterval(id);
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) clearTimeout(timer);
+    };
   }, [loadFiles, loadDiff]);
 
   // Load diff + scroll to top when user selects a file

--- a/tests/unit/diff-provider.test.ts
+++ b/tests/unit/diff-provider.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { getChangedFiles, getFileDiff, resetSnapshot } from '../../src/main/diff-provider';
+
+// Non-git directory so getChangedFiles falls through to the snapshot system.
+const TEST_DIR = path.join(os.tmpdir(), 'wmux-test-diff-' + process.pid);
+
+function write(rel: string, content: string) {
+  const abs = path.join(TEST_DIR, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+describe('diff-provider snapshot system (non-git cwd)', () => {
+  beforeEach(() => {
+    fs.mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    resetSnapshot(TEST_DIR);
+    fs.rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('first call takes the baseline and reports no changes', async () => {
+    write('a.ts', 'one\n');
+    expect(await getChangedFiles(TEST_DIR)).toEqual([]);
+  });
+
+  it('detects modified, added, and deleted files against the baseline', async () => {
+    write('a.ts', 'one\n');
+    write('b.ts', 'keep\n');
+    await getChangedFiles(TEST_DIR); // baseline
+
+    write('a.ts', 'one\ntwo\n');
+    write('c.ts', 'new\n');
+    fs.rmSync(path.join(TEST_DIR, 'b.ts'));
+
+    const changed = await getChangedFiles(TEST_DIR);
+    const byPath = new Map(changed.map(c => [c.path, c]));
+    expect(byPath.get('a.ts')?.status).toBe('modified');
+    expect(byPath.get('c.ts')?.status).toBe('added');
+    expect(byPath.get('b.ts')?.status).toBe('deleted');
+  });
+
+  it('does not report a file whose mtime moved but whose content is unchanged', async () => {
+    write('a.ts', 'same\n');
+    await getChangedFiles(TEST_DIR); // baseline
+
+    const later = new Date(Date.now() + 5000);
+    fs.utimesSync(path.join(TEST_DIR, 'a.ts'), later, later); // touch
+
+    expect(await getChangedFiles(TEST_DIR)).toEqual([]);
+    // And the refreshed stat keeps the skip path on the following poll too
+    expect(await getChangedFiles(TEST_DIR)).toEqual([]);
+  });
+
+  it('renders a unified diff for a modified file', async () => {
+    write('a.ts', 'line1\nline2\n');
+    await getChangedFiles(TEST_DIR); // baseline
+    write('a.ts', 'line1\nchanged\n');
+    await getChangedFiles(TEST_DIR);
+
+    const diff = await getFileDiff(TEST_DIR, 'a.ts');
+    expect(diff).toContain('-line2');
+    expect(diff).toContain('+changed');
+  });
+
+  it('coalesces concurrent scans of the same directory', async () => {
+    write('a.ts', 'one\n');
+    await getChangedFiles(TEST_DIR); // baseline
+    write('a.ts', 'two\n');
+
+    const [first, second] = await Promise.all([
+      getChangedFiles(TEST_DIR),
+      getChangedFiles(TEST_DIR),
+    ]);
+    // Both callers resolve with the same scan's result
+    expect(first).toEqual(second);
+    expect(first[0]?.status).toBe('modified');
+  });
+});


### PR DESCRIPTION
Fixes #133 — the three mechanical fixes proposed there: a diff pane on a non-git `cwd` (e.g. a home directory) pinned the main process at 100% of a core, froze the window, and stopped the pipe server answering.

## What changed

**1. The poll can no longer overlap itself** (`DiffPane.tsx`)
`setInterval(poll, 2000)` fired on a fixed clock regardless of how long the previous pass took — with a ~3s snapshot scan against a 2s interval, work queued faster than it drained, permanently. The poll is now a self-scheduling `setTimeout` chain: the next pass is scheduled only after the previous one (files + diff) fully resolves, with the delay stretched to `max(2000, elapsed)` so a slow scan naturally backs the cadence off instead of piling up.

**2. The snapshot path is fully async** (`diff-provider.ts`)
`walkDir` / `takeSnapshot` / `readCurrentFile` used `readdirSync` / `statSync` / `readFileSync` inside `ipcMain.handle`, so the whole scan executed as one uninterruptible block on the main process — which is why IPC, painting, and the named pipe all stalled together. All of it now uses `fs.promises`; a slow scan degrades into slow diffs instead of a frozen app.

**3. Stat before read**
Snapshot entries now store `{ content, mtimeMs, size }` instead of bare content. On each poll a file is `stat`-ed first and its content only re-read when mtime/size actually moved — in the steady state (nothing changed) this eliminates every read; on the tree from #133 that's ~26 MB of `readFileSync` per poll gone. When only metadata moved (`touch`) the stored stat is refreshed so the next poll returns to the cheap path.

Also added, in the same spirit: concurrent scans of the same directory now coalesce onto one in-flight promise (`scansInFlight`), so two diff panes on the same cwd can't double the work.

Not included (deliberately — they're design decisions, per the issue): slower re-walk cadence for new-file detection, widening `SNAPSHOT_IGNORE` with platform dirs, and gating the fallback off for home-like trees.

## Behavior preserved

- Git repos: untouched — same `git status --porcelain` path.
- Baseline semantics: first call snapshots and reports nothing; changes are always relative to the baseline until `resetSnapshot`.
- A file that grows past the 500 KB cap or turns binary is still reported as deleted, as before.
- Depth/file caps, extension filter, ignore list: unchanged.

## Tests

New `tests/unit/diff-provider.test.ts` (the snapshot system previously had no coverage):
- baseline call reports no changes
- modified / added / deleted detection
- **mtime moved but content unchanged → no report, and the skip path holds on the following poll** (the stat-before-read behavior)
- unified diff rendering for a modified file
- concurrent scans coalesce to one result

`npm run typecheck` (both tsconfigs), `npm run lint`, and the full `npm test` suite pass.

## Measured effect

Same machine and tree as #133 (3,578 dirs / 2,000 snapshot files / 26.6 MB):

| | before | after |
|---|---|---|
| Main-process CPU with a diff pane on `~` | ~100% of a core, sustained | idle between polls |
| Window `Responding` | False within seconds | True |
| `system.identify` over the pipe | timeout | sub-ms |
