### PR TITLE
fix(diff): stop the diff pane restarting its own poll every render (#141)

### DIFF
--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -76,10 +76,12 @@ function sendV1(command: string): Promise<string> {
 }
 
 function sendV2(method: string, params: Record<string, any> = {}): Promise<any> {
-  // Browser commands carry the caller's surface (WMUX_SURFACE_ID) so wmux can
-  // route each agent to its OWN browser pane — concurrent agents no longer share
-  // and clobber a single browser window (issue #62).
-  if (method.startsWith('browser.') && params.caller === undefined && process.env.WMUX_SURFACE_ID) {
+  // Every command carries the caller's surface (WMUX_SURFACE_ID). Browser
+  // commands use it to route each agent to its OWN browser pane, so concurrent
+  // agents no longer share and clobber one browser window (issue #62); the
+  // workspace/pane/surface commands use it to answer about the window the
+  // calling shell actually lives in rather than an arbitrary one (issue #141).
+  if (params.caller === undefined && process.env.WMUX_SURFACE_ID) {
     params = { ...params, caller: process.env.WMUX_SURFACE_ID };
   }
   return new Promise((resolve, reject) => {
@@ -568,7 +570,10 @@ const COMMANDS: Record<string, (args: string[]) => Promise<void> | void> = {
     print(await sendV2('surface.rename', { id, title }));
   },
   'focus-surface': async (args) => print(await sendV2('surface.focus', { id: args[1] })),
-  'list-surfaces': async (args) => print(await sendV2('surface.list', { paneId: getFlag(args, '--pane') })),
+  'list-surfaces': async (args) => print(await sendV2('surface.list', {
+    paneId: getFlag(args, '--pane'),
+    workspaceId: getFlag(args, '--workspace'),
+  })),
   'set-color-scheme': cmdSetColorScheme,
   'clear-color-scheme': async (args) => {
     const surfaceId = args[1] || process.env.WMUX_SURFACE_ID || '';
@@ -594,7 +599,10 @@ const COMMANDS: Record<string, (args: string[]) => Promise<void> | void> = {
   'focus-pane': async (args) => print(await sendV2('pane.focus', { id: args[1] })),
   'zoom-pane': async (args) => print(await sendV2('pane.zoom', { id: args[1] })),
   'list-panes': async (args) => print(await sendV2('pane.list', { workspaceId: getFlag(args, '--workspace') })),
-  tree: async () => print(await sendV2('system.tree')),
+  // `--workspace` used to be parsed by nobody: the flag was accepted on the
+  // command line and silently dropped here, so every call reported the ACTIVE
+  // workspace's tree whatever id you passed (issue #141).
+  tree: async (args) => print(await sendV2('system.tree', { workspaceId: getFlag(args, '--workspace') })),
 
   // Layout
   layout: cmdLayout,

--- a/src/main/diff-provider.ts
+++ b/src/main/diff-provider.ts
@@ -29,11 +29,23 @@ async function git(cwd: string, args: string[]): Promise<string> {
   }
 }
 
+// Whether a directory is a repo changes about as often as someone runs
+// `git init`, but the probe used to spawn a `git rev-parse` on EVERY call to
+// both public entry points — a third of the git processes in issue #141 were
+// this check. Cache it with a TTL so `git init` is still picked up eventually.
+const REPO_PROBE_TTL_MS = 30_000;
+const repoProbes = new Map<string, { isRepo: boolean; at: number }>();
+
 async function isGitRepo(cwd: string): Promise<boolean> {
+  const cached = repoProbes.get(cwd);
+  if (cached && Date.now() - cached.at < REPO_PROBE_TTL_MS) return cached.isRepo;
+  let isRepo: boolean;
   try {
     await git(cwd, ['rev-parse', '--is-inside-work-tree']);
-    return true;
-  } catch { return false; }
+    isRepo = true;
+  } catch { isRepo = false; }
+  repoProbes.set(cwd, { isRepo, at: Date.now() });
+  return isRepo;
 }
 
 // ─── Non-git snapshot system ───────────────────────────────────────────────
@@ -155,140 +167,150 @@ async function readCurrentFile(cwd: string, rel: string): Promise<string | null>
   return entry ? entry.content : null;
 }
 
+const DIFF_CONTEXT = 3;
+
+/**
+ * Advance from `start` until DIFF_CONTEXT consecutive lines match again, then
+ * back up over that matching run so it becomes trailing context rather than
+ * part of the changed region.
+ */
+function findDivergenceEnd(
+  oldLines: string[], newLines: string[], start: number,
+): { oldEnd: number; newEnd: number } {
+  let oldEnd = start;
+  let newEnd = start;
+  let matchRun = 0;
+  while (oldEnd < oldLines.length || newEnd < newLines.length) {
+    if (oldEnd < oldLines.length && newEnd < newLines.length && oldLines[oldEnd] === newLines[newEnd]) {
+      matchRun++;
+      oldEnd++;
+      newEnd++;
+      if (matchRun >= DIFF_CONTEXT) break;
+    } else {
+      matchRun = 0;
+      if (oldEnd < oldLines.length) oldEnd++;
+      if (newEnd < newLines.length) newEnd++;
+    }
+  }
+  return { oldEnd: oldEnd - matchRun, newEnd: newEnd - matchRun };
+}
+
+/** Emit one `@@` hunk covering [contextBefore, contextAfter). */
+function renderHunk(
+  out: string[], oldLines: string[], newLines: string[],
+  hunkStart: number, oldEnd: number, newEnd: number, contextAfter: number,
+): void {
+  const contextBefore = Math.max(0, hunkStart - DIFF_CONTEXT);
+  const maxLen = Math.max(oldLines.length, newLines.length);
+  const oldLen = Math.min(oldLines.length, contextAfter) - contextBefore;
+  const newLen = Math.min(newLines.length, contextAfter) - contextBefore;
+  out.push(`@@ -${contextBefore + 1},${oldLen} +${contextBefore + 1},${newLen} @@`);
+
+  for (let c = contextBefore; c < hunkStart; c++) {
+    if (c < oldLines.length) out.push(' ' + oldLines[c]);
+  }
+  for (let r = hunkStart; r < oldEnd; r++) {
+    if (r < oldLines.length) out.push('-' + oldLines[r]);
+  }
+  for (let a = hunkStart; a < newEnd; a++) {
+    if (a < newLines.length) out.push('+' + newLines[a]);
+  }
+  for (let c = Math.max(oldEnd, newEnd); c < contextAfter && c < maxLen; c++) {
+    out.push(' ' + contextLineAt(oldLines, newLines, c));
+  }
+}
+
+function contextLineAt(oldLines: string[], newLines: string[], index: number): string {
+  if (index < newLines.length) return newLines[index];
+  if (index < oldLines.length) return oldLines[index];
+  return '';
+}
+
 function generateUnifiedDiff(filePath: string, oldContent: string, newContent: string): string {
   const oldLines = oldContent.split('\n');
   const newLines = newContent.split('\n');
 
-  // Simple line-by-line diff using LCS-like approach
-  const hunks: string[] = [];
-  hunks.push(`diff --git a/${filePath} b/${filePath}`);
-  hunks.push(`--- a/${filePath}`);
-  hunks.push(`+++ b/${filePath}`);
+  const out: string[] = [
+    `diff --git a/${filePath} b/${filePath}`,
+    `--- a/${filePath}`,
+    `+++ b/${filePath}`,
+  ];
 
-  // Find changed regions
   const maxLen = Math.max(oldLines.length, newLines.length);
   let i = 0;
   while (i < maxLen) {
-    // Skip matching lines
     if (i < oldLines.length && i < newLines.length && oldLines[i] === newLines[i]) {
       i++;
       continue;
     }
-    // Found a difference — collect the hunk
-    const hunkStart = i;
-    const contextBefore = Math.max(0, hunkStart - 3);
-    // Find end of differing region
-    let oldEnd = i;
-    let newEnd = i;
-    // Simple: advance until lines match again (or end)
-    let matchRun = 0;
-    while (oldEnd < oldLines.length || newEnd < newLines.length) {
-      if (oldEnd < oldLines.length && newEnd < newLines.length && oldLines[oldEnd] === newLines[newEnd]) {
-        matchRun++;
-        oldEnd++;
-        newEnd++;
-        if (matchRun >= 3) break;
-      } else {
-        matchRun = 0;
-        if (oldEnd < oldLines.length) oldEnd++;
-        if (newEnd < newLines.length) newEnd++;
-      }
-    }
-    // Back up by the match run to not include trailing context in the diff lines
-    oldEnd -= matchRun;
-    newEnd -= matchRun;
-    const contextAfter = Math.min(maxLen, Math.max(oldEnd, newEnd) + 3);
-
-    const hunkOldStart = contextBefore + 1;
-    const hunkNewStart = contextBefore + 1;
-    const hunkOldLen = Math.min(oldLines.length, contextAfter) - contextBefore;
-    const hunkNewLen = Math.min(newLines.length, contextAfter) - contextBefore;
-
-    hunks.push(`@@ -${hunkOldStart},${hunkOldLen} +${hunkNewStart},${hunkNewLen} @@`);
-
-    // Context before
-    for (let c = contextBefore; c < hunkStart; c++) {
-      if (c < oldLines.length) hunks.push(' ' + oldLines[c]);
-    }
-    // Removed lines
-    for (let r = hunkStart; r < oldEnd; r++) {
-      if (r < oldLines.length) hunks.push('-' + oldLines[r]);
-    }
-    // Added lines
-    for (let a = hunkStart; a < newEnd; a++) {
-      if (a < newLines.length) hunks.push('+' + newLines[a]);
-    }
-    // Context after
-    for (let c = Math.max(oldEnd, newEnd); c < contextAfter && c < maxLen; c++) {
-      const line = c < newLines.length ? newLines[c] : (c < oldLines.length ? oldLines[c] : '');
-      hunks.push(' ' + line);
-    }
-
+    const { oldEnd, newEnd } = findDivergenceEnd(oldLines, newLines, i);
+    const contextAfter = Math.min(maxLen, Math.max(oldEnd, newEnd) + DIFF_CONTEXT);
+    renderHunk(out, oldLines, newLines, i, oldEnd, newEnd, contextAfter);
     i = contextAfter;
   }
 
-  return hunks.join('\n');
+  return out.join('\n');
 }
 
-async function getSnapshotChangedFiles(cwd: string): Promise<ChangedFile[]> {
-  if (!snapshots.has(cwd)) {
-    snapshots.set(cwd, await takeSnapshot(cwd));
-    return []; // First call: snapshot taken, no changes yet
-  }
-  const snap = snapshots.get(cwd)!;
-  const changed: ChangedFile[] = [];
+function deletedEntry(rel: string, entry: SnapshotEntry): ChangedFile {
+  return { path: rel, status: 'deleted', additions: 0, deletions: entry.content.split('\n').length };
+}
 
-  // Check existing files for modifications. Stat first and only read content
-  // when mtime/size moved — in the steady state this skips every read.
-  for (const [rel, entry] of snap) {
-    const resolved = resolveWithin(cwd, rel);
-    let stat: fs.Stats | null = null;
-    if (resolved) {
-      try { stat = await fs.promises.stat(resolved); } catch { /* deleted */ }
-    }
-    if (!stat) {
-      const lines = entry.content.split('\n').length;
-      changed.push({ path: rel, status: 'deleted', additions: 0, deletions: lines });
-      continue;
-    }
-    if (stat.mtimeMs === entry.mtimeMs && stat.size === entry.size) continue; // unchanged
-    const current = await readCurrentFile(cwd, rel);
-    if (current === null) {
-      // Grew past the size cap or turned binary — treat as gone, like before
-      const lines = entry.content.split('\n').length;
-      changed.push({ path: rel, status: 'deleted', additions: 0, deletions: lines });
-    } else if (current !== entry.content) {
-      // File was modified
-      const oldLines = entry.content.split('\n');
-      const newLines = current.split('\n');
-      let additions = 0, deletions = 0;
-      const max = Math.max(oldLines.length, newLines.length);
-      for (let i = 0; i < max; i++) {
-        const o = i < oldLines.length ? oldLines[i] : undefined;
-        const n = i < newLines.length ? newLines[i] : undefined;
-        if (o !== n) {
-          if (o !== undefined) deletions++;
-          if (n !== undefined) additions++;
-        }
-      }
-      changed.push({ path: rel, status: 'modified', additions, deletions });
-    } else {
-      // Content identical, only metadata moved (e.g. touch) — refresh the
-      // stored stat so the next poll goes back to the cheap skip path.
-      snap.set(rel, { content: entry.content, mtimeMs: stat.mtimeMs, size: stat.size });
-    }
+function countLineChanges(oldContent: string, newContent: string): { additions: number; deletions: number } {
+  const oldLines = oldContent.split('\n');
+  const newLines = newContent.split('\n');
+  let additions = 0, deletions = 0;
+  const max = Math.max(oldLines.length, newLines.length);
+  for (let i = 0; i < max; i++) {
+    const o = i < oldLines.length ? oldLines[i] : undefined;
+    const n = i < newLines.length ? newLines[i] : undefined;
+    if (o === n) continue;
+    if (o !== undefined) deletions++;
+    if (n !== undefined) additions++;
   }
+  return { additions, deletions };
+}
 
-  // Check for new files. The re-walk is the expensive half of a poll and new
-  // files appear far less often than existing ones change, so run discovery
-  // every Nth poll. A file added in the gap surfaces on the next discovery
-  // pass rather than being missed.
+/**
+ * Compare one baselined file against disk. Stat first and only read content
+ * when mtime/size moved — in the steady state this skips every read.
+ */
+async function diffSnapshotEntry(
+  cwd: string, rel: string, entry: SnapshotEntry, snap: Map<string, SnapshotEntry>,
+): Promise<ChangedFile | null> {
+  const resolved = resolveWithin(cwd, rel);
+  let stat: fs.Stats | null = null;
+  if (resolved) {
+    try { stat = await fs.promises.stat(resolved); } catch { /* deleted */ }
+  }
+  if (!stat) return deletedEntry(rel, entry);
+  if (stat.mtimeMs === entry.mtimeMs && stat.size === entry.size) return null; // unchanged
+
+  const current = await readCurrentFile(cwd, rel);
+  // Grew past the size cap or turned binary — treat as gone, like before
+  if (current === null) return deletedEntry(rel, entry);
+  if (current !== entry.content) {
+    return { path: rel, status: 'modified', ...countLineChanges(entry.content, current) };
+  }
+  // Content identical, only metadata moved (e.g. touch) — refresh the stored
+  // stat so the next poll goes back to the cheap skip path.
+  snap.set(rel, { content: entry.content, mtimeMs: stat.mtimeMs, size: stat.size });
+  return null;
+}
+
+/**
+ * Files present on disk but absent from the baseline. The re-walk is the
+ * expensive half of a poll and new files appear far less often than existing
+ * ones change, so discovery runs every Nth poll; a file added in the gap
+ * surfaces on the next discovery pass rather than being missed. Discovered
+ * paths are remembered so they keep being reported on the polls in between
+ * instead of flickering out of the list and back in.
+ */
+async function collectAddedFiles(cwd: string, snap: Map<string, SnapshotEntry>): Promise<ChangedFile[]> {
   const polls = (pollCounts.get(cwd) ?? 0) + 1;
   const rewalk = polls >= REWALK_EVERY_N_POLLS;
   pollCounts.set(cwd, rewalk ? 0 : polls);
 
-  // Discovered additions are remembered, so they keep being reported on the
-  // polls between re-walks instead of flickering out of the list and back in.
   let known = addedPaths.get(cwd);
   if (!known) { known = new Set<string>(); addedPaths.set(cwd, known); }
 
@@ -300,12 +322,28 @@ async function getSnapshotChangedFiles(cwd: string): Promise<ChangedFile[]> {
     }
   }
 
+  const added: ChangedFile[] = [];
   for (const rel of [...known]) {
     const content = await readCurrentFile(cwd, rel);
     if (content === null) { known.delete(rel); continue; } // gone again
-    changed.push({ path: rel, status: 'added', additions: content.split('\n').length, deletions: 0 });
+    added.push({ path: rel, status: 'added', additions: content.split('\n').length, deletions: 0 });
   }
+  return added;
+}
 
+async function getSnapshotChangedFiles(cwd: string): Promise<ChangedFile[]> {
+  if (!snapshots.has(cwd)) {
+    snapshots.set(cwd, await takeSnapshot(cwd));
+    return []; // First call: snapshot taken, no changes yet
+  }
+  const snap = snapshots.get(cwd)!;
+  const changed: ChangedFile[] = [];
+
+  for (const [rel, entry] of snap) {
+    const result = await diffSnapshotEntry(cwd, rel, entry, snap);
+    if (result) changed.push(result);
+  }
+  changed.push(...await collectAddedFiles(cwd, snap));
   return changed;
 }
 
@@ -364,94 +402,118 @@ async function getSnapshotFileDiff(cwd: string, file: string): Promise<string> {
 
 const MAX_UNTRACKED_SIZE = 1_000_000;
 
+function parseNumstat(numstat: string): Map<string, { additions: number; deletions: number }> {
+  const stats = new Map<string, { additions: number; deletions: number }>();
+  for (const line of numstat.trim().split('\n')) {
+    if (!line) continue;
+    const parts = line.split('\t');
+    if (parts.length < 3) continue;
+    stats.set(parts[2], {
+      additions: parts[0] === '-' ? 0 : parseInt(parts[0]) || 0,
+      deletions: parts[1] === '-' ? 0 : parseInt(parts[1]) || 0,
+    });
+  }
+  return stats;
+}
+
+function parsePorcelainStatus(statusOut: string): Array<{ path: string; status: ChangedFile['status'] }> {
+  return statusOut.trim().split('\n').map(line => {
+    const xy = line.substring(0, 2);
+    const filePath = line.substring(3).trim().replace(/^"(.*)"$/, '$1');
+    let status: ChangedFile['status'] = 'modified';
+    if (xy.includes('A') || xy === '??') status = 'added';
+    else if (xy.includes('D')) status = 'deleted';
+    else if (xy.includes('R')) status = 'renamed';
+    return { path: filePath, status };
+  });
+}
+
+async function getGitChangedFiles(cwd: string): Promise<ChangedFile[]> {
+  const statusOut = await git(cwd, ['status', '--porcelain', '-unormal']).catch(() => '');
+  if (!statusOut.trim()) return [];
+
+  const entries = parsePorcelainStatus(statusOut);
+  const stats = parseNumstat(await git(cwd, ['diff', 'HEAD', '--numstat']).catch(() => ''));
+
+  return entries.map(e => ({
+    ...e,
+    additions: stats.get(e.path)?.additions ?? 0,
+    deletions: stats.get(e.path)?.deletions ?? 0,
+  }));
+}
+
+/** Render an untracked file as an all-additions diff. */
+function untrackedFileDiff(cwd: string, file: string): string {
+  try {
+    const absPath = path.isAbsolute(file) ? file : path.join(cwd, file);
+    const resolved = path.resolve(absPath);
+    if (!isWithin(path.resolve(cwd), resolved)) return '';
+    const stat = fs.statSync(resolved);
+    if (stat.size > MAX_UNTRACKED_SIZE) return '(File too large to display inline)';
+    const buf = fs.readFileSync(resolved);
+    if (buf.includes(0)) return '(Binary file)';
+    const lines = buf.toString('utf-8').split('\n');
+    if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+    return [
+      `diff --git a/${file} b/${file}`,
+      'new file mode 100644',
+      '--- /dev/null',
+      `+++ b/${file}`,
+      `@@ -0,0 +1,${lines.length} @@`,
+      ...lines.map(l => '+' + l),
+    ].join('\n');
+  } catch {
+    return '';
+  }
+}
+
+async function getGitFileDiff(cwd: string, file: string): Promise<string> {
+  for (const args of [['diff', 'HEAD'], ['diff'], ['diff', '--cached']]) {
+    const out = await git(cwd, [...args, '--', file]).catch(() => '');
+    if (out.trim()) return out;
+  }
+  const status = await git(cwd, ['status', '--porcelain', '--', file]).catch(() => '');
+  return status.includes('??') ? untrackedFileDiff(cwd, file) : '';
+}
+
+/**
+ * Run `work` for `key`, or join the pass already running for it.
+ *
+ * Every git invocation below costs a process spawn, and on a large working
+ * tree `git diff HEAD --numstat` takes ~1s. A caller polling faster than that
+ * used to stack one process per call — 10-40 `git.exe`/s, saturating the main
+ * process that also relays every keystroke (issue #141). Callers that arrive
+ * mid-pass get that pass's result: at most one poll stale, which is well
+ * inside the pane's own refresh interval.
+ */
+function coalesce<T>(inFlight: Map<string, Promise<T>>, key: string, work: () => Promise<T>): Promise<T> {
+  const running = inFlight.get(key);
+  if (running) return running;
+  const started = work().finally(() => inFlight.delete(key));
+  inFlight.set(key, started);
+  return started;
+}
+
+const changedFilesInFlight = new Map<string, Promise<ChangedFile[]>>();
+const fileDiffsInFlight = new Map<string, Promise<string>>();
+
 export async function getChangedFiles(cwd: string): Promise<ChangedFile[]> {
   if (!cwd) cwd = process.cwd();
-
-  // Try git first
-  if (await isGitRepo(cwd)) {
-    const statusOut = await git(cwd, ['status', '--porcelain', '-unormal']).catch(() => '');
-    if (!statusOut.trim()) return [];
-
-    const entries = statusOut.trim().split('\n').map(line => {
-      const xy = line.substring(0, 2);
-      const filePath = line.substring(3).trim().replace(/^"(.*)"$/, '$1');
-      let status: ChangedFile['status'] = 'modified';
-      if (xy.includes('A') || xy === '??') status = 'added';
-      else if (xy.includes('D')) status = 'deleted';
-      else if (xy.includes('R')) status = 'renamed';
-      return { path: filePath, status };
-    });
-
-    const numstat = await git(cwd, ['diff', 'HEAD', '--numstat']).catch(() => '');
-    const stats = new Map<string, { additions: number; deletions: number }>();
-    for (const line of numstat.trim().split('\n')) {
-      if (!line) continue;
-      const parts = line.split('\t');
-      if (parts.length < 3) continue;
-      stats.set(parts[2], {
-        additions: parts[0] === '-' ? 0 : parseInt(parts[0]) || 0,
-        deletions: parts[1] === '-' ? 0 : parseInt(parts[1]) || 0,
-      });
-    }
-
-    return entries.map(e => ({
-      ...e,
-      additions: stats.get(e.path)?.additions ?? 0,
-      deletions: stats.get(e.path)?.deletions ?? 0,
-    }));
-  }
-
-  // No git — use snapshot system
-  return getSnapshotChangedFilesCoalesced(cwd);
+  return coalesce(changedFilesInFlight, cwd, async () => (
+    await isGitRepo(cwd)
+      ? getGitChangedFiles(cwd)
+      // No git — use snapshot system, which coalesces on its own key too so a
+      // scan shared with a direct caller is still only walked once.
+      : getSnapshotChangedFilesCoalesced(cwd)
+  ));
 }
 
 export async function getFileDiff(cwd: string, file: string): Promise<string> {
   if (!file) return '';
   if (!cwd) cwd = process.cwd();
-
-  // Try git first
-  if (await isGitRepo(cwd)) {
-    const diff = await git(cwd, ['diff', 'HEAD', '--', file]).catch(() => '');
-    if (diff.trim()) return diff;
-
-    const diff2 = await git(cwd, ['diff', '--', file]).catch(() => '');
-    if (diff2.trim()) return diff2;
-
-    const diff3 = await git(cwd, ['diff', '--cached', '--', file]).catch(() => '');
-    if (diff3.trim()) return diff3;
-
-    // Untracked files
-    const status = await git(cwd, ['status', '--porcelain', '--', file]).catch(() => '');
-    if (status.includes('??')) {
-      try {
-        const absPath = path.isAbsolute(file) ? file : path.join(cwd, file);
-        const resolved = path.resolve(absPath);
-        if (!isWithin(path.resolve(cwd), resolved)) return '';
-        const stat = fs.statSync(resolved);
-        if (stat.size > MAX_UNTRACKED_SIZE) return '(File too large to display inline)';
-        const buf = fs.readFileSync(resolved);
-        if (buf.includes(0)) return '(Binary file)';
-        const content = buf.toString('utf-8');
-        const lines = content.split('\n');
-        if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
-        const header = [
-          `diff --git a/${file} b/${file}`,
-          'new file mode 100644',
-          '--- /dev/null',
-          `+++ b/${file}`,
-          `@@ -0,0 +1,${lines.length} @@`,
-        ].join('\n');
-        return header + '\n' + lines.map(l => '+' + l).join('\n');
-      } catch {
-        return '';
-      }
-    }
-
-    return '';
-  }
-
-  // No git — use snapshot system
-  return getSnapshotFileDiff(cwd, file);
+  return coalesce(fileDiffsInFlight, `${cwd} ${file}`, async () => (
+    await isGitRepo(cwd) ? getGitFileDiff(cwd, file) : getSnapshotFileDiff(cwd, file)
+  ));
 }
 
 /** Reset the snapshot for a directory so next poll re-baselines. */
@@ -459,4 +521,16 @@ export function resetSnapshot(cwd: string): void {
   snapshots.delete(cwd);
   pollCounts.delete(cwd);
   addedPaths.delete(cwd);
+  repoProbes.delete(cwd);
+}
+
+/** Drop every cached probe/snapshot. Test seam. */
+export function resetDiffCaches(): void {
+  snapshots.clear();
+  pollCounts.clear();
+  addedPaths.clear();
+  repoProbes.clear();
+  scansInFlight.clear();
+  changedFilesInFlight.clear();
+  fileDiffsInFlight.clear();
 }

--- a/src/main/v2-bridge.ts
+++ b/src/main/v2-bridge.ts
@@ -20,9 +20,40 @@ interface BridgeSpec {
   requireResult?: string;
 }
 
-function firstWindow(): BrowserWindow | null {
-  const win = BrowserWindow.getAllWindows()[0];
-  return win && !win.isDestroyed() ? win : null;
+// caller surface id → the window that held it. `getAllWindows()` order is not
+// a promise Electron makes, so two consecutive CLI calls could land on two
+// different windows and report contradictory state (issue #141: `tree` and
+// `list-surfaces` disagreed about which panes existed, and a scripted cleanup
+// consequently found nothing to close and exited claiming success).
+const callerWindows = new Map<string, number>();
+
+/**
+ * The window that owns the calling shell's surface, or the first one.
+ *
+ * Only probes when it has to: with a single window — the common case — the
+ * answer is that window and no extra round-trip is spent.
+ */
+async function windowForCaller(caller: unknown): Promise<BrowserWindow | null> {
+  const live = BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed());
+  if (live.length <= 1) return live[0] ?? null;
+  if (typeof caller !== 'string' || !caller) return BrowserWindow.getFocusedWindow() ?? live[0];
+
+  const cachedId = callerWindows.get(caller);
+  const cached = cachedId !== undefined ? live.find((w) => w.id === cachedId) : undefined;
+  if (cached) return cached;
+
+  for (const win of live) {
+    try {
+      const owns = await win.webContents.executeJavaScript(
+        `window.__wmux_hasSurface?.(${S(caller)})`
+      );
+      if (owns) {
+        callerWindows.set(caller, win.id);
+        return win;
+      }
+    } catch { /* window went away mid-probe; try the next */ }
+  }
+  return BrowserWindow.getFocusedWindow() ?? live[0];
 }
 
 const S = (v: any) => JSON.stringify(v);
@@ -81,7 +112,7 @@ const SPECS: Record<string, BridgeSpec> = {
     js: (p) => `window.__wmux_renameSurface?.(${S(p?.id || p?.surfaceId)}, ${S(p?.title || '')}, ${S(p?.workspaceId)})`,
   },
   'surface.list': {
-    js: (p) => `window.__wmux_listSurfaces?.(${S(p?.workspaceId)})`,
+    js: (p) => `window.__wmux_listSurfaces?.(${S(p?.workspaceId)}, ${S(p?.paneId)})`,
     shape: (r) => ({ surfaces: r || [] }),
     emptyOnNoWindow: { surfaces: [] },
   },
@@ -109,7 +140,7 @@ const SPECS: Record<string, BridgeSpec> = {
 function runBridge(spec: BridgeSpec, params: any, respond: Respond, respondError: RespondError): void {
   (async () => {
     try {
-      const win = firstWindow();
+      const win = await windowForCaller(params?.caller);
       if (!win) {
         if (spec.emptyOnNoWindow !== undefined) { respond(spec.emptyOnNoWindow); return; }
         respondError(-32000, 'No window');

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,6 +6,7 @@ import SplitContainer from './components/SplitPane/SplitContainer';
 import { updateRatio, getAllPaneIds, findLeaf, replaceSoleTerminalSurface, freezeSurfaceCwds } from './store/split-utils';
 import { DEFAULT_DEV_PORTS, mergeDevPorts, matchDevPorts, firstNewDevPort } from './dev-ports';
 import { aggregateProgress } from './store/progress-slice';
+import { isDiffTabDismissed } from './store/surface-slice';
 import Sidebar from './components/Sidebar/Sidebar';
 import Titlebar from './components/Titlebar/Titlebar';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -157,12 +158,16 @@ function markSessionIdleOnStop(
 function maybeAutoOpenDiffTab(tool: string, ownerWs: WorkspaceInfo): void {
   const state = useStore.getState();
   if ((tool !== 'Edit' && tool !== 'Write') || !state.workspacePrefs.autoOpenDiffTab) return;
+  // A diff tab the user closed stays closed (issue #141). Without this, every
+  // Edit/Write put it back minutes later with no user action — and on a large
+  // repo its polling is what made typing lag, so "close it" was not a fix.
+  if (isDiffTabDismissed(ownerWs.id)) return;
   const bottomPaneId = findBottomPane(ownerWs.splitTree);
   if (!bottomPaneId) return;
   const bottomLeaf = findLeafFromTree(ownerWs.splitTree, bottomPaneId);
   // Only add diff tab if bottom pane doesn't already have one
   if (bottomLeaf && !bottomLeaf.surfaces.some(s => s.type === 'diff')) {
-    state.addSurface(ownerWs.id, bottomPaneId, 'diff');
+    state.addSurface(ownerWs.id, bottomPaneId, 'diff', { auto: true });
   }
 }
 

--- a/src/renderer/components/Diff/DiffPane.tsx
+++ b/src/renderer/components/Diff/DiffPane.tsx
@@ -26,45 +26,74 @@ interface DiffHunk {
 
 // ─── Diff parser ────────────────────────────────────────────────────────────
 
+const HEADER_PREFIXES = ['diff --git', 'index ', '---', '+++', 'new file', 'deleted file'];
+// Anchored, with non-optional groups: the loose `,?\d*` form backtracks
+// super-linearly on a crafted `@@` line.
+const HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@(.*)$/;
+
+/** Append one body line to `hunk`, advancing the line counters it owns. */
+function pushBodyLine(hunk: DiffHunk, line: string, nums: { old: number; new: number }): void {
+  if (line.startsWith('+')) {
+    hunk.lines.push({ type: 'add', content: line.slice(1), newNum: nums.new++ });
+  } else if (line.startsWith('-')) {
+    hunk.lines.push({ type: 'remove', content: line.slice(1), oldNum: nums.old++ });
+  } else if (line.startsWith(' ') || line === '') {
+    const content = line.startsWith(' ') ? line.slice(1) : '';
+    hunk.lines.push({ type: 'context', content, oldNum: nums.old++, newNum: nums.new++ });
+  }
+}
+
 function parseDiff(raw: string): DiffHunk[] {
   if (!raw) return [];
   const hunks: DiffHunk[] = [];
-  const lines = raw.split('\n');
   let currentHunk: DiffHunk | null = null;
-  let oldLine = 0;
-  let newLine = 0;
+  const nums = { old: 0, new: 0 };
 
-  for (const line of lines) {
-    if (line.startsWith('diff --git') || line.startsWith('index ') ||
-        line.startsWith('---') || line.startsWith('+++') ||
-        line.startsWith('new file') || line.startsWith('deleted file')) {
-      continue;
-    }
+  for (const line of raw.split('\n')) {
+    if (HEADER_PREFIXES.some(p => line.startsWith(p))) continue;
 
     if (line.startsWith('@@')) {
-      const match = line.match(/@@ -(\d+),?\d* \+(\d+),?\d* @@(.*)/);
+      const match = HUNK_HEADER.exec(line);
       if (match) {
-        oldLine = parseInt(match[1]);
-        newLine = parseInt(match[2]);
+        nums.old = parseInt(match[1]);
+        nums.new = parseInt(match[2]);
         currentHunk = { header: line, context: match[3]?.trim() || '', lines: [] };
         hunks.push(currentHunk);
       }
       continue;
     }
 
-    if (!currentHunk) continue;
-
-    if (line.startsWith('+')) {
-      currentHunk.lines.push({ type: 'add', content: line.slice(1), newNum: newLine++ });
-    } else if (line.startsWith('-')) {
-      currentHunk.lines.push({ type: 'remove', content: line.slice(1), oldNum: oldLine++ });
-    } else if (line.startsWith(' ') || line === '') {
-      const content = line.startsWith(' ') ? line.slice(1) : '';
-      currentHunk.lines.push({ type: 'context', content, oldNum: oldLine++, newNum: newLine++ });
-    }
+    if (currentHunk) pushBodyLine(currentHunk, line, nums);
   }
 
   return hunks;
+}
+
+const LINE_PREFIX: Record<DiffLine['type'], string> = {
+  add: '+',
+  remove: '-',
+  context: ' ',
+};
+
+// ─── Visibility ─────────────────────────────────────────────────────────────
+
+/**
+ * Is this diff surface actually on screen?
+ *
+ * Panes keep every tab mounted and hide the inactive ones with
+ * `visibility: hidden` (the keep-alive tab design), so an unmounted-looking
+ * diff surface is still running its poll. Reading the DOM avoids threading the
+ * pane's active-tab index down into this component, and covers the whole
+ * hidden chain — background tab, collapsed pane, unfocused window.
+ */
+function isSurfaceVisible(surfaceId: string): boolean {
+  if (typeof document === 'undefined') return true;
+  if (document.hidden) return false;
+  const el = document.querySelector(`.diff-pane[data-surface-id="${CSS.escape(surfaceId)}"]`);
+  if (!el) return true; // first pass, before the node is in the tree
+  const check = (el as HTMLElement & { checkVisibility?: (o?: object) => boolean }).checkVisibility;
+  if (typeof check !== 'function') return true;
+  return check.call(el, { visibilityProperty: true, contentVisibilityAuto: true });
 }
 
 // ─── Component ──────────────────────────────────────────────────────────────
@@ -87,6 +116,24 @@ export default function DiffPane({ surfaceId, cwd }: DiffPaneProps) {
   const lastDiffRawRef = useRef('');
   selectedFileRef.current = selectedFile;
 
+  // Every setState below is guarded on an actual change. A poll that finds
+  // nothing new must not re-render: renders are what restarted the poll effect
+  // and turned the 2s interval into a render-speed loop (issue #141).
+  const errorRef = useRef<string | null>(null);
+  const loadingRef = useRef(true);
+
+  const setErrorIfChanged = useCallback((next: string | null) => {
+    if (errorRef.current === next) return;
+    errorRef.current = next;
+    setError(next);
+  }, []);
+
+  const setLoadingIfChanged = useCallback((next: boolean) => {
+    if (loadingRef.current === next) return;
+    loadingRef.current = next;
+    setLoading(next);
+  }, []);
+
   const loadFiles = useCallback(async () => {
     try {
       const result = await window.wmux?.diff?.getFiles(cwd || '');
@@ -97,16 +144,18 @@ export default function DiffPane({ surfaceId, cwd }: DiffPaneProps) {
           lastFilesKeyRef.current = newKey;
           setFiles(newFiles);
         }
-        setError(null);
+        setErrorIfChanged(null);
         return newFiles;
       }
     } catch (err: any) {
-      setError(err.message || t('diffPane.failedToLoad', 'Failed to load changed files'));
+      // Kept raw and translated at render time, so `t` stays out of the
+      // dependency chain that drives the poll.
+      setErrorIfChanged(err.message || '');
     } finally {
-      setLoading(false);
+      setLoadingIfChanged(false);
     }
     return [];
-  }, [cwd, t]);
+  }, [cwd, setErrorIfChanged, setLoadingIfChanged]);
 
   const loadDiff = useCallback(async (file: string) => {
     try {
@@ -123,6 +172,26 @@ export default function DiffPane({ surfaceId, cwd }: DiffPaneProps) {
     }
   }, [cwd]);
 
+  // The poll reads its loaders through refs rather than closing over them.
+  // They are stable today, but this effect must not be restartable by a
+  // re-render under ANY future identity churn: its body kicks off a poll
+  // immediately, so a restart-per-render turns the interval below into a
+  // render-speed loop that spawns git faster than git can answer (issue #141).
+  const loadFilesRef = useRef(loadFiles);
+  const loadDiffRef = useRef(loadDiff);
+  loadFilesRef.current = loadFiles;
+  loadDiffRef.current = loadDiff;
+
+  const runPass = useCallback(async () => {
+    const loaded = await loadFilesRef.current();
+    if (loaded.length > 0 && !selectedFileRef.current) {
+      setSelectedFile(loaded[0].path);
+    }
+    if (selectedFileRef.current) {
+      await loadDiffRef.current(selectedFileRef.current);
+    }
+  }, []);
+
   // Poll every 2 seconds (~50ms per git status call). The non-git snapshot
   // fallback can take much longer than the interval on big trees, so schedule
   // the next poll only after the previous one finishes (never overlap) and
@@ -130,6 +199,7 @@ export default function DiffPane({ surfaceId, cwd }: DiffPaneProps) {
   useEffect(() => {
     lastFilesKeyRef.current = '';
     lastDiffRawRef.current = '';
+    loadingRef.current = true;
     setLoading(true);
 
     const POLL_MS = 2000;
@@ -138,14 +208,10 @@ export default function DiffPane({ surfaceId, cwd }: DiffPaneProps) {
 
     const poll = async () => {
       const started = Date.now();
-      const loaded = await loadFiles();
-      if (cancelled) return;
-      if (loaded.length > 0 && !selectedFileRef.current) {
-        setSelectedFile(loaded[0].path);
-      }
-      if (selectedFileRef.current) {
-        await loadDiff(selectedFileRef.current);
-      }
+      // Hidden tabs and background windows keep this component mounted (panes
+      // are hidden with `visibility`, never unmounted), so the surface has to
+      // opt out of the work itself.
+      if (isSurfaceVisible(surfaceId)) await runPass();
       if (cancelled) return;
       const elapsed = Date.now() - started;
       timer = setTimeout(poll, Math.max(POLL_MS, elapsed));
@@ -156,54 +222,45 @@ export default function DiffPane({ surfaceId, cwd }: DiffPaneProps) {
       cancelled = true;
       if (timer !== undefined) clearTimeout(timer);
     };
-  }, [loadFiles, loadDiff]);
+  }, [cwd, surfaceId, runPass]);
 
   // Load diff + scroll to top when user selects a file
   useEffect(() => {
     if (!selectedFile) return;
     lastDiffRawRef.current = '';
-    loadDiff(selectedFile);
+    loadDiffRef.current(selectedFile);
     contentRef.current?.scrollTo(0, 0);
-  }, [selectedFile, loadDiff]);
+  }, [selectedFile]);
 
   // Listen for immediate updates from Claude Code hooks (faster than polling)
   useEffect(() => {
     if (!window.wmux?.diff?.onUpdate) return;
     let debounce: ReturnType<typeof setTimeout>;
+    const refresh = () => {
+      lastFilesKeyRef.current = '';
+      lastDiffRawRef.current = '';
+      void runPass();
+    };
     const unsub = window.wmux.diff.onUpdate((data: { file?: string }) => {
       clearTimeout(debounce);
       debounce = setTimeout(() => {
         if (data?.file) setSelectedFile(data.file);
-        lastFilesKeyRef.current = '';
-        lastDiffRawRef.current = '';
-        loadFiles().then((loaded) => {
-          if (loaded.length > 0 && !selectedFileRef.current) {
-            setSelectedFile(loaded[0].path);
-          }
-          if (selectedFileRef.current) {
-            loadDiff(selectedFileRef.current);
-          }
-        });
+        refresh();
       }, 300);
     });
     return () => {
       clearTimeout(debounce);
       unsub();
     };
-  }, [loadFiles, loadDiff]);
+  }, [runPass]);
 
   const handleRefresh = useCallback(async () => {
     lastFilesKeyRef.current = '';
     lastDiffRawRef.current = '';
-    setLoading(true);
-    const loaded = await loadFiles();
-    if (selectedFile) {
-      loadDiff(selectedFile);
-    } else if (loaded.length > 0) {
-      setSelectedFile(loaded[0].path);
-    }
-    setLoading(false);
-  }, [loadFiles, loadDiff, selectedFile]);
+    setLoadingIfChanged(true);
+    await runPass();
+    setLoadingIfChanged(false);
+  }, [runPass, setLoadingIfChanged]);
 
   // Status badge color
   const statusColor = (status: string) => {
@@ -227,10 +284,12 @@ export default function DiffPane({ surfaceId, cwd }: DiffPaneProps) {
     );
   }
 
-  if (error) {
+  if (error !== null) {
     return (
       <div className="diff-pane" data-surface-id={surfaceId}>
-        <div className="diff-pane__empty">{error}</div>
+        <div className="diff-pane__empty">
+          {error || t('diffPane.failedToLoad', 'Failed to load changed files')}
+        </div>
       </div>
     );
   }
@@ -338,9 +397,7 @@ export default function DiffPane({ surfaceId, cwd }: DiffPaneProps) {
                     <span className="diff-line__gutter diff-line__gutter--new">
                       {line.type !== 'remove' ? line.newNum : ''}
                     </span>
-                    <span className="diff-line__prefix">
-                      {line.type === 'add' ? '+' : line.type === 'remove' ? '-' : '\u00A0'}
-                    </span>
+                    <span className="diff-line__prefix">{LINE_PREFIX[line.type]}</span>
                     <pre className="diff-line__content">{line.content || '\u00A0'}</pre>
                   </div>
                 ))}

--- a/src/renderer/i18n/core.ts
+++ b/src/renderer/i18n/core.ts
@@ -47,6 +47,25 @@ export function translate(lang: Language, key: TranslationKey, fallback?: string
   return DICTIONARIES[lang]?.[key] ?? DICTIONARIES.en[key] ?? fallback ?? key;
 }
 
+export type Translator = (key: TranslationKey, fallback?: string) => string;
+
+// One translator per language, kept forever (there are a handful of languages).
+// The identity has to be stable: `useT()`'s result is fed into `useCallback`
+// and `useEffect` dependency arrays across the renderer, and a fresh closure
+// per render invalidates every one of them. That is how the diff pane's 2s
+// poll degenerated into a render-speed loop spawning `git.exe` (issue #141).
+const translators = new Map<Language, Translator>();
+
+/** The translator for `lang` — same function object on every call. */
+export function makeT(lang: Language): Translator {
+  let t = translators.get(lang);
+  if (!t) {
+    t = (key, fallback) => translate(lang, key, fallback);
+    translators.set(lang, t);
+  }
+  return t;
+}
+
 /** Narrow an untrusted value (persisted setting, CLI arg) to a shipped language. */
 export function isLanguage(value: unknown): value is Language {
   return SUPPORTED_LANGUAGES.includes(value as Language);

--- a/src/renderer/i18n/index.ts
+++ b/src/renderer/i18n/index.ts
@@ -1,5 +1,5 @@
 import { useStore } from '../store';
-import { Language, TranslationKey, translate } from './core';
+import { Language, makeT, Translator } from './core';
 
 // Re-export the pure core so components can `import { useT, LANGUAGES, ... }
 // from '../i18n'` in one place. The store-free pieces live in ./core to avoid a
@@ -10,8 +10,12 @@ export * from './core';
  * React hook: returns a `t(key, fallback?)` bound to the current language.
  * `key` is typed against the English dictionary, so a typo at a call site is a
  * compile error rather than a raw key rendered in the UI.
+ *
+ * The returned function is referentially stable for a given language — call
+ * sites put `t` in `useCallback`/`useEffect` dependency arrays, and a fresh
+ * closure per render silently re-runs every one of those effects (issue #141).
  */
-export function useT(): (key: TranslationKey, fallback?: string) => string {
+export function useT(): Translator {
   const lang = useStore((s) => s.language);
-  return (key: TranslationKey, fallback?: string) => translate(lang as Language, key, fallback);
+  return makeT(lang as Language);
 }

--- a/src/renderer/pipe-bridge.ts
+++ b/src/renderer/pipe-bridge.ts
@@ -283,13 +283,13 @@ export function initPipeBridge(): void {
     }
   };
 
-  w.__wmux_listSurfaces = (workspaceId?: string) => {
+  w.__wmux_listSurfaces = (workspaceId?: string, paneId?: string) => {
     const store = useStore.getState();
     const wsId = (workspaceId || store.activeWorkspaceId) as WorkspaceId;
     const ws = store.workspaces.find(w => w.id === wsId);
     if (!ws) return [];
 
-    const paneIds = getAllPaneIds(ws.splitTree);
+    const paneIds = getAllPaneIds(ws.splitTree).filter(pid => !paneId || pid === paneId);
     const surfaces: Array<{ id: string; type: string; paneId: string; isActive: boolean }> = [];
     for (const pid of paneIds) {
       const leaf = findLeaf(ws.splitTree, pid);
@@ -305,6 +305,25 @@ export function initPipeBridge(): void {
       }
     }
     return surfaces;
+  };
+
+  /**
+   * Does THIS window hold `surfaceId`? Used by the main process to answer a CLI
+   * state query about the window the caller's shell actually lives in, rather
+   * than about whichever window happens to be first in `getAllWindows()`
+   * (issue #141: `tree` and `list-surfaces` reported different panes at the
+   * same moment, so a scripted "find the diff surface and close it" found
+   * nothing and exited reporting success).
+   */
+  w.__wmux_hasSurface = (surfaceId: string) => {
+    if (!surfaceId) return false;
+    for (const ws of useStore.getState().workspaces) {
+      for (const pid of getAllPaneIds(ws.splitTree)) {
+        const leaf = findLeaf(ws.splitTree, pid);
+        if (leaf?.surfaces.some(s => s.id === surfaceId)) return true;
+      }
+    }
+    return false;
   };
 
   w.__wmux_getActiveSurfaceId = () => {

--- a/src/renderer/store/surface-slice.ts
+++ b/src/renderer/store/surface-slice.ts
@@ -24,6 +24,12 @@ export interface SurfaceSlice {
       cwd?: string;
       startupCommands?: string[];
       url?: string;
+      /**
+       * This open was triggered by an event, not by the user (the Edit/Write
+       * hook auto-opening a diff tab). Such an open must respect an earlier
+       * dismissal rather than retract it — see `isDiffTabDismissed`.
+       */
+      auto?: boolean;
     },
   ) => SurfaceId | null;
 
@@ -180,10 +186,30 @@ interface ClosedSurface {
 const closedSurfaceStack: ClosedSurface[] = [];
 const MAX_CLOSED_SURFACES = 25;
 
-function pushClosedSurface(surface: SurfaceRef): void {
-  // Diff surfaces are auto-generated from hook events (issue #63) — reopening a
-  // stale one is noise, so don't track them.
-  if (surface.type === 'diff') return;
+// Workspaces where the user closed the auto-opened diff tab (issue #141).
+// Session-scoped, like the reopen stack: closing it used to last only until the
+// next Edit/Write hook fired, so the tab resurrected itself minutes later with
+// no user action — and on a large repo its polling was what made typing lag.
+// A tab the user dismissed stays dismissed until they ask for a diff again.
+const diffTabDismissed = new Set<WorkspaceId>();
+
+/** True if the user closed this workspace's diff tab and hasn't reopened one. */
+export function isDiffTabDismissed(workspaceId: WorkspaceId): boolean {
+  return diffTabDismissed.has(workspaceId);
+}
+
+/**
+ * Bookkeeping every close path owes a surface it is about to drop.
+ *
+ * Diff surfaces are auto-generated from hook events (issue #63), so reopening a
+ * stale one via Ctrl+Shift+T is noise — but the close still has to be recorded,
+ * or the next Edit/Write hook puts the tab straight back (issue #141).
+ */
+function pushClosedSurface(workspaceId: WorkspaceId, surface: SurfaceRef): void {
+  if (surface.type === 'diff') {
+    diffTabDismissed.add(workspaceId);
+    return;
+  }
   closedSurfaceStack.push({
     type: surface.type,
     colorScheme: surface.colorScheme,
@@ -208,6 +234,12 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
 
     const leaf = findLeaf(ws.splitTree, paneId);
     if (!leaf) return null;
+
+    // Asking for a diff tab retracts an earlier dismissal, so the auto-open
+    // behaviour resumes for this workspace (issue #141). `options.auto` marks
+    // the hook-driven open, which must not clear it — that is the loop the
+    // dismissal exists to break.
+    if (type === 'diff' && !options?.auto) diffTabDismissed.delete(workspaceId);
 
     const newSurface: SurfaceRef = {
       id: surfaceId,
@@ -298,7 +330,7 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
     // this action, and neither used to kill the PTY (only the tab-× button did).
     const closing = leaf.surfaces.find((s) => s.id === surfaceId);
     if (closing) {
-      pushClosedSurface(closing);
+      pushClosedSurface(workspaceId, closing);
       killSurfacePty(closing);
     }
 
@@ -349,7 +381,10 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
       return;
     }
 
-    for (const surface of leaf.surfaces) killSurfacePty(surface);
+    for (const surface of leaf.surfaces) {
+      if (surface.type === 'diff') diffTabDismissed.add(workspaceId);
+      killSurfacePty(surface);
+    }
     updateSplitTree(workspaceId, newTree);
   },
 
@@ -369,7 +404,7 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
     // mirroring the bookkeeping in closeSurface (issues #64, #65).
     for (const s of leaf.surfaces) {
       if (s.id === keepSurfaceId) continue;
-      pushClosedSurface(s);
+      pushClosedSurface(workspaceId, s);
       killSurfacePty(s);
     }
 
@@ -394,7 +429,7 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
     // Reap the shells to the right and remember them for Ctrl+Shift+T,
     // mirroring the bookkeeping in closeSurface (issues #64, #65).
     for (const s of leaf.surfaces.slice(idx + 1)) {
-      pushClosedSurface(s);
+      pushClosedSurface(workspaceId, s);
       killSurfacePty(s);
     }
 

--- a/tests/unit/diff-provider-git.test.ts
+++ b/tests/unit/diff-provider-git.test.ts
@@ -1,0 +1,104 @@
+/**
+ * The git path of the diff provider must never let invocations pile up.
+ *
+ * On a large working tree `git diff HEAD --numstat` takes ~1s. A caller asking
+ * faster than that (the diff pane did, at render speed) used to stack one
+ * `git.exe` per call — 10-40/s measured, saturating the main process and
+ * lagging every keystroke, since the main process is also the PTY relay
+ * (issue #141).
+ *
+ * The snapshot (non-git) path already coalesced via `scansInFlight`; the git
+ * path did not. These tests pin the guarantee for the git path.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { promisify } from 'util';
+
+// ─── execFile mock ──────────────────────────────────────────────────────────
+// diff-provider does `promisify(execFile)` at module load, so the mock has to
+// carry the promisify.custom symbol Node's real execFile has — otherwise
+// promisify resolves with stdout alone and the `{ stdout }` destructure breaks.
+
+interface Call { args: string[]; release: () => void }
+const calls: Call[] = [];
+/** When true, invocations hang until explicitly released. */
+let holdCalls = false;
+
+function stdoutFor(args: string[]): string {
+  if (args[0] === 'rev-parse') return 'true\n';
+  if (args[0] === 'status') return ' M src/a.ts\n';
+  if (args[0] === 'diff' && args.includes('--numstat')) return '3\t1\tsrc/a.ts\n';
+  return '';
+}
+
+const execFileImpl: any = (_cmd: string, args: string[]) => {
+  let release!: () => void;
+  const gate = new Promise<void>((r) => { release = r; });
+  calls.push({ args, release });
+  if (!holdCalls) release();
+  return gate.then(() => ({ stdout: stdoutFor(args), stderr: '' }));
+};
+execFileImpl[promisify.custom] = execFileImpl;
+
+vi.mock('child_process', () => ({ execFile: execFileImpl }));
+
+const gitArgs = () => calls.map((c) => c.args.join(' '));
+const countMatching = (needle: string) => gitArgs().filter((a) => a.includes(needle)).length;
+/** Release everything queued and let the microtask chain advance. */
+async function drain(): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    calls.forEach((c) => c.release());
+    await Promise.resolve();
+  }
+}
+
+let getChangedFiles: (cwd: string) => Promise<Array<{ path: string }>>;
+let resetDiffCaches: () => void;
+
+beforeEach(async () => {
+  calls.length = 0;
+  holdCalls = false;
+  vi.resetModules();
+  const mod = await import('../../src/main/diff-provider');
+  getChangedFiles = mod.getChangedFiles as typeof getChangedFiles;
+  resetDiffCaches = mod.resetDiffCaches;
+  resetDiffCaches();
+});
+
+describe('getChangedFiles — git path concurrency', () => {
+  it('coalesces overlapping calls into a single git pass', async () => {
+    holdCalls = true;
+    const pending = [
+      getChangedFiles('/repo'),
+      getChangedFiles('/repo'),
+      getChangedFiles('/repo'),
+      getChangedFiles('/repo'),
+      getChangedFiles('/repo'),
+    ];
+    holdCalls = false;
+    await drain();
+    const results = await Promise.all(pending);
+
+    expect(countMatching('--numstat')).toBe(1);
+    // Every caller still gets the answer.
+    for (const r of results) expect(r).toHaveLength(1);
+  });
+
+  it('runs again once the previous pass has settled', async () => {
+    await getChangedFiles('/repo');
+    expect(countMatching('--numstat')).toBe(1);
+    await getChangedFiles('/repo');
+    expect(countMatching('--numstat')).toBe(2);
+  });
+
+  it('does not coalesce across different directories', async () => {
+    await Promise.all([getChangedFiles('/repo-a'), getChangedFiles('/repo-b')]);
+    expect(countMatching('--numstat')).toBe(2);
+  });
+
+  it('caches the repo probe instead of re-running rev-parse every pass', async () => {
+    await getChangedFiles('/repo');
+    await getChangedFiles('/repo');
+    await getChangedFiles('/repo');
+    expect(countMatching('rev-parse')).toBe(1);
+  });
+});

--- a/tests/unit/i18n-translator.test.ts
+++ b/tests/unit/i18n-translator.test.ts
@@ -1,0 +1,31 @@
+/**
+ * The translator returned for a language must be referentially stable.
+ *
+ * `useT()` feeds `t` into `useCallback`/`useEffect` dependency arrays all over
+ * the renderer. A fresh closure per render silently invalidates every one of
+ * them, which is how the diff pane's 2s poll degenerated into a render-speed
+ * loop that spawned `git.exe` faster than git could answer (issue #141).
+ */
+import { describe, it, expect } from 'vitest';
+import { makeT, translate } from '../../src/renderer/i18n/core';
+
+describe('makeT', () => {
+  it('returns the same function identity for the same language', () => {
+    expect(makeT('en')).toBe(makeT('en'));
+    expect(makeT('fr')).toBe(makeT('fr'));
+  });
+
+  it('returns a different translator per language', () => {
+    expect(makeT('en')).not.toBe(makeT('fr'));
+  });
+
+  it('translates identically to translate()', () => {
+    const t = makeT('fr');
+    expect(t('diffPane.changed', 'Changed')).toBe(translate('fr', 'diffPane.changed', 'Changed'));
+  });
+
+  it('honours the fallback for an unknown key', () => {
+    const t = makeT('en');
+    expect(t('not.a.real.key' as never, 'Fallback')).toBe('Fallback');
+  });
+});

--- a/tests/unit/surface-slice.test.ts
+++ b/tests/unit/surface-slice.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { create } from 'zustand';
 import { createWorkspaceSlice, WorkspaceSlice } from '../../src/renderer/store/workspace-slice';
-import { createSurfaceSlice, SurfaceSlice } from '../../src/renderer/store/surface-slice';
+import { createSurfaceSlice, isDiffTabDismissed, SurfaceSlice } from '../../src/renderer/store/surface-slice';
 import { WorkspaceId, PaneId, SurfaceId, SplitNode } from '../../src/shared/types';
 
 type TestStore = WorkspaceSlice & SurfaceSlice;
@@ -111,6 +111,62 @@ describe('surface-slice', () => {
       const leaf = currentLeaf();
       expect(leaf.surfaces).toHaveLength(1);
       expect(leaf.activeSurfaceIndex).toBe(0);
+    });
+  });
+
+  // Issue #141: closing the auto-opened diff tab used to last only until the
+  // next Edit/Write hook fired, so it came back minutes later with no user
+  // action — and on a large repo its git polling was what made typing lag.
+  describe('diff tab dismissal', () => {
+    it('is not dismissed before the user closes one', () => {
+      expect(isDiffTabDismissed(workspaceId)).toBe(false);
+    });
+
+    it('records the dismissal when the diff tab is closed', () => {
+      const id = useStore.getState().addSurface(workspaceId, paneId, 'diff', { auto: true })!;
+      useStore.getState().closeSurface(workspaceId, paneId, id);
+      expect(isDiffTabDismissed(workspaceId)).toBe(true);
+    });
+
+    it('records it when the diff tab is swept up by closeOtherSurfaces', () => {
+      const keep = currentLeaf().surfaces[0].id;
+      useStore.getState().addSurface(workspaceId, paneId, 'diff', { auto: true });
+      useStore.getState().closeOtherSurfaces(workspaceId, paneId, keep);
+      expect(isDiffTabDismissed(workspaceId)).toBe(true);
+    });
+
+    it('records it when the diff tab is swept up by closeSurfacesToRight', () => {
+      const first = currentLeaf().surfaces[0].id;
+      useStore.getState().addSurface(workspaceId, paneId, 'diff', { auto: true });
+      useStore.getState().closeSurfacesToRight(workspaceId, paneId, first);
+      expect(isDiffTabDismissed(workspaceId)).toBe(true);
+    });
+
+    it('stays dismissed when a later auto-open is attempted', () => {
+      const id = useStore.getState().addSurface(workspaceId, paneId, 'diff', { auto: true })!;
+      useStore.getState().closeSurface(workspaceId, paneId, id);
+      useStore.getState().addSurface(workspaceId, paneId, 'diff', { auto: true });
+      expect(isDiffTabDismissed(workspaceId)).toBe(true);
+    });
+
+    it('is retracted when the user asks for a diff tab explicitly', () => {
+      const id = useStore.getState().addSurface(workspaceId, paneId, 'diff', { auto: true })!;
+      useStore.getState().closeSurface(workspaceId, paneId, id);
+      useStore.getState().addSurface(workspaceId, paneId, 'diff');
+      expect(isDiffTabDismissed(workspaceId)).toBe(false);
+    });
+
+    it('does not leak across workspaces', () => {
+      const other = useStore.getState().createWorkspace({ title: 'Other' });
+      const id = useStore.getState().addSurface(workspaceId, paneId, 'diff', { auto: true })!;
+      useStore.getState().closeSurface(workspaceId, paneId, id);
+      expect(isDiffTabDismissed(other)).toBe(false);
+    });
+
+    it('does not track non-diff surfaces', () => {
+      const id = useStore.getState().addSurface(workspaceId, paneId, 'terminal')!;
+      useStore.getState().closeSurface(workspaceId, paneId, id);
+      expect(isDiffTabDismissed(workspaceId)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Fixes #141.

## Root cause

The 2s poll interval never applied.

`useT()` built a fresh closure on every render. That churned `loadFiles`'
`useCallback` identity, which invalidated the polling effect's
`[loadFiles, loadDiff]` dependency array on every render — and the effect body
starts a poll immediately. Its `setTimeout(poll, Math.max(2000, elapsed))` was
cancelled by the cleanup every single time and never once fired.

It amplified itself. Cleanup sets `cancelled = true`, but that cannot un-spawn
the `git.exe` already running, and each completion fired `setError(null)` /
`setLoading(false)` → render → effect restart → another immediate poll. On a
repo where `git diff HEAD --numstat` takes ~1s the overlap window is wide
enough to stack 10–30 git processes, which is exactly what @Ray0483 measured
(79–106% of a core, main process, fully idle session). Small repos hid it: at
5ms per invocation nothing overlaps long enough to pile up.

## Changes

**The poll storm**

| | |
|---|---|
| `i18n/core.ts` | `makeT(lang)` memoises one translator per language; `useT()` is now referentially stable. 42 call sites feed `t` into dependency arrays — this was mis-invalidating all of them, not just the diff pane. |
| `DiffPane.tsx` | Poll reads its loaders through refs and depends only on `[cwd, surfaceId]`, so no re-render can restart it. Every `setState` is guarded on an actual change. A pane hidden behind another tab or in a background window skips the pass — tabs stay mounted by design, so the surface has to opt out itself. |
| `diff-provider.ts` | The git path coalesces per cwd, like the snapshot path already did — a caller polling faster than git answers joins the pass in flight instead of spawning another. The `rev-parse` repo probe (a third of the spawned processes) is cached with a 30s TTL. |

**The auto-recreation**

Closing the tab wasn't a workaround either — the Edit/Write hook re-opened it
minutes later with no user action. A closed diff tab is now recorded per
workspace and stays closed until the user asks for one explicitly;
`maybeAutoOpenDiffTab` passes `auto: true` so a hook-driven open can never
retract the dismissal.

**Issue 2 — the state commands used to diagnose this**

- `wmux tree --workspace <id>` parsed the flag and dropped it on the floor,
  always reporting the active workspace. `list-surfaces` ignored `--workspace`
  too, and `--pane` was never applied renderer-side.
- Both resolved their target as `getAllWindows()[0]`, an order Electron does
  not guarantee, so consecutive calls could describe different windows. V2
  commands now carry the caller's `WMUX_SURFACE_ID` (as `browser.*` already
  did) and answer about the window that owns it. This is what made a scripted
  "find the diff surface → close it" find nothing and exit reporting success.

`wmux diff` creating a workspace, and the `工作区 3` / `Workspace 3` default-name
locale mix, are **not** addressed here — I could not reproduce either and
neither has a mechanism I can point at yet. Tracking separately.

## Tests

`tests/unit/diff-provider-git.test.ts` (new) — pins that overlapping
`getChangedFiles` calls produce exactly one `--numstat`, that a later call
still runs, that different cwds don't coalesce, and that `rev-parse` is probed
once.

`tests/unit/i18n-translator.test.ts` (new) — pins translator identity
stability, the property the whole fix rests on.

`tests/unit/surface-slice.test.ts` — dismissal is recorded via all three close
paths, survives a later auto-open, is retracted by an explicit open, and does
not leak across workspaces.

705 tests pass. `build:main`, renderer `tsc --noEmit`, and `vite build` are
clean; lint count is unchanged from master (31 pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwpQ2e9r28DcBNqeq3F7qv
