### PR TITLE
fix(cli): outwait the main process on browser commands, and say what timed out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,6 +396,8 @@ wmux read-screen [--lines N] [--surface <id>] | trigger-flash
 wmux browser open <url> | snapshot | click eN | type eN <text>
 wmux browser fill eN <value> | get-text | screenshot | eval <js>
 wmux browser back | forward | reload
+wmux browser <verb> [--surface <id>]   # whose browser to drive; defaults to
+                                       # $WMUX_SURFACE_ID inside a pane
 
 # Declared agent state (issue #128) — blocked / working / idle, no screen scraping.
 # Surface defaults to $WMUX_SURFACE_ID, so an agent inside a pane needs no id.

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -75,7 +75,35 @@ function sendV1(command: string): Promise<string> {
   });
 }
 
-function sendV2(method: string, params: Record<string, any> = {}): Promise<any> {
+/**
+ * How long to wait for a V2 reply before giving up.
+ *
+ * This deadline has to stay LARGER than whatever budget the main process spends
+ * serving the same request. When it is shorter the CLI loses a race it should
+ * never have been in: a command that succeeds late is reported as a failure, and
+ * the server's own diagnosis ('Could not open browser panel', 'browser_not_open',
+ * 'ref_not_found: …') is discarded unread because it arrives after we hung up.
+ * Only the browser verbs currently need more than this — see BROWSER_CMDS.
+ */
+const DEFAULT_V2_TIMEOUT_MS = 5000;
+
+/**
+ * What a stalled request says when it gives up.
+ *
+ * The bare 'timeout' this used to reject with named neither the method nor the
+ * deadline, so an operation that was merely slow was indistinguishable from a
+ * broken install — and since the deadline was also shorter than the server's own
+ * budget, it was usually the *only* thing a slow browser command ever printed.
+ */
+export function timeoutMessage(method: string, timeoutMs: number): string {
+  return `${method} timed out after ${timeoutMs}ms — wmux accepted the request but sent no reply. The command may still have completed.`;
+}
+
+function sendV2(
+  method: string,
+  params: Record<string, any> = {},
+  timeoutMs: number = DEFAULT_V2_TIMEOUT_MS,
+): Promise<any> {
   // Every command carries the caller's surface (WMUX_SURFACE_ID). Browser
   // commands use it to route each agent to its OWN browser pane, so concurrent
   // agents no longer share and clobber one browser window (issue #62); the
@@ -90,7 +118,10 @@ function sendV2(method: string, params: Record<string, any> = {}): Promise<any> 
       client.write(request + '\n');
     });
     let data = '';
-    const timer = setTimeout(() => { client.end(); reject(new Error('timeout')); }, 5000);
+    const timer = setTimeout(() => {
+      client.end();
+      reject(new Error(timeoutMessage(method, timeoutMs)));
+    }, timeoutMs);
     client.on('data', (chunk) => {
       data += chunk.toString();
       if (data.includes('\n')) {
@@ -123,27 +154,102 @@ function stripFlag(args: string[], name: string): string[] {
 
 const print = (v: any) => console.log(JSON.stringify(v, null, 2));
 
-// Each browser subcommand maps to the V2 request it issues. sendV2 auto-attaches
-// the caller surface so concurrent agents get isolated browsers (issue #62).
-const BROWSER_CMDS: Record<string, (args: string[]) => Promise<any>> = {
-  open: (args) => sendV2('browser.navigate', { url: args[2] }),
-  snapshot: () => sendV2('browser.snapshot'),
-  click: (args) => sendV2('browser.click', { ref: args[2] }),
-  type: (args) => sendV2('browser.type', { ref: args[2], text: args.slice(3).join(' ') }),
-  fill: (args) => sendV2('browser.fill', { ref: args[2], value: args.slice(3).join(' ') }),
-  screenshot: (args) => sendV2('browser.screenshot', { fullPage: args.includes('--full') }),
-  'get-text': (args) => sendV2('browser.get_text', { ref: args[2] }),
-  eval: (args) => sendV2('browser.eval', { js: args.slice(2).join(' ') }),
-  wait: (args) => sendV2('browser.wait', { ref: args[2], timeout: parseInt(args[3]) || undefined }),
-  back: () => sendV2('browser.back'),
-  forward: () => sendV2('browser.forward'),
-  reload: () => sendV2('browser.reload'),
+/**
+ * Server-side budgets a browser command can legitimately spend before it is even
+ * able to reply. Mirrored from the main process so the CLI can outwait it:
+ *
+ *   BROWSER_READY_MS   v2-browser.ts readies a browser first — it splits a pane
+ *                      and then polls up to 5s for CDP to attach.
+ *   CDP_NAVIGATE_MS    cdp-bridge.ts navigate() waits for did-finish-load.
+ *   CDP_WAIT_MS        cdp-bridge.ts wait() polls for a ref.
+ *
+ * Both cdp-bridge budgets already exceeded the old flat 5s CLI deadline on their
+ * own, so `browser open` on any slow page and `browser wait` on any absent ref
+ * could not report anything but 'timeout' — including when they went on to
+ * succeed. Keep these in step if the main-process defaults change.
+ */
+const BROWSER_READY_MS = 5000;
+const CDP_NAVIGATE_MS = 30000;
+const CDP_WAIT_MS = 10000;
+/** Pane split plus the executeJavaScript round-trips around it. */
+const BROWSER_SLACK_MS = 5000;
+
+/** The CLI deadline for a browser verb whose own server-side budget is `verbMs`. */
+const browserDeadline = (verbMs: number): number => BROWSER_READY_MS + verbMs + BROWSER_SLACK_MS;
+
+export interface BrowserRequest {
+  method: string;
+  params: Record<string, any>;
+  timeoutMs: number;
+}
+
+// Each browser subcommand maps to the V2 request it issues.
+const BROWSER_CMDS: Record<string, (args: string[]) => BrowserRequest> = {
+  open: (args) => ({
+    method: 'browser.navigate',
+    params: { url: args[2] },
+    timeoutMs: browserDeadline(CDP_NAVIGATE_MS),
+  }),
+  snapshot: () => ({ method: 'browser.snapshot', params: {}, timeoutMs: browserDeadline(0) }),
+  click: (args) => ({ method: 'browser.click', params: { ref: args[2] }, timeoutMs: browserDeadline(0) }),
+  type: (args) => ({
+    method: 'browser.type',
+    params: { ref: args[2], text: args.slice(3).join(' ') },
+    timeoutMs: browserDeadline(0),
+  }),
+  fill: (args) => ({
+    method: 'browser.fill',
+    params: { ref: args[2], value: args.slice(3).join(' ') },
+    timeoutMs: browserDeadline(0),
+  }),
+  screenshot: (args) => ({
+    method: 'browser.screenshot',
+    params: { fullPage: args.includes('--full') },
+    timeoutMs: browserDeadline(0),
+  }),
+  'get-text': (args) => ({ method: 'browser.get_text', params: { ref: args[2] }, timeoutMs: browserDeadline(0) }),
+  eval: (args) => ({ method: 'browser.eval', params: { js: args.slice(2).join(' ') }, timeoutMs: browserDeadline(0) }),
+  wait: (args) => {
+    const explicit = parseInt(args[3]) || undefined;
+    return {
+      method: 'browser.wait',
+      params: { ref: args[2], timeout: explicit },
+      // An explicit ms is the budget the server will honour; outwait that one.
+      timeoutMs: browserDeadline(explicit ?? CDP_WAIT_MS),
+    };
+  },
+  back: () => ({ method: 'browser.back', params: {}, timeoutMs: browserDeadline(0) }),
+  forward: () => ({ method: 'browser.forward', params: {}, timeoutMs: browserDeadline(0) }),
+  reload: () => ({ method: 'browser.reload', params: {}, timeoutMs: browserDeadline(0) }),
 };
 
+/**
+ * Resolve `wmux browser <verb> …` to the request it issues. Null for an unknown
+ * verb. Pure, so the deadlines and the caller wiring are testable without a
+ * running app.
+ *
+ * `caller` is the *terminal* surface the command is issued on behalf of, not a
+ * browser surface: the main process maps it to that pane's own browser, which is
+ * what keeps concurrent agents isolated (issue #62). Passing it explicitly does
+ * not change that routing — it only supplies from a flag what a shell inside a
+ * pane supplies from $WMUX_SURFACE_ID.
+ */
+export function browserRequest(args: string[], caller?: string): BrowserRequest | null {
+  const build = BROWSER_CMDS[args[1]];
+  if (!build) return null;
+  const req = build(args);
+  return caller ? { ...req, params: { ...req.params, caller } } : req;
+}
+
 async function cmdBrowser(args: string[]): Promise<void> {
-  const handler = BROWSER_CMDS[args[1]];
-  if (!handler) { console.error(`Unknown browser command: ${args[1]}`); process.exit(1); return; }
-  print(await handler(args));
+  // --surface says which pane's browser to drive, mirroring send / read-screen /
+  // agent-activity. Strip it before the verb reads its positional args, or
+  // `browser type e5 --surface surf-x hi` would type the flag into the page.
+  const caller = getFlag(args, '--surface') || process.env.WMUX_SURFACE_ID;
+  const rest = stripFlag(args, '--surface');
+  const req = browserRequest(rest, caller);
+  if (!req) { console.error(`Unknown browser command: ${rest[1]}`); process.exit(1); return; }
+  print(await sendV2(req.method, req.params, req.timeoutMs));
 }
 
 function agentSpawn(args: string[]): Promise<any> {
@@ -669,6 +775,7 @@ const COMMAND_SPECS = {
       'wmux browser open <url> | snapshot | click <ref> | type <ref> <text> | fill <ref> <value>',
       'wmux browser screenshot [--full] | get-text [ref] | eval <js> | wait <ref> [ms]',
       'wmux browser back | forward | reload',
+      `  [--surface <id>]   ${SURFACE_NOTE}`,
     ].join('\n'),
     passthrough: true,
   },
@@ -1022,6 +1129,7 @@ Pane:       split [--down] [--type T] [--color-scheme NAME], close-pane, focus-p
 Layout:     layout grid --count <N> [--type terminal] [--anchor-surface <id>]
 Terminal:   send <text>, send-key <key>, read-screen [--lines N] [--surface <id>], trigger-flash
 Browser:    browser open|snapshot|click|type|fill|screenshot|get-text|eval|wait|back|forward|reload
+            browser <verb> [--surface <id>]   # which pane's browser to drive
 Agent:      agent spawn [--cmd C] [--label L] [--cwd D] [--pane P] [--replace-tab] | spawn-batch|status|list|kill
 Markdown:   markdown <file>   (open a file in a new markdown view)
             markdown set <id> --content <text> | --file <path>
@@ -1047,4 +1155,6 @@ Help:       wmux help <command>       (per-command usage; works for every comman
 `);
 }
 
-main();
+// Run only when invoked as the CLI. The pure helpers above are exported so the
+// unit tests can import this file without it trying to execute a command.
+if (require.main === module) main();

--- a/src/main/cdp-bridge.ts
+++ b/src/main/cdp-bridge.ts
@@ -215,7 +215,14 @@ export class CDPBridge {
     try { wc = webContents.fromId(target.wcId); } catch { throw new Error('browser_not_open'); }
     if (!wc || wc.isDestroyed()) throw new Error('browser_not_open');
     const loadPromise = new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => { wc?.removeListener('did-finish-load', onFinish); reject(new Error('timeout')); }, timeout);
+      const timer = setTimeout(() => {
+        wc?.removeListener('did-finish-load', onFinish);
+        // Say which page and how long. The CLI used to hang up before this could
+        // arrive, so a bare 'timeout' was indistinguishable from its own.
+        reject(new Error(
+          `navigate timed out after ${timeout}ms — ${url} never finished loading. It may still be loading in the browser pane.`,
+        ));
+      }, timeout);
       const onFinish = () => { clearTimeout(timer); resolve(); };
       wc?.once('did-finish-load', onFinish);
     });
@@ -383,6 +390,8 @@ export class CDPBridge {
       }
       await new Promise((r) => setTimeout(r, 300));
     }
-    throw new Error('timeout');
+    throw new Error(
+      `wait timed out after ${timeout}ms — ${ref} never appeared. Run browser.snapshot to see what the page exposes now.`,
+    );
   }
 }

--- a/tests/unit/browser-timeout.test.ts
+++ b/tests/unit/browser-timeout.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { browserRequest, timeoutMessage } from '../../src/cli/wmux';
+
+/**
+ * `wmux browser open <url>` failed with a bare `Error: timeout` after ~5s on any
+ * page that took longer than that to load — while the navigation itself went on
+ * to succeed. The CLI applied one flat 5s deadline to every V2 method, but the
+ * main process is allowed to spend far more than that serving a browser command:
+ * cdp-bridge's navigate() waits 30s for did-finish-load and wait() polls for 10s,
+ * and before either runs v2-browser may split a pane and poll 5s for CDP.
+ *
+ * So the client deadline was shorter than the server's own budget. Two things
+ * followed, and the second is the worse one:
+ *
+ *   1. A command that succeeded late was reported as a failure.
+ *   2. The server's real diagnosis ('Could not open browser panel',
+ *      'browser_not_open', 'ref_not_found: …') could never reach the user,
+ *      because it arrived after the CLI had already hung up. A bare `timeout`
+ *      was the only thing left, which reads like a broken install.
+ *
+ * The deadlines below are therefore not free-floating numbers — each one has to
+ * clear the corresponding main-process budget. These tests read those budgets
+ * out of the main-process source rather than restating them, so raising a
+ * default in cdp-bridge.ts fails here instead of quietly reintroducing the bug.
+ */
+
+const SRC = path.join(__dirname, '..', '..', 'src', 'main');
+const cdpBridge = fs.readFileSync(path.join(SRC, 'cdp-bridge.ts'), 'utf-8');
+const v2Browser = fs.readFileSync(path.join(SRC, 'v2-browser.ts'), 'utf-8');
+
+/** Pull a `timeout = <ms>` default off a method signature in cdp-bridge.ts. */
+function cdpDefault(method: string): number {
+  const match = cdpBridge.match(new RegExp(`async ${method}\\([^)]*timeout = (\\d+)`));
+  if (!match) throw new Error(`no timeout default found for cdp-bridge ${method}()`);
+  return Number(match[1]);
+}
+
+/** The longest wait v2-browser can spend readying a browser before the verb runs. */
+function browserReadyBudget(): number {
+  const waits = [...v2Browser.matchAll(/(?:Date\.now\(\) \+ |pollSurfaceWcId\([^,]+,\s*)(\d+)/g)]
+    .map((m) => Number(m[1]));
+  if (waits.length === 0) throw new Error('no readiness budget found in v2-browser.ts');
+  return Math.max(...waits);
+}
+
+const deadlineOf = (argv: string[]): number => {
+  const req = browserRequest(argv);
+  if (!req) throw new Error(`unknown browser verb: ${argv[1]}`);
+  return req.timeoutMs;
+};
+
+// Every verb the CLI exposes, as `wmux browser …` argv.
+const VERBS: string[][] = [
+  ['browser', 'open', 'https://example.com'],
+  ['browser', 'snapshot'],
+  ['browser', 'click', 'e5'],
+  ['browser', 'type', 'e5', 'hello'],
+  ['browser', 'fill', 'e5', 'value'],
+  ['browser', 'screenshot'],
+  ['browser', 'get-text'],
+  ['browser', 'eval', '1+1'],
+  ['browser', 'wait', 'e5'],
+  ['browser', 'back'],
+  ['browser', 'forward'],
+  ['browser', 'reload'],
+];
+
+describe('browser command deadlines outlast the main process', () => {
+  it('finds the budgets it is meant to be checking', () => {
+    // Guards the guard: a refactor that renames these would make the
+    // comparisons below vacuously pass against a default of 0.
+    expect(cdpDefault('navigate')).toBeGreaterThan(0);
+    expect(cdpDefault('wait')).toBeGreaterThan(0);
+    expect(browserReadyBudget()).toBeGreaterThan(0);
+  });
+
+  // The reported symptom, in one assertion: a page slower than the CLI deadline
+  // but faster than the server's is exactly the window where `browser open`
+  // printed `timeout` for a navigation that worked.
+  it('waits out a full-length navigation instead of quitting mid-load', () => {
+    expect(deadlineOf(['browser', 'open', 'https://example.com'])).toBeGreaterThan(cdpDefault('navigate'));
+  });
+
+  it('waits out a ref poll that runs its default course', () => {
+    expect(deadlineOf(['browser', 'wait', 'e5'])).toBeGreaterThan(cdpDefault('wait'));
+  });
+
+  // `browser wait e5 20000` asks the server for a 20s poll. A client deadline
+  // pinned to the 10s default would cut off the very wait the user requested.
+  it('honours an explicit wait budget rather than its own default', () => {
+    expect(deadlineOf(['browser', 'wait', 'e5', '20000'])).toBeGreaterThan(20000);
+  });
+
+  // Readying a browser happens before *any* verb runs, so no verb — not even
+  // `back` — can be given a deadline that expires during it.
+  it('leaves room for a cold browser bring-up on every verb', () => {
+    const ready = browserReadyBudget();
+    for (const argv of VERBS) {
+      expect(deadlineOf(argv), `${argv[1]} deadline`).toBeGreaterThan(ready);
+    }
+  });
+
+  it('covers every verb the CLI dispatches', () => {
+    // Keeps the sweep above honest: a subcommand added to BROWSER_CMDS without a
+    // deadline opinion would otherwise never be measured by it.
+    const cli = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'cli', 'wmux.ts'), 'utf-8');
+    const start = cli.indexOf('const BROWSER_CMDS');
+    const end = cli.indexOf('export function browserRequest');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const dispatched = [...cli.slice(start, end).matchAll(/^ {2}'?([a-z-]+)'?:/gm)].map((m) => m[1]);
+
+    expect(new Set(dispatched)).toEqual(new Set(VERBS.map((argv) => argv[1])));
+  });
+
+  it('rejects an unknown verb instead of guessing a deadline', () => {
+    expect(browserRequest(['browser', 'teleport'])).toBeNull();
+  });
+});
+
+describe('--surface targets a browser from outside a pane', () => {
+  // The rest of the CLI already takes --surface (send, read-screen,
+  // agent-activity, report-agent). Browser commands only ever read
+  // $WMUX_SURFACE_ID, so a shell wmux did not spawn had no way to say which
+  // pane's browser it meant.
+  it('sends the surface as the caller the isolation routing expects', () => {
+    const req = browserRequest(['browser', 'snapshot'], 'surf-abc');
+    expect(req?.params.caller).toBe('surf-abc');
+  });
+
+  it('omits caller entirely when there is none, preserving the legacy path', () => {
+    // Not `caller: undefined` — sendV2 fills that field from the environment,
+    // and the main process treats absent-caller as "use the shared browser".
+    const req = browserRequest(['browser', 'snapshot']);
+    expect(req?.params).not.toHaveProperty('caller');
+  });
+
+  it('keeps the flag out of the text it types into the page', () => {
+    // `browser type e5 --surface surf-x hello world` must type "hello world".
+    // cmdBrowser strips the flag before the verb reads its positional args;
+    // this pins the joined-text behaviour that strip protects.
+    const req = browserRequest(['browser', 'type', 'e5', 'hello', 'world'], 'surf-x');
+    expect(req?.params.text).toBe('hello world');
+    expect(req?.params.caller).toBe('surf-x');
+  });
+});
+
+describe('the timeout message', () => {
+  // A bare 'timeout' named neither what stalled nor how long we waited, so a
+  // slow command and a broken install produced identical output.
+  it('names the method and the deadline it actually waited', () => {
+    const message = timeoutMessage('browser.navigate', 40000);
+    expect(message).toContain('browser.navigate');
+    expect(message).toContain('40000ms');
+    expect(message).not.toBe('timeout');
+  });
+
+  it('says the command may have run, because it may have', () => {
+    expect(timeoutMessage('browser.navigate', 40000).toLowerCase()).toContain('may still have completed');
+  });
+});

--- a/tests/unit/cdp-bridge.test.ts
+++ b/tests/unit/cdp-bridge.test.ts
@@ -8,6 +8,10 @@ function makeWc(id: number, respond?: (method: string, params: any) => any) {
   const sent: Array<{ method: string; params: any }> = [];
   const wc = {
     isDestroyed: () => false,
+    // navigate() subscribes to did-finish-load; a page that never loads simply
+    // never fires it, which is the case the timeout message is for.
+    once: () => {},
+    removeListener: () => {},
     sent,
     debugger: {
       isAttached: () => attached,
@@ -209,6 +213,33 @@ describe('CDP Bridge', () => {
       bridge.attach(1);
       bridge.detach();
       expect(bridge.attachedWebContentsId).toBeNull();
+    });
+  });
+
+  /**
+   * Both of these used to throw a bare `new Error('timeout')`. Nobody ever read
+   * it: navigate's budget is 30s and wait's is 10s, while the CLI hung up at 5s
+   * and printed its own indistinguishable `timeout`. Now that the CLI outwaits
+   * the main process, whatever these say is what the user actually sees — so
+   * they have to say which operation stalled, for how long, and on what.
+   */
+  describe('timeout messages say what stalled', () => {
+    it('navigate names the page it was waiting on and the budget it spent', async () => {
+      makeWc(70);
+      const bridge = new CDPBridge();
+      bridge.attach(70);
+      await expect(bridge.navigate('https://slow.example', 20, 70)).rejects.toThrow(
+        /navigate timed out after 20ms .* https:\/\/slow\.example never finished loading/,
+      );
+    });
+
+    it('wait names the ref that never arrived and points at the next step', async () => {
+      makeWc(71, () => ({ nodes: [] })); // an empty tree, so the ref never resolves
+      const bridge = new CDPBridge();
+      bridge.attach(71);
+      await expect(bridge.wait('e9', 30, 71)).rejects.toThrow(
+        /wait timed out after 30ms .* e9 never appeared.*browser\.snapshot/,
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

`wmux browser open <url>` fails with a bare `Error: timeout` after ~5s on any page that takes longer than that to load — while the navigation itself goes on to succeed. The CLI applies one flat 5s deadline to every V2 method, but the main process is allowed to spend considerably longer serving a browser command.

The deeper problem is the second-order one: because the client deadline is *shorter* than the server's own budget, the server's real error message can never reach the user. A bare `timeout` is the only thing a slow or broken browser command can print, and it reads like a broken install.

## Repro

Against a healthy wmux (v0.46.0, Windows 11), with a browser pane open and CDP attached. Any page slower than 5s will do; a local server makes it deterministic:

```js
// slow-server.js — headers immediately, body finishes at 12s
require('http').createServer((req, res) => {
  res.writeHead(200, { 'Content-Type': 'text/html' });
  res.write('<html><body>loading');
  setTimeout(() => res.end('done</body></html>'), 12000);
}).listen(8931, '127.0.0.1');
```

```
$ wmux browser open http://127.0.0.1:8931/
Error: timeout
exit=1  elapsed_ms=5157
```

The navigation was not the problem. Sending the identical request over the pipe by hand, with a 40s deadline instead of 5s:

```
replied after 12017ms: {"result":{"ok":true},"id":1}
```

The server answered correctly. The CLI just stopped listening at 5s.

## Root cause

`sendV2` hard-codes 5000ms and rejects with `new Error('timeout')`:

https://github.com/amirlehmam/wmux/blob/fae21a5bbdf2edcd1c41d4c0b5372aab56caef83/src/cli/wmux.ts#L93

Three main-process budgets sit at or above that number, so the CLI is structurally guaranteed to lose the race:

| Server-side wait | Budget | Source |
|---|---|---|
| `navigate()` waiting for `did-finish-load` | **30000ms** | [cdp-bridge.ts#L212](https://github.com/amirlehmam/wmux/blob/fae21a5bbdf2edcd1c41d4c0b5372aab56caef83/src/main/cdp-bridge.ts#L212) |
| `wait()` polling for a ref | **10000ms** | [cdp-bridge.ts#L373](https://github.com/amirlehmam/wmux/blob/fae21a5bbdf2edcd1c41d4c0b5372aab56caef83/src/main/cdp-bridge.ts#L373) |
| readying a browser (pane split, then poll for CDP attach) | **5000ms** | [v2-browser.ts#L33-L37](https://github.com/amirlehmam/wmux/blob/fae21a5bbdf2edcd1c41d4c0b5372aab56caef83/src/main/v2-browser.ts#L33-L37), [#L100](https://github.com/amirlehmam/wmux/blob/fae21a5bbdf2edcd1c41d4c0b5372aab56caef83/src/main/v2-browser.ts#L100) |

Two consequences, and the second is the one that costs debugging time:

1. A command that succeeds late is reported as a failure. `browser open` is effectively nondeterministic — it passes or fails on page speed, and when it "fails" the navigation has still happened.
2. **The server's own diagnosis is unreachable.** `Could not open browser panel`, `browser_not_open` and the careful `ref_not_found: … the last snapshot of this browser has @e1..@eN` message from #121 all arrive after the CLI has hung up. The user gets `timeout` instead.

### A note on the obvious-looking diagnosis

I first went after this as a missing-caller bug: no `WMUX_SURFACE_ID` outside a pane → no `caller` attached → main can't route the request. That turns out **not** to be what is happening, and I want to flag it since it is the intuitive reading.

With no caller, `resolveBrowserWcId` deliberately falls back to `legacyWcId()` — the documented shared-browser path for manual human use ([v2-browser.ts#L8-L9](https://github.com/amirlehmam/wmux/blob/fae21a5bbdf2edcd1c41d4c0b5372aab56caef83/src/main/v2-browser.ts#L8-L9), [#L68](https://github.com/amirlehmam/wmux/blob/fae21a5bbdf2edcd1c41d4c0b5372aab56caef83/src/main/v2-browser.ts#L68)). That path works fine:

```
$ wmux browser open https://example.com     # no WMUX_SURFACE_ID anywhere
{ "ok": true }                               # 1709ms
```

And the failure reproduces just as reliably *with* a valid caller set:

```
$ WMUX_SURFACE_ID=surf-617012f2-… wmux browser open http://127.0.0.1:8931/
Error: timeout
exit=1  elapsed_ms=5124
```

Same result, 5124ms. The caller is irrelevant to this failure; the deadline is the whole story. Anywhere setting `WMUX_SURFACE_ID` appears to fix it, what actually changed is which resolution path ran and whether it happened to finish inside 5s.

## The fix

**Derive each browser verb's client deadline from the budget the server may spend on it**, so the main process always loses the race and its own error is what surfaces. `BROWSER_READY_MS + verbBudget + slack`: 40s for `open`, 20s for `wait` (or the explicit `ms` plus headroom), 10s for everything else. The 5s default is unchanged for every other V2 method.

**Make the timeout message diagnostic.** It now names the method and the deadline actually waited, and says the command may have completed anyway — because it may have.

**Make the two cdp-bridge timeouts earn their keep.** They also threw a bare `new Error('timeout')`. That was invisible before (the CLI's own timeout always fired first); now that it is what the user reads, it should say which operation stalled, for how long, and on what. This is the same treatment `ref_not_found` got in #121.

**Add `--surface` to the browser verbs**, matching `send` / `read-screen` / `agent-activity` / `report-agent`. A shell wmux did not spawn has no `$WMUX_SURFACE_ID` and so had no way to say which pane's browser it meant; the legacy fallback picks the most-recently-attached one, which is arbitrary when several exist. The flag is stripped before the verb reads its positional args, so `browser type e5 --surface surf-x hello world` still types `hello world`.

## Options I considered

1. **Fail fast when there is no caller, with an actionable message.** Rejected: it would turn a working path into an error. The no-caller fallback is deliberate and, as shown above, works — and it is not what breaks here.
2. **`--surface` alone.** Useful, and included, but it does not fix the reported bug at all: the failure reproduces with a valid caller.
3. **Fall back to the active surface when no caller is set.** Rejected, and I would push back on it: `resolveBrowserWcId` binds a caller to its own browser and records it in `boundBrowserSurfaces` so a second agent never adopts the first agent's browser. Silently substituting "the active surface" for an absent caller would let an agent-less invocation adopt a browser an agent already owns — exactly the #62 clobbering, reintroduced through the back door.
4. **Raise the flat deadline for everything.** Rejected: it would slow the failure path for every method that legitimately answers in milliseconds, and it papers over the client/server mismatch rather than fixing it.

## What I deliberately did not change

- **The isolation contract (#62).** No change to `resolveBrowserWcId`, to how callers bind to browser surfaces, or to the no-caller fallback. `--surface` only supplies from a flag what a pane already supplies from the environment.
- **The server-side budgets themselves.** 30s/10s/5s are the main process's calls to make; the CLI now accommodates them instead of contradicting them. The tests read those numbers out of the main-process source rather than restating them, so changing one there fails here rather than silently reintroducing the mismatch.
- **The 5s default for non-browser methods.**
- **`browser.batch`**, which the CLI does not expose.
- **The diff-provider snapshot code**, untouched.

## Tests

`tests/unit/browser-timeout.test.ts` (new, 12 cases) and 2 added to `tests/unit/cdp-bridge.test.ts`. Following the approach in `packaging.test.ts`, the deadline assertions are *derived* from the main-process source rather than restated, so a raised default in `cdp-bridge.ts` fails the test instead of quietly recreating the bug.

Confirmed the tests fail against the old behaviour: pinning `browserDeadline` back to a flat 5000 fails exactly the 4 cases that describe the bug.

To make the CLI importable by tests at all, `main()` is now guarded by `require.main === module`. Nothing imports `src/cli/wmux.ts` as a module today — it is only ever executed as a script, where the guard is true. I kept everything in the one file rather than extracting a module, since the release process copies `dist/cli/wmux.js` individually and a new sibling would not be packaged.

```
Test Files  1 failed | 72 passed (73)
Tests       1 failed | 848 passed (849)
```

The one failure is `tests/unit/cdp-proxy.test.ts > falls back to a free port instead of raising an uncaught error`. It fails identically on a clean `master` checkout with nothing applied, so it is pre-existing and not from this PR — it looks environment-dependent (the default port being free on this machine). I left it alone rather than fold an unrelated fix in here.

## Verification

Built and run against a live wmux instance, same command, before and after:

```
### BEFORE (shipped 0.46.0 CLI)
$ wmux browser open http://127.0.0.1:8931/
Error: timeout
exit=1  elapsed_ms=5157

### AFTER (this branch)
$ node dist/cli/wmux.js browser open http://127.0.0.1:8931/
{ "ok": true }
exit=0  elapsed_ms=12212
```

Also verified live: `--surface <id>` drives the named pane's browser from a shell wmux did not spawn; `browser snapshot` still returns in ~215ms (no added latency on the fast path); non-browser methods unaffected; unknown verbs still exit 1.

On a URL that never finishes loading, the CLI now waits and receives the **server's** answer at 30s rather than its own at 5s — which is the plumbing fix working end to end. The running instance there was 0.46.0, so the text it returned was still the old bare `timeout`; the new cdp-bridge wording is covered by unit tests rather than that live run, since exercising it would have meant restarting the instance.
