### PR TITLE
fix(diff): bound the snapshot walk and slow the new-file discovery cadence

### DIFF
--- a/src/main/diff-provider.ts
+++ b/src/main/diff-provider.ts
@@ -58,24 +58,49 @@ const SNAPSHOT_EXTENSIONS = new Set([
   '.sh', '.bash', '.zsh', '.ps1', '.bat', '.cmd',
   '.sql', '.graphql', '.proto', '.xml', '.svg',
 ]);
-const SNAPSHOT_IGNORE = new Set(['node_modules', '.git', 'dist', 'build', '.next', '__pycache__', '.venv', 'venv']);
+const SNAPSHOT_IGNORE = new Set([
+  // Build/dependency output
+  'node_modules', '.git', 'dist', 'build', '.next', '__pycache__', '.venv', 'venv',
+  // Platform directories. A home directory is never a git repo, so it lands on
+  // the snapshot path; without these the walk descends into caches and installed
+  // applications, burning the directory budget on files nobody is editing.
+  'AppData', 'Library', 'Application Data', '$RECYCLE.BIN', 'System Volume Information',
+  'OneDrive', 'Recovery', 'ntuser.dat',
+]);
 const MAX_SNAPSHOT_FILE = 500_000; // 500KB per file
 const MAX_SNAPSHOT_FILES = 2000;
+// The file cap bounds how much we READ, not how much we WALK: on a home
+// directory ~3,500 directories get enumerated before the file cap bites, and
+// which files you end up with is then an accident of traversal order. Budget
+// directories too, so the walk itself is bounded.
+const MAX_SNAPSHOT_DIRS = 500;
+// Re-walking to discover new files is far more expensive than stat-ing the
+// files already known, and new files appear far less often than they change.
+// Run discovery on a multiple of the content check instead of every poll.
+const REWALK_EVERY_N_POLLS = 5;
+const pollCounts = new Map<string, number>(); // cwd → polls since last re-walk
+const addedPaths = new Map<string, Set<string>>(); // cwd → files discovered since the baseline
 
 function shouldSnapshotFile(filePath: string): boolean {
   const ext = path.extname(filePath).toLowerCase();
   return SNAPSHOT_EXTENSIONS.has(ext);
 }
 
-async function walkDir(dir: string, base: string, files: string[], depth = 0): Promise<void> {
-  if (depth > 5 || files.length >= MAX_SNAPSHOT_FILES) return;
+interface WalkBudget { dirs: number }
+
+async function walkDir(
+  dir: string, base: string, files: string[], depth = 0,
+  budget: WalkBudget = { dirs: MAX_SNAPSHOT_DIRS },
+): Promise<void> {
+  if (depth > 5 || files.length >= MAX_SNAPSHOT_FILES || budget.dirs <= 0) return;
+  budget.dirs--;
   let entries: fs.Dirent[];
   try { entries = await fs.promises.readdir(dir, { withFileTypes: true }); } catch { return; }
   for (const entry of entries) {
-    if (files.length >= MAX_SNAPSHOT_FILES) return;
+    if (files.length >= MAX_SNAPSHOT_FILES || budget.dirs <= 0) return;
     if (entry.isDirectory()) {
       if (!SNAPSHOT_IGNORE.has(entry.name) && !entry.name.startsWith('.')) {
-        await walkDir(path.join(dir, entry.name), base, files, depth + 1);
+        await walkDir(path.join(dir, entry.name), base, files, depth + 1, budget);
       }
     } else if (entry.isFile() && shouldSnapshotFile(entry.name)) {
       const rel = path.relative(base, path.join(dir, entry.name)).replace(/\\/g, '/');
@@ -84,10 +109,22 @@ async function walkDir(dir: string, base: string, files: string[], depth = 0): P
   }
 }
 
+/**
+ * True if `resolved` is `root` or sits underneath it.
+ * Uses path.relative rather than a string prefix test, so a sibling whose name
+ * merely starts with root (C:\foobar vs C:\foo) is not treated as contained.
+ */
+function isWithin(root: string, resolved: string): boolean {
+  if (resolved === root) return true;
+  const rel = path.relative(root, resolved);
+  return !!rel && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
 /** Resolve `rel` inside `cwd`, or null if it escapes the directory. */
 function resolveWithin(cwd: string, rel: string): string | null {
-  const resolved = path.resolve(path.join(cwd, rel));
-  return resolved.startsWith(path.resolve(cwd)) ? resolved : null;
+  const root = path.resolve(cwd);
+  const resolved = path.resolve(path.join(root, rel));
+  return isWithin(root, resolved) ? resolved : null;
 }
 
 async function readSnapshotEntry(abs: string): Promise<SnapshotEntry | null> {
@@ -242,16 +279,31 @@ async function getSnapshotChangedFiles(cwd: string): Promise<ChangedFile[]> {
     }
   }
 
-  // Check for new files
-  const currentFiles: string[] = [];
-  await walkDir(cwd, cwd, currentFiles);
-  for (const rel of currentFiles) {
-    if (!snap.has(rel)) {
-      const content = await readCurrentFile(cwd, rel);
-      if (content !== null) {
-        changed.push({ path: rel, status: 'added', additions: content.split('\n').length, deletions: 0 });
-      }
+  // Check for new files. The re-walk is the expensive half of a poll and new
+  // files appear far less often than existing ones change, so run discovery
+  // every Nth poll. A file added in the gap surfaces on the next discovery
+  // pass rather than being missed.
+  const polls = (pollCounts.get(cwd) ?? 0) + 1;
+  const rewalk = polls >= REWALK_EVERY_N_POLLS;
+  pollCounts.set(cwd, rewalk ? 0 : polls);
+
+  // Discovered additions are remembered, so they keep being reported on the
+  // polls between re-walks instead of flickering out of the list and back in.
+  let known = addedPaths.get(cwd);
+  if (!known) { known = new Set<string>(); addedPaths.set(cwd, known); }
+
+  if (rewalk) {
+    const currentFiles: string[] = [];
+    await walkDir(cwd, cwd, currentFiles);
+    for (const rel of currentFiles) {
+      if (!snap.has(rel)) known.add(rel);
     }
+  }
+
+  for (const rel of [...known]) {
+    const content = await readCurrentFile(cwd, rel);
+    if (content === null) { known.delete(rel); continue; } // gone again
+    changed.push({ path: rel, status: 'added', additions: content.split('\n').length, deletions: 0 });
   }
 
   return changed;
@@ -374,7 +426,7 @@ export async function getFileDiff(cwd: string, file: string): Promise<string> {
       try {
         const absPath = path.isAbsolute(file) ? file : path.join(cwd, file);
         const resolved = path.resolve(absPath);
-        if (!resolved.startsWith(path.resolve(cwd))) return '';
+        if (!isWithin(path.resolve(cwd), resolved)) return '';
         const stat = fs.statSync(resolved);
         if (stat.size > MAX_UNTRACKED_SIZE) return '(File too large to display inline)';
         const buf = fs.readFileSync(resolved);
@@ -405,4 +457,6 @@ export async function getFileDiff(cwd: string, file: string): Promise<string> {
 /** Reset the snapshot for a directory so next poll re-baselines. */
 export function resetSnapshot(cwd: string): void {
   snapshots.delete(cwd);
+  pollCounts.delete(cwd);
+  addedPaths.delete(cwd);
 }

--- a/tests/unit/diff-provider.test.ts
+++ b/tests/unit/diff-provider.test.ts
@@ -28,20 +28,32 @@ describe('diff-provider snapshot system (non-git cwd)', () => {
     expect(await getChangedFiles(TEST_DIR)).toEqual([]);
   });
 
-  it('detects modified, added, and deleted files against the baseline', async () => {
+  it('detects modified and deleted files on the very next poll', async () => {
     write('a.ts', 'one\n');
     write('b.ts', 'keep\n');
     await getChangedFiles(TEST_DIR); // baseline
 
     write('a.ts', 'one\ntwo\n');
-    write('c.ts', 'new\n');
     fs.rmSync(path.join(TEST_DIR, 'b.ts'));
 
     const changed = await getChangedFiles(TEST_DIR);
     const byPath = new Map(changed.map(c => [c.path, c]));
     expect(byPath.get('a.ts')?.status).toBe('modified');
-    expect(byPath.get('c.ts')?.status).toBe('added');
     expect(byPath.get('b.ts')?.status).toBe('deleted');
+  });
+
+  it('detects added files once the periodic re-walk runs', async () => {
+    write('a.ts', 'one\n');
+    await getChangedFiles(TEST_DIR); // baseline
+    write('c.ts', 'new\n');
+
+    // Discovery is deliberately on a slower cadence than the content check,
+    // so an added file appears within REWALK_EVERY_N_POLLS polls, not instantly.
+    let added;
+    for (let i = 0; i < 5 && !added; i++) {
+      added = (await getChangedFiles(TEST_DIR)).find(c => c.path === 'c.ts');
+    }
+    expect(added?.status).toBe('added');
   });
 
   it('does not report a file whose mtime moved but whose content is unchanged', async () => {
@@ -65,6 +77,48 @@ describe('diff-provider snapshot system (non-git cwd)', () => {
     const diff = await getFileDiff(TEST_DIR, 'a.ts');
     expect(diff).toContain('-line2');
     expect(diff).toContain('+changed');
+  });
+
+  it('keeps reporting a newly added file on the polls between re-walks', async () => {
+    write('a.ts', 'one\n');
+    await getChangedFiles(TEST_DIR); // baseline
+
+    write('new.ts', 'hello\n');
+    // Discovery runs every 5th poll; run enough polls to pass one, then keep
+    // polling and assert the added file does not flicker out of the list.
+    let seen = 0;
+    for (let i = 0; i < 12; i++) {
+      const changed = await getChangedFiles(TEST_DIR);
+      const added = changed.find(c => c.path === 'new.ts');
+      if (added) seen++;
+      // Once discovered, it must appear on every subsequent poll
+      if (seen > 0) expect(added?.status).toBe('added');
+    }
+    expect(seen).toBeGreaterThan(0);
+  });
+
+  it('drops a discovered file from the list once it is deleted again', async () => {
+    write('a.ts', 'one\n');
+    await getChangedFiles(TEST_DIR); // baseline
+    write('temp.ts', 'x\n');
+    for (let i = 0; i < 6; i++) await getChangedFiles(TEST_DIR); // let discovery run
+
+    fs.rmSync(path.join(TEST_DIR, 'temp.ts'));
+    const changed = await getChangedFiles(TEST_DIR);
+    expect(changed.find(c => c.path === 'temp.ts')).toBeUndefined();
+  });
+
+  it('ignores platform directories such as AppData', async () => {
+    write('AppData/Local/thing/deep.ts', 'should not be seen\n');
+    write('real.ts', 'baseline\n');
+    await getChangedFiles(TEST_DIR); // baseline
+
+    write('AppData/Local/thing/deep.ts', 'changed\n');
+    write('real.ts', 'changed\n');
+    for (let i = 0; i < 6; i++) {
+      const changed = await getChangedFiles(TEST_DIR);
+      expect(changed.some(c => c.path.startsWith('AppData/'))).toBe(false);
+    }
   });
 
   it('coalesces concurrent scans of the same directory', async () => {


### PR DESCRIPTION
Follow-ups **(1)** and **(2)** from #133, which were deliberately left out of #135 as design calls rather than bug fixes. **(3)** — whether to offer the fallback at all for home-like trees — is still yours; happy to implement whatever you land on.

## (1) Bound the walk, not just the read

`SNAPSHOT_IGNORE` gains the platform directories: `AppData`, `Library`, `Application Data`, `$RECYCLE.BIN`, `System Volume Information`, `OneDrive`, `Recovery`.

More importantly, `MAX_SNAPSHOT_DIRS` (500) is now threaded through `walkDir` as a mutable budget shared across the recursion, so traversal is bounded independently of the file cap. This is the half you identified as the important one: the 2,000-file cap bounds how much we *read*, but ~3,578 directories were still enumerated before it bit, and the resulting 2,000 files were an accident of traversal order.

## (2) Slower discovery cadence

The re-walk that finds *new* files now runs every 5th poll (`REWALK_EVERY_N_POLLS`). The stat-based check for *existing* files still runs every poll.

**Behaviour change worth calling out explicitly:** a newly added file now appears within ~10s instead of ~2s. Modifications and deletions are unchanged — they come from the snapshot map and are still detected on the very next poll. If you want a different number, it's a one-line constant.

There's a trap in this change that isn't obvious: because newly discovered files are not in the snapshot map, running discovery only every Nth poll makes them *flicker* — present on poll 5, absent on 6–9, present on 10. So discovered additions are now remembered per-cwd in `addedPaths` and re-reported on every poll (and dropped when the file goes away). `resetSnapshot` clears that alongside the snapshot. Two tests pin this: one that an added file keeps appearing across 12 consecutive polls, one that it disappears once deleted.

## Also: the prefix check you noted

`resolveWithin` used `resolved.startsWith(path.resolve(cwd))`, which accepts `C:\foobar` as inside `C:\foo`. The untracked-file branch of `getFileDiff` had the identical test three lines away. Both now go through one `isWithin` helper built on `path.relative`.

Neither was reachable — as you said, the paths come from a walk of `cwd` itself — so this is hygiene, not a security fix. Flagging it as slightly outside what you asked for; it seemed odd to fix one and leave its twin adjacent to it.

## Tests

`tests/unit/diff-provider.test.ts` grows from 5 to 9 cases:
- added files surface once the periodic re-walk runs
- an added file keeps being reported between re-walks (no flicker)
- a discovered file drops out of the list once deleted
- `AppData/**` is never reported, across several polls

The pre-existing "modified, added, deleted" case was split in two, because added-file detection is deliberately no longer immediate and the old case asserted that it was. Modified/deleted still assert next-poll detection.

Full suite: 61 files, 667 tests passing. `npm run typecheck` and `npm run lint` clean.
