### PR TITLE
fix(pty): reap process trees orphaned by an abnormal exit (#139)

### DIFF
--- a/src/cli/wmux-hook.ts
+++ b/src/cli/wmux-hook.ts
@@ -32,9 +32,31 @@ let stdinData = '';
 let sent = false;
 const MAX_STDIN = 64 * 1024; // 64KB cap
 
+/**
+ * Backstop ceiling on this process's lifetime once it starts talking to the
+ * pipe. Every other way out of here is event-driven; this is the one that does
+ * not depend on an event arriving.
+ *
+ * Deliberately a backstop and not a fix for an observed hang: measured against
+ * an absent, a responsive and a wedged (accepts, never answers) server, the
+ * hook exits on its own in every case, because on Windows named pipes `end()`
+ * tears the connection down rather than half-closing it. The wmux CLI has
+ * always armed this same 5s timer before connecting (see sendV1/sendV2); the
+ * hook helper was the one client without it, and matching costs nothing.
+ */
+const PIPE_DEADLINE_MS = 5000;
+
+/** Cleared once we stop reading, so the happy path is not held open by it. */
+let stdinTimer: NodeJS.Timeout | null = null;
+
 function sendHook(): void {
   if (sent) return;
   sent = true;
+  if (stdinTimer) { clearTimeout(stdinTimer); stdinTimer = null; }
+  // stdin is a live handle that keeps the event loop alive on its own. If the
+  // caller opened it and never closes it, exiting would otherwise wait on a
+  // stream nobody is going to end.
+  process.stdin.pause();
 
   let file = '';
   let message = '';
@@ -63,9 +85,24 @@ function sendHook(): void {
   const client = net.connect({ path: pipePath }, () => {
     const msg = JSON.stringify({ method: 'hook.event', params, id: 1, token });
     client.write(msg + '\n', () => client.end());
+    // Drain the reply we do not care about. This is not cosmetic: wmux answers
+    // but never closes the connection (pipe-server.ts), and a socket left in
+    // paused mode never reads far enough to see EOF — so it never emits 'end',
+    // never auto-destroys, and never emits 'close'. Without this the deadline
+    // below becomes the ONLY way out and every hook takes the full 5s.
+    client.resume();
   });
+  // Referenced, not unref'd: it has to be able to fire while the pending socket
+  // is what is holding the loop open. 'close' covers both a clean end and a
+  // destroy, so the happy path clears it immediately rather than lingering.
+  const deadline = setTimeout(() => {
+    client.destroy();
+    process.exit(0);
+  }, PIPE_DEADLINE_MS);
+  client.on('close', () => clearTimeout(deadline));
   client.on('error', () => {
     // wmux not running — silently ignore.
+    clearTimeout(deadline);
     process.exit(0);
   });
 }
@@ -77,7 +114,13 @@ process.stdin.on('end', sendHook);
 process.stdin.on('error', sendHook);
 
 // Timeout: if no stdin arrives within 1s, send without payload info.
-setTimeout(sendHook, 1000);
+//
+// Held in a variable so sendHook can clear it (issue #139). Left armed, this
+// one timer kept EVERY hook process — including the ones whose work finished in
+// ~90ms — resident for the full second: measured 1049ms before, 101ms after.
+// Claude Code fires a hook per tool call in every pane, so under a few busy
+// agents that is a standing population of node.exe doing nothing.
+stdinTimer = setTimeout(sendHook, 1000);
 
 // If stdin is already ended (e.g. no pipe), send immediately.
 if (process.stdin.readableEnded) sendHook();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, ipcMain, shell } from 'electron';
-import { registerIpcHandlers, agentManager, ptyManager, setupAgentPtyForwarding } from './ipc-handlers';
+import { registerIpcHandlers, agentManager, ptyManager, setupAgentPtyForwarding, reapOrphanedPtys } from './ipc-handlers';
 import { handleBrowserV2 } from './v2-browser';
 import { handleBridgeV2 } from './v2-bridge';
 import { distributeAgents } from './agent-manager';
@@ -477,6 +477,18 @@ app.whenReady().then(() => {
   });
 
   registerIpcHandlers(windowManager, cdpProxy);
+
+  // Tree-kill whatever a previously CRASHED instance left running (issue #139).
+  // `will-quit` — the only thing that calls killAll() — does not run on a crash,
+  // and Windows does not tear down a process tree when its root dies, so every
+  // pane's shell, its agent and that agent's MCP servers survive. Restoring the
+  // session below then spawns a fresh set beside them, so without this a
+  // crash-loop multiplies processes instead of replacing them.
+  //
+  // Runs before the restore for tidiness only: the orphans are unrelated to the
+  // PTYs about to be created, and the reap itself is async and unawaited so
+  // startup never blocks on it.
+  reapOrphanedPtys();
 
   // Clear stale session data on version change (clean start for upgrades/fresh installs)
   handleVersionChange(app.getVersion());

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -6,6 +6,8 @@ import { IPC_CHANNELS, SurfaceId, WindowId, WorkspaceId, AgentId } from '../shar
 import { observePtyData, clearActivity } from './claude-observer';
 import { clearAgentState } from './agent-state';
 import { PtyManager } from './pty-manager';
+import { PtyLedger, reapOrphans } from './pty-ledger';
+import { getAppDataDir } from '../shared/instance';
 import { NotificationManager } from './notification-manager';
 import { detectShells } from './shell-detector';
 import { listSystemFonts } from './font-detector';
@@ -32,10 +34,27 @@ import {
 } from './markdown-file';
 import { grantMarkdownPath, isMarkdownPathGranted } from './markdown-grants';
 
-const ptyManager = new PtyManager();
+// Claimed at module load, before anything can spawn a PTY, so the candidate
+// list is strictly what a PREVIOUS instance left behind (issue #139). The
+// killing half is async and driven from index.ts once the app is up.
+const ptyLedger = new PtyLedger(path.join(getAppDataDir(), 'pty-ledger.json'));
+const orphanCandidates = ptyLedger.takeOver();
+
+const ptyManager = new PtyManager(ptyLedger);
 const notificationManager = new NotificationManager();
 const cdpBridge = new CDPBridge();
 const agentManager = new AgentManager(ptyManager);
+
+/**
+ * Tree-kill the PTY subtrees a previously crashed wmux left running (issue
+ * #139). Best-effort and unawaited by design — see reapOrphans().
+ */
+export function reapOrphanedPtys(): void {
+  reapOrphans(orphanCandidates).then(
+    () => { /* reaped, or nothing to reap */ },
+    (err) => { console.warn('[wmux] orphan reap failed:', err?.message); },
+  );
+}
 
 export function registerIpcHandlers(windowManager: WindowManager, cdpProxyInstance?: CDPProxy): void {
   // Toggle DevTools for the renderer window

--- a/src/main/pty-ledger.ts
+++ b/src/main/pty-ledger.ts
@@ -1,0 +1,274 @@
+/**
+ * Orphan reaping across an abnormal wmux death (issue #139).
+ *
+ * `PtyManager.kill()` already tree-kills a pane's whole subtree with
+ * `taskkill /T /F` (issue #65) — Claude Code's backend and the MCP servers it
+ * spawns are grandchildren that do not share the pseudoconsole's lifetime, so
+ * nothing else reaps them. But every caller of that path requires wmux to be
+ * alive and cooperating: closing a pane, or `killAll()` on `will-quit`.
+ *
+ * A native crash reaches none of them, and Windows does not tear down a process
+ * tree when the root dies — descendants are reparented and keep running. So a
+ * crashed wmux leaves every pane's shell, its agent, and each of that agent's
+ * MCP servers resident. Restarting restores the session and spawns a fresh set
+ * beside them; a crash-loop multiplies rather than replaces (the reporter saw
+ * 251 processes / 3.3 GB across six crash cycles).
+ *
+ * The fix is a ledger of spawned PIDs on disk. The next launch takes it over,
+ * and anything the dead instance left behind is tree-killed.
+ *
+ * ── On not killing the wrong process ──────────────────────────────────────
+ * Windows recycles PIDs, and this runs `taskkill /T /F`, so a stale ledger
+ * entry whose PID has since been reused would kill an unrelated process *and
+ * its children*. A recorded PID being alive is therefore NOT sufficient
+ * evidence that it is ours. Before killing anything we re-query the live
+ * process and require its image name and creation time to match what we
+ * recorded. Every failure — no PowerShell, a query error, unparseable output —
+ * reaps nothing. Leaking a process is recoverable; killing the user's editor
+ * is not.
+ */
+
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** One spawned PTY root, as recorded at spawn time. */
+export interface LedgerEntry {
+  pid: number;
+  /** Image file name (`pwsh.exe`), re-checked before killing. */
+  image: string;
+  /** Epoch ms, stamped immediately after `pty.spawn` returned. */
+  startedAt: number;
+}
+
+interface LedgerFile {
+  ownerPid: number;
+  entries: LedgerEntry[];
+}
+
+/** A live process as reported by Win32_Process. */
+export interface LiveProcess {
+  pid: number;
+  image: string;
+  /** Epoch ms of the real process creation time. */
+  startedAt: number;
+}
+
+/**
+ * How far a live process's creation time may sit from the recorded `startedAt`
+ * and still count as the same process.
+ *
+ * `startedAt` is stamped microseconds after `pty.spawn` returns, so a genuine
+ * match is near-exact and this window only absorbs clock skew. It is not a
+ * fuzzy match: a recycled PID would have to be reborn under the same image
+ * name within a minute of the original to slip through both checks.
+ */
+export const REUSE_TOLERANCE_MS = 60_000;
+
+/** Ledger entries beyond this are dropped — a file this large is corrupt, not real. */
+const MAX_ENTRIES = 512;
+
+/**
+ * The PIDs from `entries` that are still alive AND still the process we
+ * recorded. Pure, because this is the decision that force-kills process trees:
+ * everything it needs is passed in, so the safety rules are testable without
+ * spawning anything.
+ */
+export function selectOrphans(entries: LedgerEntry[], live: LiveProcess[]): number[] {
+  const byPid = new Map(live.map((p) => [p.pid, p]));
+  const orphans: number[] = [];
+  for (const entry of entries) {
+    const found = byPid.get(entry.pid);
+    if (!found) continue; // already gone — the common case
+    // A recycled PID. Either check failing is enough to disqualify it.
+    if (found.image.toLowerCase() !== entry.image.toLowerCase()) continue;
+    if (Math.abs(found.startedAt - entry.startedAt) > REUSE_TOLERANCE_MS) continue;
+    orphans.push(entry.pid);
+  }
+  return orphans;
+}
+
+/** Drop anything that isn't a well-formed entry — the file is user-writable. */
+export function parseEntries(raw: unknown): LedgerEntry[] {
+  const entries = (raw as LedgerFile | null)?.entries;
+  if (!Array.isArray(entries)) return [];
+  return entries
+    .filter(
+      (e): e is LedgerEntry =>
+        !!e &&
+        typeof e.pid === 'number' &&
+        Number.isInteger(e.pid) &&
+        e.pid > 0 &&
+        typeof e.image === 'string' &&
+        e.image.length > 0 &&
+        typeof e.startedAt === 'number' &&
+        Number.isFinite(e.startedAt),
+    )
+    .slice(0, MAX_ENTRIES);
+}
+
+function systemRoot(): string {
+  return process.env.SystemRoot || process.env.windir || 'C:\\Windows';
+}
+
+/**
+ * Creation time + image name for the given PIDs.
+ *
+ * PowerShell rather than `wmic`, which is being removed from Windows, and
+ * resolved by absolute path rather than through PATH for the same reason
+ * `PtyManager.kill()` resolves taskkill that way — a writeable directory on
+ * PATH must not be able to shadow it. The command deliberately contains no
+ * double quotes so nothing depends on how execFile escapes the argument.
+ *
+ * Returns [] on any failure, which reaps nothing.
+ */
+export function queryProcesses(pids: number[]): Promise<LiveProcess[]> {
+  if (pids.length === 0) return Promise.resolve([]);
+  const filter = pids.map((pid) => `ProcessId=${pid}`).join(' or ');
+  const script =
+    `Get-CimInstance Win32_Process -Filter '${filter}' | ForEach-Object { ` +
+    `Write-Output ('{0}|{1}|{2}' -f $_.ProcessId,$_.Name,` +
+    `[int64]($_.CreationDate.ToUniversalTime()-[datetime]'1970-01-01').TotalMilliseconds) }`;
+  const shell = path.join(systemRoot(), 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+
+  return new Promise((resolve) => {
+    execFile(
+      shell,
+      ['-NoProfile', '-NonInteractive', '-Command', script],
+      { windowsHide: true, timeout: 15_000 },
+      (err, stdout) => {
+        if (err) {
+          console.warn('[wmux] orphan scan failed, reaping nothing:', err.message);
+          resolve([]);
+          return;
+        }
+        resolve(parseProcessLines(stdout));
+      },
+    );
+  });
+}
+
+/** Parse the `pid|image|epochMs` lines emitted by queryProcesses. */
+export function parseProcessLines(stdout: string): LiveProcess[] {
+  const live: LiveProcess[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const parts = line.trim().split('|');
+    if (parts.length !== 3) continue;
+    const pid = Number(parts[0]);
+    const startedAt = Number(parts[2]);
+    if (!Number.isInteger(pid) || pid <= 0 || !Number.isFinite(startedAt) || !parts[1]) continue;
+    live.push({ pid, image: parts[1], startedAt });
+  }
+  return live;
+}
+
+/** Force-kill a PID and everything below it. Same invocation as PtyManager.kill(). */
+function treeKill(pid: number): void {
+  try {
+    const taskkill = path.join(systemRoot(), 'System32', 'taskkill.exe');
+    const killer = execFile(taskkill, ['/PID', String(pid), '/T', '/F'], { windowsHide: true });
+    killer.on('error', () => {
+      /* taskkill missing, or the tree died between the scan and now */
+    });
+  } catch {
+    /* spawn failed — nothing further to try */
+  }
+}
+
+/**
+ * The on-disk record of what this instance has spawned.
+ *
+ * Writes are synchronous and whole-file: the list is at most a few dozen
+ * entries, and the write has to have landed before the process can crash for
+ * the ledger to be worth anything.
+ */
+export class PtyLedger {
+  private entries: LedgerEntry[] = [];
+  private enabled = true;
+
+  constructor(private readonly filePath: string) {}
+
+  /**
+   * Claim the ledger for this process and return what the previous owner left
+   * behind — candidates only; `selectOrphans` still has to clear them.
+   *
+   * Returns [] when the recorded owner is still running: those processes have
+   * a live parent and are not orphans at all. The single-instance lock makes
+   * that near-impossible, but "kill the other instance's terminals" is a bad
+   * enough outcome to check for explicitly.
+   */
+  takeOver(): LedgerEntry[] {
+    let previous: LedgerEntry[] = [];
+    try {
+      const raw = JSON.parse(fs.readFileSync(this.filePath, 'utf-8'));
+      const ownerPid = Number(raw?.ownerPid);
+      previous = ownerPid && ownerPid !== process.pid && isAlive(ownerPid) ? [] : parseEntries(raw);
+    } catch {
+      // No ledger, or an unreadable one. Either way there is nothing to reap.
+    }
+    this.flush();
+    return previous;
+  }
+
+  add(pid: number, image: string): void {
+    if (!this.enabled) return;
+    this.entries.push({ pid, image, startedAt: Date.now() });
+    this.flush();
+  }
+
+  remove(pid: number): void {
+    if (!this.enabled) return;
+    const next = this.entries.filter((e) => e.pid !== pid);
+    if (next.length === this.entries.length) return; // not ours / already gone
+    this.entries = next;
+    this.flush();
+  }
+
+  /** Everything was just killed — one write instead of one per PID. */
+  clear(): void {
+    if (!this.enabled || this.entries.length === 0) return;
+    this.entries = [];
+    this.flush();
+  }
+
+  private flush(): void {
+    const payload: LedgerFile = { ownerPid: process.pid, entries: this.entries };
+    try {
+      fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+      fs.writeFileSync(this.filePath, JSON.stringify(payload), 'utf-8');
+    } catch (err) {
+      // A ledger we cannot write is a ledger we must not read next launch, or
+      // we would reap against a stale list. Go inert rather than half-correct.
+      this.enabled = false;
+      console.warn('[wmux] PTY ledger disabled (write failed):', (err as Error).message);
+    }
+  }
+}
+
+/** Whether a PID is currently running. Signal 0 tests without delivering. */
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM means it exists but belongs to someone else — still alive.
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Reap what a previously crashed instance left running.
+ *
+ * Best-effort and fire-and-forget: the orphans are unrelated to the PTYs this
+ * launch is about to spawn, so nothing needs to wait on it, and startup must
+ * not block on a PowerShell round-trip.
+ */
+export async function reapOrphans(candidates: LedgerEntry[]): Promise<number[]> {
+  if (process.platform !== 'win32' || candidates.length === 0) return [];
+  const live = await queryProcesses(candidates.map((e) => e.pid));
+  const orphans = selectOrphans(candidates, live);
+  if (orphans.length === 0) return [];
+  console.warn(`[wmux] reaping ${orphans.length} process tree(s) orphaned by a previous crash (issue #139)`);
+  for (const pid of orphans) treeKill(pid);
+  return orphans;
+}

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -5,6 +5,7 @@ import { execFileSync, spawn } from 'child_process';
 import { v4 as uuidv4 } from 'uuid';
 import { SurfaceId } from '../shared/types';
 import { getPipePath, readPipeToken } from '../shared/instance';
+import { PtyLedger } from './pty-ledger';
 
 // ─── Shell resolution ──────────────────────────────────────────────────────
 // Validates that a shell executable exists before spawning.
@@ -251,6 +252,16 @@ const DA1_REPLY = '\x1b[?62;4;9;22c';
 export class PtyManager {
   private ptys = new Map<SurfaceId, PtyEntry>();
 
+  /**
+   * Optional on-disk record of every PID spawned here, so the next launch can
+   * tree-kill whatever this process left running if it dies without reaching
+   * `killAll()` (issue #139). Optional rather than constructed internally
+   * because tests spawn real PTYs: without an explicit ledger they must not
+   * touch — let alone overwrite — the ledger of the wmux instance the user has
+   * running on the same machine.
+   */
+  constructor(private readonly ledger: PtyLedger | null = null) {}
+
   // ConPTY's input pipe silently drops bytes when a single write outruns the
   // foreground process. Splitting at ~1 KB keeps every chunk well under the
   // pipe buffer; setImmediate between chunks lets ConPTY drain without adding
@@ -400,11 +411,18 @@ export class PtyManager {
 
     ptyProcess.onExit(({ exitCode }) => {
       entry.alive = false; // stops any in-flight chunked write
+      if (typeof ptyProcess.pid === 'number') this.ledger?.remove(ptyProcess.pid);
       for (const listener of entry.exitListeners) {
         listener(exitCode);
       }
       this.ptys.delete(id);
     });
+
+    // Recorded after the listeners are attached but before returning, so a
+    // crash between here and the first user keystroke still leaves a trail.
+    if (typeof ptyProcess.pid === 'number' && ptyProcess.pid > 0) {
+      this.ledger?.add(ptyProcess.pid, path.basename(shell));
+    }
 
     this.ptys.set(id, entry);
     return { id, shell, startupCommandsConsumed, reused: false };
@@ -517,6 +535,7 @@ export class PtyManager {
     } catch {
       // Process may already be dead
     }
+    if (typeof pid === 'number') this.ledger?.remove(pid);
     this.ptys.delete(id);
   }
 
@@ -524,6 +543,9 @@ export class PtyManager {
     for (const id of this.ptys.keys()) {
       this.kill(id);
     }
+    // Belt and braces: kill() already dropped each PID, but killAll() is the
+    // shutdown path and the ledger must not outlive it under any partial failure.
+    this.ledger?.clear();
   }
 
   has(id: SurfaceId): boolean {

--- a/tests/unit/pty-ledger.test.ts
+++ b/tests/unit/pty-ledger.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  PtyLedger,
+  selectOrphans,
+  parseEntries,
+  parseProcessLines,
+  queryProcesses,
+  REUSE_TOLERANCE_MS,
+  type LedgerEntry,
+  type LiveProcess,
+} from '../../src/main/pty-ledger';
+
+// Issue #139: a crashed wmux never reaches will-quit, so killAll() never runs
+// and every pane's shell — plus the agent and MCP servers beneath it — keeps
+// running. The ledger is what lets the next launch find them.
+//
+// The tests that matter most here are the ones that pin what must NOT be
+// killed: this list feeds `taskkill /T /F`, so a stale entry whose PID has been
+// recycled would take out an unrelated process tree.
+
+const T0 = 1_700_000_000_000;
+
+const entry = (pid: number, image = 'pwsh.exe', startedAt = T0): LedgerEntry => ({ pid, image, startedAt });
+const live = (pid: number, image = 'pwsh.exe', startedAt = T0): LiveProcess => ({ pid, image, startedAt });
+
+describe('selectOrphans', () => {
+  it('selects a recorded PID that is still alive and still the same process', () => {
+    expect(selectOrphans([entry(1234)], [live(1234)])).toEqual([1234]);
+  });
+
+  it('ignores a recorded PID that is no longer running (the common case)', () => {
+    expect(selectOrphans([entry(1234)], [])).toEqual([]);
+  });
+
+  it('does NOT select a recycled PID now running a different image', () => {
+    expect(selectOrphans([entry(1234, 'pwsh.exe')], [live(1234, 'chrome.exe')])).toEqual([]);
+  });
+
+  it('does NOT select a recycled PID with the same image but a later creation time', () => {
+    const recycled = live(1234, 'pwsh.exe', T0 + REUSE_TOLERANCE_MS + 1);
+    expect(selectOrphans([entry(1234, 'pwsh.exe', T0)], [recycled])).toEqual([]);
+  });
+
+  it('tolerates clock skew inside the reuse window', () => {
+    const skewed = live(1234, 'pwsh.exe', T0 + REUSE_TOLERANCE_MS - 1);
+    expect(selectOrphans([entry(1234, 'pwsh.exe', T0)], [skewed])).toEqual([1234]);
+  });
+
+  it('matches the image name case-insensitively (Win32_Process casing varies)', () => {
+    expect(selectOrphans([entry(1234, 'PWSH.EXE')], [live(1234, 'pwsh.exe')])).toEqual([1234]);
+  });
+
+  it('selects only the surviving entries out of a mixed list', () => {
+    const entries = [entry(1, 'pwsh.exe'), entry(2, 'cmd.exe'), entry(3, 'wsl.exe')];
+    const alive = [live(1, 'pwsh.exe'), live(2, 'notepad.exe'), live(3, 'wsl.exe')];
+    expect(selectOrphans(entries, alive)).toEqual([1, 3]);
+  });
+});
+
+describe('parseProcessLines', () => {
+  it('parses the pid|image|epochMs lines the PowerShell probe emits', () => {
+    const out = '4321|pwsh.exe|1700000000000\r\n99|cmd.exe|1700000001000\r\n';
+    expect(parseProcessLines(out)).toEqual([
+      { pid: 4321, image: 'pwsh.exe', startedAt: 1_700_000_000_000 },
+      { pid: 99, image: 'cmd.exe', startedAt: 1_700_000_001_000 },
+    ]);
+  });
+
+  it('drops malformed lines rather than inventing a process to kill', () => {
+    const out = ['', 'garbage', '12|pwsh.exe', 'abc|pwsh.exe|1700000000000', '0|pwsh.exe|1700000000000',
+      '13||1700000000000', '14|pwsh.exe|notanumber', '15|pwsh.exe|1700000000000'].join('\n');
+    expect(parseProcessLines(out)).toEqual([{ pid: 15, image: 'pwsh.exe', startedAt: 1_700_000_000_000 }]);
+  });
+});
+
+describe('parseEntries', () => {
+  it('keeps well-formed entries', () => {
+    expect(parseEntries({ entries: [entry(7)] })).toEqual([entry(7)]);
+  });
+
+  it('drops anything malformed — the file is user-writable', () => {
+    const raw = {
+      entries: [
+        null,
+        { pid: 0, image: 'pwsh.exe', startedAt: T0 },
+        { pid: -1, image: 'pwsh.exe', startedAt: T0 },
+        { pid: 1.5, image: 'pwsh.exe', startedAt: T0 },
+        { pid: 8, image: '', startedAt: T0 },
+        { pid: 9, image: 'pwsh.exe' },
+        { pid: 10, image: 'pwsh.exe', startedAt: T0 },
+      ],
+    };
+    expect(parseEntries(raw)).toEqual([entry(10)]);
+  });
+
+  it('returns [] for a file with no entries array', () => {
+    expect(parseEntries(null)).toEqual([]);
+    expect(parseEntries({})).toEqual([]);
+    expect(parseEntries({ entries: 'nope' })).toEqual([]);
+  });
+});
+
+describe('PtyLedger', () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-ledger-'));
+    file = path.join(dir, 'pty-ledger.json');
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  const read = () => JSON.parse(fs.readFileSync(file, 'utf-8'));
+
+  it('records a spawned PID and stamps this process as the owner', () => {
+    const ledger = new PtyLedger(file);
+    ledger.add(4242, 'pwsh.exe');
+
+    const saved = read();
+    expect(saved.ownerPid).toBe(process.pid);
+    expect(saved.entries).toHaveLength(1);
+    expect(saved.entries[0]).toMatchObject({ pid: 4242, image: 'pwsh.exe' });
+    expect(saved.entries[0].startedAt).toBeGreaterThan(0);
+  });
+
+  it('forgets a PID once its PTY is killed, so a clean shutdown leaves nothing to reap', () => {
+    const ledger = new PtyLedger(file);
+    ledger.add(1, 'pwsh.exe');
+    ledger.add(2, 'cmd.exe');
+    ledger.remove(1);
+
+    expect(read().entries.map((e: LedgerEntry) => e.pid)).toEqual([2]);
+    ledger.clear();
+    expect(read().entries).toEqual([]);
+  });
+
+  it('takeOver returns what a dead owner left behind, then claims the file', () => {
+    // A PID far above the Windows range, so it cannot be running.
+    fs.writeFileSync(file, JSON.stringify({ ownerPid: 0x7ffffff0, entries: [entry(4242)] }));
+
+    const orphans = new PtyLedger(file).takeOver();
+
+    expect(orphans).toEqual([entry(4242)]);
+    expect(read()).toEqual({ ownerPid: process.pid, entries: [] });
+  });
+
+  it('takeOver returns nothing when the recorded owner is still running', () => {
+    // Those PTYs have a live parent — they are not orphans, and killing them
+    // would tear down another instance's terminals.
+    expect(process.ppid).toBeGreaterThan(0);
+    fs.writeFileSync(file, JSON.stringify({ ownerPid: process.ppid, entries: [entry(4242)] }));
+
+    expect(new PtyLedger(file).takeOver()).toEqual([]);
+  });
+
+  it('takeOver reclaims a ledger this same PID already owned', () => {
+    fs.writeFileSync(file, JSON.stringify({ ownerPid: process.pid, entries: [entry(4242)] }));
+    expect(new PtyLedger(file).takeOver()).toEqual([entry(4242)]);
+  });
+
+  it('takeOver survives a missing or corrupt ledger', () => {
+    expect(new PtyLedger(file).takeOver()).toEqual([]);
+
+    fs.writeFileSync(file, 'not json {{{');
+    expect(new PtyLedger(file).takeOver()).toEqual([]);
+  });
+
+  it('creates the ledger directory if it does not exist yet', () => {
+    const nested = path.join(dir, 'a', 'b', 'pty-ledger.json');
+    new PtyLedger(nested).add(1, 'pwsh.exe');
+    expect(fs.existsSync(nested)).toBe(true);
+  });
+});
+
+describe('queryProcesses (live Win32_Process probe)', () => {
+  it('answers nothing for an empty request without spawning PowerShell', async () => {
+    expect(await queryProcesses([])).toEqual([]);
+  });
+
+  // The command string is built to contain no double quotes so nothing depends
+  // on execFile's escaping — this is the test that proves that actually holds.
+  // Probing our own PID keeps it hermetic: the answer is known, and nothing
+  // here ever reaches the killing half.
+  it('reports this process with a real image name and creation time', async () => {
+    const found = await queryProcesses([process.pid]);
+
+    expect(found).toHaveLength(1);
+    expect(found[0].pid).toBe(process.pid);
+    expect(found[0].image.toLowerCase()).toMatch(/\.exe$/);
+    expect(found[0].startedAt).toBeLessThanOrEqual(Date.now());
+    expect(found[0].startedAt).toBeGreaterThan(Date.now() - 24 * 60 * 60 * 1000);
+  }, 30_000);
+
+  it('would not select this process from a ledger entry naming a different image', async () => {
+    const [self] = await queryProcesses([process.pid]);
+    const stale = entry(process.pid, 'pwsh.exe', self.startedAt);
+
+    expect(selectOrphans([stale], [self])).toEqual([]);
+  }, 30_000);
+});


### PR DESCRIPTION
Closes #139.

## What actually goes wrong

`killAll()` is reachable from exactly one place — `app.on('will-quit')` — and that does not run when the process dies abnormally. Windows does not tear down a process tree when its root dies, so a crashed wmux leaves every pane's shell resident, along with the agent under it and each of that agent's MCP servers. Restoring the session then spawns a fresh set *beside* them, so a crash-loop multiplies processes instead of replacing them. Six crash cycles is how the reporter reached 251 `node.exe` / 3.3 GB.

The tree-kill itself was never the problem: `PtyManager.kill()` has done `taskkill /PID <pid> /T /F` since #65, precisely because Claude Code's backend orphans otherwise. Every caller just required wmux to be alive and cooperating to reach it.

## The fix

A ledger of spawned PIDs under `APPDATA`. Each spawn appends, each kill removes, `killAll()` clears. The next launch claims the file and reaps whatever a dead owner left behind.

**On not killing the wrong process.** This list feeds `taskkill /T /F`, so a stale entry whose PID has since been recycled would kill an unrelated process *and its children*. A recorded PID being alive is therefore not evidence that it is ours. Before killing anything, each PID is re-queried through `Win32_Process` and must still match the image name **and** the creation time recorded at spawn. Every failure path — no PowerShell, a query error, unparseable output — reaps nothing: leaking a process is recoverable, killing the user's editor is not. `selectOrphans()` is pure so those rules are tested without spawning anything.

Two smaller notes:

- The ledger is **injected** into `PtyManager` rather than constructed inside it. The pty tests spawn real shells, and must not overwrite the ledger of an instance the user has running on the same machine.
- `takeOver()` returns nothing when the recorded owner is still running — those PTYs have a live parent and are not orphans.

## Also: two hook lifetimes

Found while chasing the same symptom, in `wmux-hook.js`:

- The 1s stdin fallback timer was never cleared, so **every** hook process stayed resident for a full second even when its work finished in ~90 ms. Claude Code fires one per tool call, per pane. Measured **1049 ms → 101 ms**.
- The reply was never read. On Windows named pipes `end()` tears the connection down, but a paused socket has no queued read, so the EOF never surfaces to JS — `'end'` and `'close'` never fire. `resume()` makes the close observable and deterministic.

A 5s connect deadline matching the CLI's `sendV1`/`sendV2` is added as a backstop. **It is explicitly not a fix for an observed hang** — measured against absent, responsive and wedged servers, the hook exits on its own in all three. I had assumed a hang and the measurement disproved it; the comment says so rather than claiming otherwise.

## Verification

`tests/unit/pty-ledger.test.ts` — 22 cases, weighted toward what must **not** be killed: recycled PID under a different image, recycled PID outside the creation-time window, malformed ledger entries, a live owner. Plus a live `Win32_Process` probe of our own PID, which is what proves the PowerShell command string quotes correctly.

Beyond the suite, exercised against real process trees (two `cmd.exe` → `ping` trees, one recorded truthfully, one recorded under a wrong image):

```
PASS  recorded tree root killed
PASS  recorded tree GRANDCHILD killed (the MCP-server case)
PASS  image-mismatched tree root SPARED
PASS  image-mismatched tree grandchild SPARED
PASS  ledger now owned by this process
```

And the hook, pre-fix vs post-fix:

```
server shape    | before (HEAD)      | after (fix)
----------------+--------------------+------------------
absent          | 43ms               | 40ms
responsive      | 1044ms             | 100ms
wedged          | 1051ms             | 99ms
```

Full suite: 62 files, 689 tests passing. `npm run typecheck` clean; `npm run lint` unchanged from master (31 problems before and after, none in the touched lines).

## What this does not fix

The crash itself. Six `.dmp` files means a native crash, and I have no way to diagnose one without them — asked for them on the issue. This change makes a crash survivable rather than cumulative; it does not stop it happening.