### PR TITLE
fix(cli): scope V2 commands to the caller's workspace, reject unknown flags (#143)

### DIFF
--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -503,10 +503,12 @@ async function cmdReportMetadata(args: string[]): Promise<void> {
   print(await sendV2('pane.report_metadata', params));
 }
 
-const AGENT_STATE_COMMANDS: Record<string, (args: string[]) => Promise<void>> = {
+// Keys stay inferred (no Record<string, …> annotation) so spreading this into
+// COMMANDS still satisfies the exhaustive Record<CommandName, …> check.
+const AGENT_STATE_COMMANDS = {
   'report-agent': cmdReportAgent,
   'report-metadata': cmdReportMetadata,
-  'report-session': async (args) => {
+  'report-session': async (args: string[]) => {
     const surfaceId = reportingSurface(args, 'report-session');
     print(await sendV2('pane.report_agent_session', {
       surfaceId,
@@ -515,22 +517,283 @@ const AGENT_STATE_COMMANDS: Record<string, (args: string[]) => Promise<void>> = 
     }));
   },
   'answer-agent': cmdAnswerAgent,
-  'release-agent': async (args) => {
+  'release-agent': async (args: string[]) => {
     const surfaceId = reportingSurface(args, 'release-agent');
     print(await sendV2('pane.release_agent', { surfaceId, seq: seqFlag(args) }));
   },
   // No --surface → the whole picture, including a `blocked` list that answers
   // "which pane needs me?" in one call.
-  'agent-state': async (args) => {
+  'agent-state': async (args: string[]) => {
     const surfaceId = getFlag(args, '--surface');
     print(await sendV2('pane.agent_state', surfaceId ? { surfaceId } : {}));
   },
 };
 
+// ─── Per-command usage + flag validation (issue #143) ────────────────────────
+// `getFlag()` picks out the flags it knows and ignores the rest, so a typo or an
+// exploratory `--help` used to fall through to "run with defaults" — probing the
+// CLI mutated the user's layout (`wmux split --help` split a pane) and returned
+// a JSON reply that read as success. Every command now declares its flags, so
+// anything else is an error, and `--help` prints usage without touching wmux.
+interface CommandSpec {
+  /** Printed by `--help`, by `wmux help <command>`, and after a rejected flag. */
+  usage: string;
+  /** Flags that consume the following argv token. */
+  value?: string[];
+  /** Flags that stand alone. */
+  bool?: string[];
+  /**
+   * Arguments are free-form text or belong to another program (ssh), so nothing
+   * here can be judged a typo. Their argv is never validated and `--help` is
+   * left alone — `wmux send --help` must type "--help" into the pane, not print
+   * usage. `wmux help <command>` is the way in for these.
+   */
+  passthrough?: boolean;
+}
+
+const SURFACE_NOTE = '(surface defaults to $WMUX_SURFACE_ID inside a pane)';
+
+const COMMAND_SPECS = {
+  // System
+  ping: { usage: 'wmux ping' },
+  identify: { usage: 'wmux identify' },
+  capabilities: { usage: 'wmux capabilities' },
+  'list-windows': { usage: 'wmux list-windows' },
+  'focus-window': { usage: 'wmux focus-window <windowId>' },
+  'new-window': { usage: 'wmux new-window' },
+
+  // Remote management (issue #78)
+  bridge: {
+    usage: 'wmux bridge [--port P] [--host H]   (expose this wmux\'s pipe over TCP, default 127.0.0.1:9787)',
+    value: ['--port', '--host'],
+  },
+  token: { usage: 'wmux token   (print this instance\'s pipe auth token)' },
+
+  // Workspace
+  'new-workspace': {
+    usage: 'wmux new-workspace [--title T] [--shell S] [--cwd D]',
+    value: ['--title', '--shell', '--cwd'],
+  },
+  ssh: { usage: 'wmux ssh [ssh options] <user@host> [--title T]', passthrough: true },
+  'close-workspace': { usage: 'wmux close-workspace [workspaceId]' },
+  'select-workspace': { usage: 'wmux select-workspace <workspaceId>' },
+  'rename-workspace': { usage: 'wmux rename-workspace <workspaceId> <title>', passthrough: true },
+  'list-workspaces': { usage: 'wmux list-workspaces' },
+
+  // Surface
+  'new-surface': {
+    usage: 'wmux new-surface [--type terminal|browser|markdown] [--color-scheme NAME]',
+    value: ['--type', '--color-scheme'],
+  },
+  'close-surface': { usage: 'wmux close-surface [surfaceId]' },
+  'rename-surface': {
+    usage: 'wmux rename-surface [surfaceId] <title>   (renames the current surface inside a pane)',
+    passthrough: true,
+  },
+  'focus-surface': { usage: 'wmux focus-surface <surfaceId>' },
+  'list-surfaces': {
+    usage: 'wmux list-surfaces [--pane <paneId>] [--workspace <workspaceId>]',
+    value: ['--pane', '--workspace'],
+  },
+  'set-color-scheme': { usage: 'wmux set-color-scheme [surfaceId] <scheme>' },
+  'clear-color-scheme': { usage: 'wmux clear-color-scheme [surfaceId]' },
+  'list-themes': { usage: 'wmux list-themes' },
+  themes: { usage: 'wmux themes   (alias of list-themes)' },
+
+  // User config
+  'reload-config': { usage: 'wmux reload-config' },
+  config: { usage: 'wmux config <show|reload|path>' },
+
+  // Pane
+  split: {
+    usage: 'wmux split [--down] [--type terminal|browser|markdown] [--color-scheme NAME]',
+    value: ['--type', '--color-scheme'],
+    bool: ['--down'],
+  },
+  pane: {
+    usage: [
+      'wmux pane new [--down] [--type T] [--color-scheme NAME]',
+      'wmux pane close <paneId> | focus <paneId> | list [--workspace <id>]',
+    ].join('\n'),
+    value: ['--type', '--color-scheme', '--workspace'],
+    bool: ['--down'],
+  },
+  'close-pane': { usage: 'wmux close-pane [paneId]' },
+  'focus-pane': { usage: 'wmux focus-pane <paneId>' },
+  'zoom-pane': { usage: 'wmux zoom-pane [paneId]' },
+  'list-panes': { usage: 'wmux list-panes [--workspace <workspaceId>]', value: ['--workspace'] },
+  tree: { usage: 'wmux tree [--workspace <workspaceId>]', value: ['--workspace'] },
+
+  // Layout
+  layout: {
+    usage: 'wmux layout grid --count <N> [--type T] [--anchor-surface <id>] [--anchor-pane <id>] [--workspace <id>]',
+    value: ['--count', '--type', '--anchor-surface', '--anchor-pane', '--workspace'],
+  },
+
+  // Terminal interaction
+  send: { usage: 'wmux send [--surface <id>] <text>', passthrough: true },
+  'send-key': {
+    usage: 'wmux send-key <key> [--ctrl] [--shift] [--alt] [--surface <id>]',
+    value: ['--surface'],
+    bool: ['--ctrl', '--shift', '--alt'],
+  },
+  'read-screen': {
+    usage: `wmux read-screen [--lines N] [--surface <id>]   ${SURFACE_NOTE}`,
+    value: ['--lines', '--surface'],
+  },
+  'trigger-flash': { usage: 'wmux trigger-flash [surfaceId]' },
+
+  // Browser (free-form text for type/fill/eval)
+  browser: {
+    usage: [
+      'wmux browser open <url> | snapshot | click <ref> | type <ref> <text> | fill <ref> <value>',
+      'wmux browser screenshot [--full] | get-text [ref] | eval <js> | wait <ref> [ms]',
+      'wmux browser back | forward | reload',
+    ].join('\n'),
+    passthrough: true,
+  },
+
+  // Agent
+  agent: {
+    usage: [
+      'wmux agent spawn --cmd <C> [--label L] [--cwd D] [--pane P] [--workspace W] [--replace-tab]',
+      'wmux agent spawn-batch --json \'[...]\' [--strategy distribute|stack|split]',
+      'wmux agent status <agentId> | list [--workspace <id>] | kill <agentId>',
+    ].join('\n'),
+    value: ['--cmd', '--label', '--cwd', '--pane', '--workspace', '--json', '--strategy'],
+    bool: ['--replace-tab'],
+  },
+
+  // Markdown (--content takes free-form text)
+  markdown: {
+    usage: [
+      'wmux markdown <file>                                   (open a file in a new markdown view)',
+      'wmux markdown set <id> --content <text> [--title T]',
+      'wmux markdown set <id> --file <path>',
+      'wmux markdown get <id>',
+    ].join('\n'),
+    passthrough: true,
+  },
+
+  // Notifications
+  notify: { usage: 'wmux notify <text>', passthrough: true },
+  'list-notifications': { usage: 'wmux list-notifications' },
+  'clear-notifications': { usage: 'wmux clear-notifications [notificationId]' },
+
+  // Sidebar
+  'set-status': {
+    usage: [
+      'wmux set-status --workspace <id> --state <idle|running|interrupted> [--text "<label>"]',
+      'wmux set-status <key> <value>                          (legacy positional form)',
+    ].join('\n'),
+    value: ['--workspace', '--state', '--text'],
+  },
+  'set-progress': { usage: 'wmux set-progress <value> [--label L]', value: ['--label'] },
+  log: { usage: 'wmux log <level> <message>', passthrough: true },
+  'sidebar-state': { usage: 'wmux sidebar-state' },
+
+  diff: { usage: 'wmux diff [--file <path>]', value: ['--file'] },
+  hook: {
+    usage: 'wmux hook --event <type> --tool <name> [--agent <id>]',
+    value: ['--event', '--tool', '--agent'],
+  },
+  'agent-activity': {
+    usage: `wmux agent-activity [--tool T] [--skill S] [--done|--active] [--surface <id>]   ${SURFACE_NOTE}`,
+    value: ['--tool', '--skill', '--surface'],
+    bool: ['--done', '--active'],
+  },
+
+  // Declared agent state (issue #128)
+  'report-agent': {
+    usage: [
+      'wmux report-agent --blocked [reason] [--choices <json>] | --unblocked',
+      'wmux report-agent --run-start | --run-end | --run-depth <N>',
+      `  [--seq N] [--surface <id>]   ${SURFACE_NOTE}`,
+    ].join('\n'),
+    // --blocked's reason is optional; treating it as value-taking only ever
+    // skips one token that a later flag would have re-validated anyway.
+    value: ['--blocked', '--reason', '--choices', '--run-depth', '--seq', '--surface'],
+    bool: ['--unblocked', '--run-start', '--run-end'],
+  },
+  'report-metadata': {
+    usage: `wmux report-metadata [--model M] [--tokens T] [--context-pct N] [--ttl ms] [--seq N] [--surface <id>]   ${SURFACE_NOTE}`,
+    value: ['--model', '--tokens', '--context-pct', '--ttl', '--seq', '--surface'],
+  },
+  'report-session': {
+    usage: `wmux report-session <sessionId> [--seq N] [--surface <id>]   ${SURFACE_NOTE}`,
+    value: ['--session', '--seq', '--surface'],
+  },
+  'answer-agent': {
+    usage: 'wmux answer-agent --surface <id> --choice <choiceId>   (reply to ANOTHER pane; no ambient default)',
+    value: ['--surface', '--choice'],
+  },
+  'release-agent': {
+    usage: `wmux release-agent [--seq N] [--surface <id>]   ${SURFACE_NOTE}`,
+    value: ['--seq', '--surface'],
+  },
+  'agent-state': {
+    usage: 'wmux agent-state [--surface <id>]   (no --surface → every pane, plus the blocked list)',
+    value: ['--surface'],
+  },
+} satisfies Record<string, CommandSpec>;
+
+type CommandName = keyof typeof COMMAND_SPECS;
+
+/**
+ * Reject flags the command does not declare, instead of running with defaults.
+ *
+ * Only `--` flags are judged: single-dash tokens belong to passthrough commands
+ * (ssh options) and bare words are positional arguments.
+ */
+function checkFlags(command: string, args: string[], spec: CommandSpec): void {
+  if (spec.passthrough) return;
+  const takesValue = new Set(spec.value ?? []);
+  const standalone = new Set(spec.bool ?? []);
+  for (let i = 1; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith('--')) continue;
+    if (standalone.has(arg)) continue;
+    if (takesValue.has(arg)) {
+      // A trailing value flag is the same silent default in a different
+      // costume: `getFlag` returns undefined and the command runs anyway.
+      // --blocked is the one flag whose value is genuinely optional.
+      if (i === args.length - 1 && arg !== '--blocked') {
+        fail(command, spec, `Flag '${arg}' needs a value.`);
+      }
+      i++;
+      continue;
+    }
+    fail(command, spec, `Unknown flag for '${command}': ${arg}`);
+  }
+}
+
+/** Print why the argv was rejected, then that command's usage, then exit 1. */
+function fail(command: string, spec: CommandSpec, message: string): never {
+  console.error(message);
+  console.error('');
+  console.error(spec.usage);
+  process.exit(1);
+}
+
+/** `wmux help [command]` — the only help route that works for passthrough commands. */
+function cmdHelp(args: string[]): void {
+  const topic = args[1];
+  if (!topic) { printUsage(); return; }
+  const spec = (COMMAND_SPECS as Record<string, CommandSpec>)[topic];
+  if (!spec) {
+    console.error(`Unknown command: ${topic}`);
+    printUsage();
+    process.exit(1);
+  }
+  console.log(spec.usage);
+}
+
 // Command dispatch table. Each handler receives the raw argv (args[0] is the
 // command name). Replaces a single giant switch so each command stays small and
-// independently testable.
-const COMMANDS: Record<string, (args: string[]) => Promise<void> | void> = {
+// independently testable. Typed against COMMAND_SPECS so the compiler — not a
+// bug report — catches a command that ships without usage text, or usage text
+// for a command that no longer exists.
+const COMMANDS: Record<CommandName, (args: string[]) => Promise<void> | void> = {
   // System
   ping: async () => console.log(await sendV1('ping')),
   identify: async () => print(await sendV2('system.identify')),
@@ -684,17 +947,26 @@ async function main() {
 
   const command = args[0];
 
-  if (!command) {
-    printUsage();
+  if (!command || command === 'help' || command === '--help' || command === '-h') {
+    cmdHelp(command === 'help' ? args : []);
     process.exit(0);
   }
 
-  const handler = COMMANDS[command];
+  const handler = COMMANDS[command as CommandName];
   if (!handler) {
     console.error(`Unknown command: ${command}`);
     printUsage();
     process.exit(1);
   }
+
+  // Usage and flag checks both happen before a single byte reaches the pipe, so
+  // probing the CLI can no longer mutate the user's layout (issue #143).
+  const spec: CommandSpec = COMMAND_SPECS[command as CommandName];
+  if (!spec.passthrough && (args.includes('--help') || args.includes('-h'))) {
+    console.log(spec.usage);
+    process.exit(0);
+  }
+  checkFlags(command, args, spec);
 
   try {
     await handler(args);
@@ -744,6 +1016,11 @@ Agent state: report-agent --blocked [reason] [--choices <json>] | --unblocked
             (surface defaults to $WMUX_SURFACE_ID — an agent in a pane needs no id)
 Config:     config show|reload|path   (edits ~/.wmux/config.toml — see docs)
             reload-config             (shorthand for 'config reload')
+
+Help:       wmux help <command>       (per-command usage; works for every command)
+            wmux <command> --help     (same, except for free-form commands such as
+                                       send / notify / log / ssh / browser / markdown,
+                                       where --help is part of the text you are sending)
 `);
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -497,14 +497,20 @@ app.whenReady().then(() => {
   // Each gets its own slot in the registry so its renderer restores its own
   // workspaces — `SESSION_LOAD_AUTO` used to hand windows[0] to whoever asked,
   // which made a second window a clone of the first.
+  //
+  // These are also the only windows allowed to fall back to the newest *named*
+  // session when they have no slot: a window opened later in the run must come
+  // up empty instead of cloning one, which would duplicate its surface ids —
+  // and PTY id is surface id, so the clone would attach to live PTYs (#143).
   const savedSession = loadSession();
   const savedWindows = (savedSession?.windows ?? []).slice(0, MAX_RESTORED_WINDOWS);
   if (savedWindows.length === 0) {
-    windowManager.createWindow();
+    sessionWindows.markStartup(windowManager.createWindow());
   } else {
     for (const saved of savedWindows) {
       const id = windowManager.createWindow(saved.bounds, saved.maximized);
       sessionWindows.prime(id, saved);
+      sessionWindows.markStartup(id);
     }
   }
 

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -20,7 +20,7 @@ import { CDPBridge } from './cdp-bridge';
 import { CDPProxy } from './cdp-proxy';
 import { AgentManager } from './agent-manager';
 import { saveNamedSession, loadNamedSession, listNamedSessions, deleteNamedSession, loadSession } from './session-persistence';
-import { sessionWindows, toRestorePayload } from './session-windows';
+import { sessionWindows, toRestorePayload, restoreAnswerFor } from './session-windows';
 import { loadSettings, saveSetting } from './settings-store';
 import { readConsent, updateConsent } from './agent-integration';
 import { handleAgentStateV2 } from './agent-state-rpc';
@@ -319,7 +319,11 @@ export function registerIpcHandlers(windowManager: WindowManager, cdpProxyInstan
   // could never restore more than one window's worth of state.
   ipcMain.handle(IPC_CHANNELS.SESSION_LOAD_AUTO, (event) => {
     const windowId = windowManager.idForWebContents(event.sender);
-    if (windowId) return toRestorePayload(sessionWindows.get(windowId));
+    if (windowId) {
+      return restoreAnswerFor(sessionWindows.get(windowId), {
+        startup: sessionWindows.isStartup(windowId),
+      });
+    }
     // Unattributable sender: fall back to the file's first window rather than
     // leaving a legitimately-restored window empty.
     return toRestorePayload(loadSession()?.windows?.[0] ?? null);

--- a/src/main/session-windows.ts
+++ b/src/main/session-windows.ts
@@ -28,6 +28,21 @@ export class SessionWindowRegistry {
   // they were created rather than the order they happened to answer in.
   private slots = new Map<string, SessionWindowState>();
 
+  // Windows the startup restore created, as opposed to ones opened mid-run.
+  // Only the former may fall back to the newest *named* session; see
+  // restoreAnswerFor.
+  private startup = new Set<string>();
+
+  /** Mark a window as one of the app's launch windows. */
+  markStartup(windowId: string): void {
+    this.startup.add(windowId);
+  }
+
+  /** Was this window created by the startup restore rather than during the run? */
+  isStartup(windowId: string): boolean {
+    return this.startup.has(windowId);
+  }
+
   /** Seed a freshly created window with the state it was restored from. */
   prime(windowId: string, state: SessionWindowState): void {
     this.slots.set(windowId, state);
@@ -46,6 +61,7 @@ export class SessionWindowRegistry {
   /** Drop one window's slot — it was closed and should not come back. */
   forget(windowId: string): void {
     this.slots.delete(windowId);
+    this.startup.delete(windowId);
   }
 
   /**
@@ -58,6 +74,9 @@ export class SessionWindowRegistry {
     const live = new Set(liveWindowIds);
     for (const id of [...this.slots.keys()]) {
       if (!live.has(id)) this.slots.delete(id);
+    }
+    for (const id of [...this.startup]) {
+      if (!live.has(id)) this.startup.delete(id);
     }
   }
 
@@ -94,4 +113,36 @@ export function toRestorePayload(state: SessionWindowState | null): {
     sidebarWidth: state.sidebarWidth,
     activeIndex: activeIndex >= 0 ? activeIndex : 0,
   };
+}
+
+/** What `session:load-auto` answers a window with. */
+export type RestoreAnswer =
+  | NonNullable<ReturnType<typeof toRestorePayload>>
+  /** "Come up empty" — do NOT fall back to a named session. */
+  | { fresh: true }
+  /** "I have nothing for you" — the renderer's own fallbacks apply. */
+  | null;
+
+/**
+ * The answer for one window, which hinges on WHEN the window was created.
+ *
+ * `null` used to mean both "nothing saved" and "deliberately empty", and the
+ * renderer reads it as the former: it falls back to the newest *named* session.
+ * That is right at launch, and wrong for a window opened during the run — which
+ * came up as a clone of that named session, re-using its workspace, pane and
+ * surface ids (issue #143). Duplicated surface ids are not cosmetic here: PTY id
+ * IS surface id in wmux, so the clone's terminals attach to the original
+ * window's PTYs, and every id-based CLI lookup has two equally valid answers.
+ *
+ * So a mid-run window gets an explicit `{ fresh: true }` instead — the same
+ * contract the per-window restore has claimed since issue #118, now actually
+ * enforceable on the renderer side.
+ */
+export function restoreAnswerFor(
+  state: SessionWindowState | null,
+  opts: { startup: boolean },
+): RestoreAnswer {
+  const payload = toRestorePayload(state);
+  if (payload) return payload;
+  return opts.startup ? null : { fresh: true };
 }

--- a/src/main/v2-bridge.ts
+++ b/src/main/v2-bridge.ts
@@ -18,45 +18,94 @@ interface BridgeSpec {
   emptyOnNoWindow?: any;
   // Error message when the renderer returns a falsy result (creation methods).
   requireResult?: string;
+  /**
+   * Methods that act on "a workspace" with no id of their own to go by. They
+   * fall back to the *active* workspace of whatever window they land on, which
+   * is only the right answer when the caller happens to be looking at it — so
+   * when we know where the calling shell lives, its workspace is the better
+   * default (issue #143). Methods that take an explicit surface/pane id are
+   * deliberately NOT scoped: the renderer resolves those ids window-wide.
+   */
+  callerScoped?: boolean;
 }
 
-// caller surface id → the window that held it. `getAllWindows()` order is not
-// a promise Electron makes, so two consecutive CLI calls could land on two
-// different windows and report contradictory state (issue #141: `tree` and
-// `list-surfaces` disagreed about which panes existed, and a scripted cleanup
-// consequently found nothing to close and exited claiming success).
-const callerWindows = new Map<string, number>();
+/** Which window (by `BrowserWindow.id`) and workspace a call should be answered by. */
+export interface CallerTarget<W> {
+  win: W;
+  /** Undefined when the caller's surface is unknown — the window's own active workspace stands. */
+  workspaceId?: string;
+}
 
 /**
- * The window that owns the calling shell's surface, or the first one.
+ * Resolve the calling shell's surface to the window AND workspace that hold it.
  *
- * Only probes when it has to: with a single window — the common case — the
- * answer is that window and no extra round-trip is spent.
+ * Split out from the Electron plumbing (injected `live` / `focused` / `locate`)
+ * so the resolution rules are unit-testable without a running app.
+ *
+ * Rules, in order:
+ *   1. No caller id → the focused window, no workspace opinion. Unchanged.
+ *   2. Probe windows for the surface, cached window first. First hit wins and
+ *      supplies BOTH the window and the workspace.
+ *   3. Surface unknown anywhere (stale `WMUX_SURFACE_ID`, closed pane) → fall
+ *      back to the focused window, exactly as if no id had been passed.
+ *
+ * The cache is only a probe-ORDER hint, never the answer. It used to be
+ * authoritative, so one wrong or outdated hit pinned that caller to that window
+ * for the rest of the session — the "byte-stable across focus changes" wrong
+ * result in issue #143. Re-probing costs one round-trip and lets a stale entry
+ * heal itself on the very next call.
  */
-async function windowForCaller(caller: unknown): Promise<BrowserWindow | null> {
-  const live = BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed());
-  if (live.length <= 1) return live[0] ?? null;
-  if (typeof caller !== 'string' || !caller) return BrowserWindow.getFocusedWindow() ?? live[0];
+export async function resolveCallerTarget<W>(
+  caller: unknown,
+  deps: {
+    live: readonly W[];
+    focused: () => W | null;
+    keyOf: (win: W) => number;
+    locate: (win: W, surfaceId: string) => Promise<{ workspaceId?: string | null } | null | undefined>;
+    cache: Map<string, number>;
+  },
+): Promise<CallerTarget<W> | null> {
+  const { live } = deps;
+  if (live.length === 0) return null;
+  const fallback = () => ({ win: live.length === 1 ? live[0] : (deps.focused() ?? live[0]) });
+  if (typeof caller !== 'string' || !caller) return fallback();
 
-  const cachedId = callerWindows.get(caller);
-  const cached = cachedId !== undefined ? live.find((w) => w.id === cachedId) : undefined;
-  if (cached) return cached;
+  const cachedKey = deps.cache.get(caller);
+  const cached = cachedKey === undefined ? undefined : live.find((w) => deps.keyOf(w) === cachedKey);
+  const order = cached ? [cached, ...live.filter((w) => w !== cached)] : live;
 
-  for (const win of live) {
+  for (const win of order) {
+    let found: { workspaceId?: string | null } | null | undefined;
     try {
-      const owns = await win.webContents.executeJavaScript(
-        `window.__wmux_hasSurface?.(${S(caller)})`
-      );
-      if (owns) {
-        callerWindows.set(caller, win.id);
-        return win;
-      }
-    } catch { /* window went away mid-probe; try the next */ }
+      found = await deps.locate(win, caller);
+    } catch {
+      continue; // window went away mid-probe; try the next
+    }
+    if (found) {
+      deps.cache.set(caller, deps.keyOf(win));
+      return { win, workspaceId: found.workspaceId ?? undefined };
+    }
   }
-  return BrowserWindow.getFocusedWindow() ?? live[0];
+  deps.cache.delete(caller);
+  return fallback();
 }
 
 const S = (v: any) => JSON.stringify(v);
+
+// caller surface id → the window that last held it. See resolveCallerTarget:
+// this is a hint that reorders the probe, not a binding.
+const callerWindows = new Map<string, number>();
+
+function targetForCaller(caller: unknown): Promise<CallerTarget<BrowserWindow> | null> {
+  return resolveCallerTarget(caller, {
+    live: BrowserWindow.getAllWindows().filter((w) => !w.isDestroyed()),
+    focused: () => BrowserWindow.getFocusedWindow(),
+    keyOf: (w) => w.id,
+    locate: (w, surfaceId) =>
+      w.webContents.executeJavaScript(`window.__wmux_locateSurface?.(${S(surfaceId)})`),
+    cache: callerWindows,
+  });
+}
 
 const SPECS: Record<string, BridgeSpec> = {
   'workspace.create': {
@@ -80,6 +129,7 @@ const SPECS: Record<string, BridgeSpec> = {
   'pane.split': {
     js: (p) => `window.__wmux_splitPane?.(${S(p || {})})`,
     requireResult: 'No active workspace or panes',
+    callerScoped: true,
   },
   'pane.close': {
     js: (p) => `window.__wmux_closePane?.(${S(p?.id || p?.paneId)}, ${S(p?.workspaceId)})`,
@@ -88,19 +138,23 @@ const SPECS: Record<string, BridgeSpec> = {
     js: (p) => `window.__wmux_listPanes?.(${S(p?.workspaceId)})`,
     shape: (r) => ({ panes: r || [] }),
     emptyOnNoWindow: { panes: [] },
+    callerScoped: true,
   },
   'layout.grid': {
     js: (p) => `window.__wmux_layoutGrid?.(${S(p || {})})`,
     requireResult: 'No active workspace or invalid anchor',
+    callerScoped: true,
   },
   'system.tree': {
     js: (p) => `window.__wmux_getTree?.(${S(p?.workspaceId)})`,
     shape: (r) => ({ tree: r || null }),
     emptyOnNoWindow: { tree: null },
+    callerScoped: true,
   },
   'surface.create': {
     js: (p) => `window.__wmux_createSurface?.(${S(p || {})})`,
     requireResult: 'No active workspace or panes',
+    callerScoped: true,
   },
   'surface.close': {
     js: (p) => `window.__wmux_closeSurface?.(${S(p?.id || p?.surfaceId)}, ${S(p?.workspaceId)})`,
@@ -115,6 +169,7 @@ const SPECS: Record<string, BridgeSpec> = {
     js: (p) => `window.__wmux_listSurfaces?.(${S(p?.workspaceId)}, ${S(p?.paneId)})`,
     shape: (r) => ({ surfaces: r || [] }),
     emptyOnNoWindow: { surfaces: [] },
+    callerScoped: true,
   },
   'markdown.set_content': {
     // `title` is optional and only sets the tab label; without it every
@@ -140,13 +195,18 @@ const SPECS: Record<string, BridgeSpec> = {
 function runBridge(spec: BridgeSpec, params: any, respond: Respond, respondError: RespondError): void {
   (async () => {
     try {
-      const win = await windowForCaller(params?.caller);
-      if (!win) {
+      const target = await targetForCaller(params?.caller);
+      if (!target) {
         if (spec.emptyOnNoWindow !== undefined) { respond(spec.emptyOnNoWindow); return; }
         respondError(-32000, 'No window');
         return;
       }
-      const result = await win.webContents.executeJavaScript(spec.js(params));
+      // An explicit --workspace always wins; the caller's workspace is only a
+      // default for the methods that would otherwise guess (issue #143).
+      const scoped = spec.callerScoped && target.workspaceId && !params?.workspaceId
+        ? { ...params, workspaceId: target.workspaceId }
+        : params;
+      const result = await target.win.webContents.executeJavaScript(spec.js(scoped));
       if (spec.requireResult && !result) { respondError(-32000, spec.requireResult); return; }
       respond(spec.shape ? spec.shape(result) : (result ?? { ok: true }));
     } catch (err: any) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -107,6 +107,48 @@ type MetaDeps = {
   t: T;
 };
 
+type SetWidth = (width: number) => void;
+
+/**
+ * Rehydrate from the rolling auto-save (the file main writes every 30s + on quit).
+ *
+ * `'fresh'` is main saying "this window was opened during the run — come up
+ * empty". It is distinct from `'none'` ("nothing saved for you") precisely
+ * because the caller must NOT fall through to a named session in that case:
+ * doing so cloned the session's workspace, pane and surface ids into a second
+ * window, and PTY id is surface id, so the clone re-attached to live PTYs and
+ * every id-based CLI lookup had two equally valid answers (issue #143).
+ */
+async function restoreAutoSaved(t: T, setWidth: SetWidth): Promise<'restored' | 'fresh' | 'none'> {
+  try {
+    const autoSaved = await window.wmux?.session?.loadAuto?.();
+    if (autoSaved && Array.isArray(autoSaved.workspaces) && autoSaved.workspaces.length > 0) {
+      useStore.getState().replaceAllWorkspaces(autoSaved.workspaces, autoSaved.activeIndex, t);
+      if (autoSaved.sidebarWidth) setWidth(autoSaved.sidebarWidth);
+      return 'restored';
+    }
+    return (autoSaved as { fresh?: boolean } | null | undefined)?.fresh ? 'fresh' : 'none';
+  } catch {
+    return 'none';
+  }
+}
+
+/** Fall back to the most recent manually-saved session. Returns whether it restored one. */
+async function restoreNamedSession(t: T, setWidth: SetWidth): Promise<boolean> {
+  try {
+    const sessions = await window.wmux?.session?.list();
+    const name = sessions?.[0]?.name;
+    if (!name) return false;
+    const session = await window.wmux?.session?.load(name);
+    if (!session) return false;
+    useStore.getState().replaceAllWorkspaces(session.workspaces, undefined, t);
+    if (session.sidebarWidth) setWidth(session.sidebarWidth);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function fireNotification(
   surfaceId: string,
   workspaceId: WorkspaceId | null,
@@ -470,28 +512,12 @@ export default function App() {
   // restart users with no manually-saved snapshot lost their workspaces.
   useEffect(() => {
     (async () => {
-      try {
-        const autoSaved = await window.wmux?.session?.loadAuto?.();
-        if (autoSaved && Array.isArray(autoSaved.workspaces) && autoSaved.workspaces.length > 0) {
-          const { replaceAllWorkspaces } = useStore.getState();
-          replaceAllWorkspaces(autoSaved.workspaces, autoSaved.activeIndex, t);
-          if (autoSaved.sidebarWidth) setSidebarWidth(autoSaved.sidebarWidth);
-          return;
-        }
-      } catch {}
-      try {
-        const sessions = await window.wmux?.session?.list();
-        if (sessions && sessions.length > 0) {
-          const session = await window.wmux?.session?.load(sessions[0].name);
-          if (session) {
-            const { replaceAllWorkspaces } = useStore.getState();
-            replaceAllWorkspaces(session.workspaces, undefined, t);
-            if (session.sidebarWidth) setSidebarWidth(session.sidebarWidth);
-            return;
-          }
-        }
-      } catch {}
-      // No saved session — create default workspace
+      const outcome = await restoreAutoSaved(t, setSidebarWidth);
+      if (outcome === 'restored') return;
+      // 'fresh' means main deliberately wants this window empty — a named
+      // session must not be cloned into it (issue #143).
+      if (outcome !== 'fresh' && await restoreNamedSession(t, setSidebarWidth)) return;
+      // Nothing to restore — create the default workspace.
       if (useStore.getState().workspaces.length === 0) {
         createWorkspace({
           title: t('app.firstSessionTitle', 'Session 1'),

--- a/src/renderer/pipe-bridge.ts
+++ b/src/renderer/pipe-bridge.ts
@@ -116,14 +116,19 @@ export function initPipeBridge(): void {
 
   w.__wmux_closePane = (paneId: string, workspaceId?: string) => {
     const store = useStore.getState();
-    const wsId = (workspaceId || store.activeWorkspaceId) as WorkspaceId;
-    if (!wsId) return;
-    const ws = store.workspaces.find(w => w.id === wsId);
+    // Without an explicit workspace, find the pane wherever it is rather than
+    // assuming it is in the active one (issue #143) — pane ids are uuids, so
+    // the search is unambiguous, and the old assumption made `close-pane` a
+    // no-op that still reported success for any pane not currently on screen.
+    const candidates = workspaceId
+      ? store.workspaces.filter(w => w.id === workspaceId)
+      : store.workspaces;
+    const ws = candidates.find(w => getAllPaneIds(w.splitTree).includes(paneId as PaneId));
     if (!ws) return;
 
     // Reaping + tree surgery live in the store action (issue #65 fixed the
     // missing reap here; the last-pane case was still wrong in all three copies).
-    store.closePane(wsId, paneId as PaneId);
+    store.closePane(ws.id, paneId as PaneId);
   };
 
   w.__wmux_layoutGrid = (params: { count: number; type?: string; anchorSurfaceId?: string; anchorPaneId?: string; workspaceId?: string }) => {
@@ -231,34 +236,45 @@ export function initPipeBridge(): void {
     return { ok: false, error: 'Surface not found' };
   };
 
+  /**
+   * The workspaces an id-targeted op should search: the one it was given, else
+   * every workspace in this window.
+   *
+   * Surface and pane ids are uuids, so a global search cannot hit the wrong
+   * thing — whereas restricting the search to the *active* workspace silently
+   * did nothing whenever the target lived elsewhere, and still answered `ok`
+   * (issue #143: a scripted mutation "succeeding" without mutating anything is
+   * worse than an error, because nothing downstream notices).
+   */
+  const searchScope = (workspaceId?: string) => {
+    const store = useStore.getState();
+    if (!workspaceId) return store.workspaces;
+    const ws = store.workspaces.find(w => w.id === workspaceId);
+    return ws ? [ws] : [];
+  };
+
   w.__wmux_closeSurface = (surfaceId: string, workspaceId?: string) => {
     const store = useStore.getState();
-    const wsId = (workspaceId || store.activeWorkspaceId) as WorkspaceId;
-    if (!wsId) return;
-    const ws = store.workspaces.find(w => w.id === wsId);
-    if (!ws) return;
-    const paneIds = getAllPaneIds(ws.splitTree);
-    for (const pid of paneIds) {
-      const leaf = findLeaf(ws.splitTree, pid);
-      if (leaf?.surfaces?.some(s => s.id === surfaceId)) {
-        store.closeSurface(wsId, pid, surfaceId as SurfaceId);
-        return;
+    for (const ws of searchScope(workspaceId)) {
+      for (const pid of getAllPaneIds(ws.splitTree)) {
+        const leaf = findLeaf(ws.splitTree, pid);
+        if (leaf?.surfaces?.some(s => s.id === surfaceId)) {
+          store.closeSurface(ws.id, pid, surfaceId as SurfaceId);
+          return;
+        }
       }
     }
   };
 
   w.__wmux_renameSurface = (surfaceId: string, title: string, workspaceId?: string) => {
     const store = useStore.getState();
-    const wsId = (workspaceId || store.activeWorkspaceId) as WorkspaceId;
-    if (!wsId) return { ok: false, error: 'No active workspace' };
-    const ws = store.workspaces.find(w => w.id === wsId);
-    if (!ws) return { ok: false, error: 'Workspace not found' };
-    const paneIds = getAllPaneIds(ws.splitTree);
-    for (const pid of paneIds) {
-      const leaf = findLeaf(ws.splitTree, pid);
-      if (leaf?.surfaces?.some(s => s.id === surfaceId)) {
-        store.renameSurface(wsId, pid, surfaceId as SurfaceId, title ?? '');
-        return { ok: true };
+    for (const ws of searchScope(workspaceId)) {
+      for (const pid of getAllPaneIds(ws.splitTree)) {
+        const leaf = findLeaf(ws.splitTree, pid);
+        if (leaf?.surfaces?.some(s => s.id === surfaceId)) {
+          store.renameSurface(ws.id, pid, surfaceId as SurfaceId, title ?? '');
+          return { ok: true };
+        }
       }
     }
     return { ok: false, error: 'Surface not found' };
@@ -266,17 +282,12 @@ export function initPipeBridge(): void {
 
   w.__wmux_focusSurface = (surfaceId: string, workspaceId?: string) => {
     const store = useStore.getState();
-    const wsId = (workspaceId || store.activeWorkspaceId) as WorkspaceId;
-    if (!wsId) return;
-    const ws = store.workspaces.find(w => w.id === wsId);
-    if (!ws) return;
-    const paneIds = getAllPaneIds(ws.splitTree);
-    for (const pid of paneIds) {
-      const leaf = findLeaf(ws.splitTree, pid);
-      if (leaf?.surfaces) {
-        const idx = leaf.surfaces.findIndex(s => s.id === surfaceId);
+    for (const ws of searchScope(workspaceId)) {
+      for (const pid of getAllPaneIds(ws.splitTree)) {
+        const leaf = findLeaf(ws.splitTree, pid);
+        const idx = leaf?.surfaces?.findIndex(s => s.id === surfaceId) ?? -1;
         if (idx >= 0) {
-          store.selectSurface(wsId, pid, idx);
+          store.selectSurface(ws.id, pid, idx);
           return;
         }
       }
@@ -308,22 +319,31 @@ export function initPipeBridge(): void {
   };
 
   /**
-   * Does THIS window hold `surfaceId`? Used by the main process to answer a CLI
-   * state query about the window the caller's shell actually lives in, rather
-   * than about whichever window happens to be first in `getAllWindows()`
+   * WHERE in THIS window does `surfaceId` live — `{ workspaceId, paneId }` — or
+   * null if this window does not hold it at all? Used by the main process to
+   * answer a CLI state query about the place the caller's shell actually lives,
+   * rather than about whichever window happens to be first in `getAllWindows()`
    * (issue #141: `tree` and `list-surfaces` reported different panes at the
    * same moment, so a scripted "find the diff surface and close it" found
    * nothing and exited reporting success).
+   *
+   * It returns the workspace, not just a yes/no, because yes/no was only half
+   * an answer (issue #143): a window owns many workspaces, and a caller parked
+   * in a background one still had every query answered about the *active* one.
+   * The window was right and the workspace was wrong, so `tree` reliably
+   * described panes the caller had never seen.
    */
-  w.__wmux_hasSurface = (surfaceId: string) => {
-    if (!surfaceId) return false;
+  w.__wmux_locateSurface = (surfaceId: string) => {
+    if (!surfaceId) return null;
     for (const ws of useStore.getState().workspaces) {
       for (const pid of getAllPaneIds(ws.splitTree)) {
         const leaf = findLeaf(ws.splitTree, pid);
-        if (leaf?.surfaces.some(s => s.id === surfaceId)) return true;
+        if (leaf?.surfaces.some(s => s.id === surfaceId)) {
+          return { workspaceId: ws.id, paneId: pid };
+        }
       }
     }
-    return false;
+    return null;
   };
 
   w.__wmux_getActiveSurfaceId = () => {

--- a/tests/unit/caller-scope.test.ts
+++ b/tests/unit/caller-scope.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import { vi } from 'vitest';
+
+// v2-bridge pulls in electron at module load; the resolution rules under test
+// are dependency-injected and never touch it.
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [], getFocusedWindow: () => null },
+}));
+
+import { resolveCallerTarget } from '../../src/main/v2-bridge';
+
+interface FakeWindow {
+  id: number;
+  /** surfaceId → the workspace that holds it, in THIS window. */
+  surfaces: Record<string, string>;
+  throws?: boolean;
+}
+
+const win = (id: number, surfaces: Record<string, string>, throws = false): FakeWindow =>
+  ({ id, surfaces, throws });
+
+function harness(live: FakeWindow[], focused: FakeWindow | null, cache = new Map<string, number>()) {
+  const probed: number[] = [];
+  return {
+    probed,
+    cache,
+    deps: {
+      live,
+      focused: () => focused,
+      keyOf: (w: FakeWindow) => w.id,
+      locate: async (w: FakeWindow, surfaceId: string) => {
+        probed.push(w.id);
+        if (w.throws) throw new Error('window went away');
+        const workspaceId = w.surfaces[surfaceId];
+        return workspaceId ? { workspaceId } : null;
+      },
+      cache,
+    },
+  };
+}
+
+const CALLER = 'surf-caller';
+
+describe('caller resolution (issue #143)', () => {
+  // The reported symptom: `wmux tree` from a pane reported a workspace the
+  // caller was not in. Knowing the WINDOW was never enough — a window holds
+  // many workspaces and every unscoped method fell back to the active one.
+  it('answers about the workspace holding the caller, not the window\'s active one', async () => {
+    const only = win(1, { [CALLER]: 'ws-background' });
+    const h = harness([only], only);
+
+    const target = await resolveCallerTarget(CALLER, h.deps);
+
+    expect(target?.win).toBe(only);
+    expect(target?.workspaceId).toBe('ws-background');
+  });
+
+  it('picks the window that holds the caller even when another one is focused', async () => {
+    const other = win(1, {});
+    const home = win(2, { [CALLER]: 'ws-home' });
+    const h = harness([other, home], other);
+
+    const target = await resolveCallerTarget(CALLER, h.deps);
+
+    expect(target?.win).toBe(home);
+    expect(target?.workspaceId).toBe('ws-home');
+  });
+
+  // "Fall back to the focused window only when the id is unknown" — a stale
+  // WMUX_SURFACE_ID (closed pane, exported env) must not strand the caller.
+  it('falls back to the focused window, with no workspace opinion, for an unknown surface', async () => {
+    const a = win(1, {});
+    const b = win(2, {});
+    const h = harness([a, b], b);
+
+    const target = await resolveCallerTarget('surf-gone', h.deps);
+
+    expect(target?.win).toBe(b);
+    expect(target?.workspaceId).toBeUndefined();
+  });
+
+  it('leaves resolution to the focused window when no caller id is supplied', async () => {
+    const a = win(1, { [CALLER]: 'ws-a' });
+    const b = win(2, {});
+    const h = harness([a, b], b);
+
+    const target = await resolveCallerTarget(undefined, h.deps);
+
+    expect(target?.win).toBe(b);
+    expect(target?.workspaceId).toBeUndefined();
+    expect(h.probed).toEqual([]); // no id to probe with
+  });
+
+  it('probes the cached window first', async () => {
+    const a = win(1, {});
+    const home = win(2, { [CALLER]: 'ws-home' });
+    const h = harness([a, home], a, new Map([[CALLER, 2]]));
+
+    await resolveCallerTarget(CALLER, h.deps);
+
+    expect(h.probed).toEqual([2]);
+  });
+
+  // The cache used to be authoritative, so one outdated hit pinned a caller to
+  // the wrong window for the rest of the session — the "byte-stable across
+  // focus changes" wrong answer in the report. It is now only a probe order.
+  it('heals a stale cache entry instead of pinning the caller to the wrong window', async () => {
+    const home = win(1, { [CALLER]: 'ws-home' });
+    const stale = win(2, {});
+    const h = harness([home, stale], stale, new Map([[CALLER, 2]]));
+
+    const target = await resolveCallerTarget(CALLER, h.deps);
+
+    expect(h.probed).toEqual([2, 1]); // cached first, then the rest
+    expect(target?.win).toBe(home);
+    expect(h.cache.get(CALLER)).toBe(1);
+  });
+
+  it('forgets the cache when the surface has disappeared everywhere', async () => {
+    const a = win(1, {});
+    const h = harness([a], a, new Map([[CALLER, 1]]));
+
+    await resolveCallerTarget(CALLER, h.deps);
+
+    expect(h.cache.has(CALLER)).toBe(false);
+  });
+
+  it('skips a window that dies mid-probe and keeps looking', async () => {
+    const dying = win(1, {}, true);
+    const home = win(2, { [CALLER]: 'ws-home' });
+    const h = harness([dying, home], dying);
+
+    const target = await resolveCallerTarget(CALLER, h.deps);
+
+    expect(target?.win).toBe(home);
+  });
+
+  it('returns null when there is no window at all', async () => {
+    const h = harness([], null);
+    expect(await resolveCallerTarget(CALLER, h.deps)).toBeNull();
+  });
+});

--- a/tests/unit/session-windows.test.ts
+++ b/tests/unit/session-windows.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   SessionWindowRegistry,
   toRestorePayload,
+  restoreAnswerFor,
   type SessionWindowState,
 } from '../../src/main/session-windows';
 
@@ -98,11 +99,57 @@ describe('toRestorePayload', () => {
     expect(toRestorePayload(state)?.activeIndex).toBe(0);
   });
 
-  // A window opened during this run has no slot. Returning null makes the
-  // renderer create a fresh workspace; returning windows[0] (the old behaviour)
-  // made every new window a clone of the first window's tabs.
+  // A window opened during this run has no slot. Returning windows[0] (the old
+  // behaviour) made every new window a clone of the first window's tabs.
   it('returns null for a window with no saved state', () => {
     expect(toRestorePayload(null)).toBeNull();
     expect(toRestorePayload(win('a', []))).toBeNull();
+  });
+});
+
+describe('restoreAnswerFor (issue #143)', () => {
+  // `null` alone was ambiguous: the renderer reads it as "nothing saved" and
+  // falls back to the newest NAMED session. Right at launch — and wrong for a
+  // window opened mid-run, which came up as a clone of that named session,
+  // re-using its workspace, pane and surface ids. PTY id is surface id, so the
+  // clone's terminals re-attached to the original window's PTYs, and every
+  // id-based CLI lookup then had two equally valid answers.
+  it('tells a window opened during the run to come up empty', () => {
+    expect(restoreAnswerFor(null, { startup: false })).toEqual({ fresh: true });
+  });
+
+  it('lets a launch window fall back to a named session', () => {
+    expect(restoreAnswerFor(null, { startup: true })).toBeNull();
+  });
+
+  it('hands back saved workspaces regardless of when the window was created', () => {
+    const state = win('a', ['kept']);
+    expect(restoreAnswerFor(state, { startup: false })).toEqual(toRestorePayload(state));
+    expect(restoreAnswerFor(state, { startup: true })).toEqual(toRestorePayload(state));
+  });
+});
+
+describe('startup window marking (issue #143)', () => {
+  it('only reports windows the launch restore created', () => {
+    const reg = new SessionWindowRegistry();
+    reg.markStartup('win-launch');
+    expect(reg.isStartup('win-launch')).toBe(true);
+    expect(reg.isStartup('win-opened-later')).toBe(false);
+  });
+
+  it('forgets the mark with the window, so a recycled id is not mistaken for a launch window', () => {
+    const reg = new SessionWindowRegistry();
+    reg.markStartup('win-a');
+    reg.forget('win-a');
+    expect(reg.isStartup('win-a')).toBe(false);
+  });
+
+  it('prunes marks for windows that are gone', () => {
+    const reg = new SessionWindowRegistry();
+    reg.markStartup('win-a');
+    reg.markStartup('win-b');
+    reg.retainOnly(['win-a']);
+    expect(reg.isStartup('win-a')).toBe(true);
+    expect(reg.isStartup('win-b')).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #143.

## 1. `WMUX_SURFACE_ID` resolved to the wrong window

`windowForCaller` asked each window *"do you hold this surface?"* and stopped at the first yes. But `__wmux_hasSurface` scans **every** workspace in a window, while `__wmux_getTree` / `listPanes` / `listSurfaces` answer about the **active** one — so resolution could be right about the window and still describe a workspace the caller had never seen.

Resolution now returns the surface's window **and** its workspace (`__wmux_locateSurface`), and that workspace becomes the default for the methods that would otherwise guess. An explicit `--workspace` still wins.

The window cache was also authoritative, so one outdated hit pinned a caller to that window for the rest of the session — the *"byte-stable across focus changes"* wrong answer in the report. It is now only a probe-**order** hint, so a stale entry heals on the next call.

### The duplicate ids underneath

Surface ids were not unique across windows. A window opened mid-run gets no session slot, which the renderer read as *"nothing saved"* and answered by cloning the newest **named** session — same workspace, pane and surface ids as the window that already had them. PTY id **is** surface id in wmux, so the clone's terminals re-attached to the original window's PTYs, and every id-based lookup had two equally valid answers.

`session:load-auto` now distinguishes *"nothing saved"* (`null`, launch windows only) from *"come up empty"* (`{ fresh: true }`) — the contract per-window restore has claimed since #118, now actually enforceable on the renderer side.

Id-targeted operations (`close-surface`, `focus-surface`, `rename-surface`, `close-pane`) also now find their target anywhere in the window instead of only in the active workspace. Ids are uuids, so the search cannot hit the wrong thing — whereas the old scope silently did nothing and still reported `ok`.

## 2. Unknown flags ran the command anyway

`getFlag()` picked out the flags it knew and ignored the rest, so `wmux new-surface --help` created a surface and `wmux split --help` split a pane.

Every command now declares its flags. Anything else is rejected with that command's usage, and `--help` / `-h` prints usage without touching the pipe. A value flag with no value is rejected too — same silent default, different costume.

Commands whose arguments are free-form text or belong to another program (`send`, `notify`, `log`, `ssh`, `browser`, `markdown`, `rename-*`) are exempt, because `--help` there is part of what you are sending; `wmux help <command>` works for those. `COMMANDS` is typed against the spec table, so the compiler catches a command shipped without usage text.

```
$ wmux split --help
wmux split [--down] [--type terminal|browser|markdown] [--color-scheme NAME]

$ wmux split --bogus
Unknown flag for 'split': --bogus

wmux split [--down] [--type terminal|browser|markdown] [--color-scheme NAME]

$ wmux tree --workspace
Flag '--workspace' needs a value.

wmux tree [--workspace <workspaceId>]
```

## Verification

- `npx tsc --noEmit` clean for both projects; `npm run lint` shows no new findings.
- 720 unit tests pass, including 15 new ones: `tests/unit/caller-scope.test.ts` covers wrong-window selection, background-workspace scoping, stale-cache healing, unknown-surface fallback and mid-probe window death; `session-windows.test.ts` covers `restoreAnswerFor`.
- CLI help / rejection paths exercised against the built `dist/cli/wmux.js` (they exit before any pipe I/O).
- The multi-window end-to-end path is covered by the resolver unit tests, not by a live two-window run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7nJeuxL4z9Yi5NL2KuhCV
