### PR TITLE
fix(agent-state): status path handling refinement and edge cases (#151)

### DIFF
--- a/src/main/agent-hook-bridge.ts
+++ b/src/main/agent-hook-bridge.ts
@@ -195,9 +195,8 @@ export function hookToAgentReport(
     case 'PostToolUse':
       return { awaitingHuman: false, runDepth: 1 };
 
-    // One parallel subagent finished — and the parent turn is, by construction,
-    // still running: it has a result to read, and Claude Code fires the parent's
-    // `Stop` after every subagent has stopped.
+    // One parallel subagent finished. It may SUSTAIN a turn; it may never START
+    // one.
     //
     // This used to decrement the refcount, which was wrong in the way that
     // produced the loudest half of issue #151. Subagent hooks inherit the
@@ -207,7 +206,37 @@ export function hookToAgentReport(
     // with the parent and two siblings still working. A refcount only survives
     // contact with reality when every increment is paired, and these are not
     // paired; the parent's `Stop` is the pairing, and it is already decisive.
+    //
+    // Fixing that by asserting an unconditional depth of 1 rested on a premise
+    // that measurement does not support: that Claude Code fires the parent's
+    // `Stop` only after every subagent has stopped. It does not. Traced at the
+    // hook helper on two independent panes, the wire order is `Stop` first and
+    // `SubagentStop` 1.8-2.2s LATER — so the unconditional form resurrected the
+    // very run `Stop` had just ended, and the pane sat on "Running" until the
+    // 15-minute trust window with the agent idle at its prompt.
+    //
+    // The wall-clock gate in agent-state.ts cannot catch it, and that is the
+    // point worth remembering: it drops reports that are OLDER than what has
+    // been accepted, which is the right defence against two hook processes
+    // racing to the pipe. This is not a race. The trailing report is genuinely
+    // newer; it is the EVENT ORDER that is counter-intuitive, and no amount of
+    // timestamp discipline fixes a report that is late by design.
+    //
+    // Reading the current depth is what separates the two situations, using the
+    // one fact that distinguishes them: the parent's `Stop` has already zeroed
+    // it. So a subagent finishing inside a live turn holds that turn open, and
+    // a subagent finishing after the turn ended says nothing at all. Declining
+    // to report also leaves the freshness stamp alone, so the 60s idle
+    // `Notification` that follows still sees depth 0 and is correctly read as a
+    // nudge rather than a prompt — the resurrection defeated that gate too, and
+    // the pane went on to claim "Needs you" with nothing to answer.
+    //
+    // `known` is checked for the same reason `Notification` checks it: a pane
+    // wmux holds no record for has a depth of 0 by DEFAULT, not by observation.
+    // Nothing is lost by staying quiet there — a turn wmux never saw begin is
+    // not one a subagent's completion should invent.
     case 'SubagentStop':
+      if (!ctx.known || ctx.runDepth === 0) return null;
       return { awaitingHuman: false, runDepth: 1 };
 
     // The turn is over: nothing can still be running and nothing can still be

--- a/src/main/agent-hook-bridge.ts
+++ b/src/main/agent-hook-bridge.ts
@@ -21,7 +21,7 @@
  */
 
 import { SurfaceId } from '../shared/types';
-import { reportAgent, releaseAgent, ReportAgentParams } from './agent-state';
+import { getAgentState, reportAgent, releaseAgent, ReportAgentParams } from './agent-state';
 
 /** The hook events wmux registers. */
 export type ClaudeHookEvent =
@@ -33,6 +33,74 @@ export type ClaudeHookEvent =
   | 'Stop'
   | 'SubagentStop'
   | 'SessionEnd';
+
+const KNOWN_EVENTS: ClaudeHookEvent[] = [
+  'SessionStart', 'UserPromptSubmit', 'PreToolUse', 'PostToolUse',
+  'Notification', 'Stop', 'SubagentStop', 'SessionEnd',
+];
+
+/**
+ * Which event a `hook.event` wire payload denotes, or null for one outside the
+ * model.
+ *
+ * This exists because the payload does not always say. `wmux-hook.js` is
+ * invoked two ways (see its usage block): `--event <Event>` for the lifecycle
+ * hooks, and a bare `<tool-name>` for the per-tool PostToolUse entries
+ * claude-context.ts installs — and the bare form sends `{ tool }` with NO
+ * `event` field. Reading `params.event` directly therefore admits every
+ * lifecycle event while silently dropping every PostToolUse, which makes the
+ * `case 'PostToolUse'` below unreachable.
+ *
+ * Since 0.48.0 that is no longer catastrophic — matcher-less `PreToolUse`
+ * declares the run at the START of every tool, so a pane still reads `working`.
+ * What is lost is the other end: PostToolUse is the event that says a tool
+ * FINISHED without the turn ending, and it is the one report that arrives
+ * during the stretch between approving a permission prompt and the turn
+ * closing. Dropping it also drops the freshness stamp that keeps a long turn
+ * inside the trust window, so a turn spent in tracked tools ages out of
+ * `working` on nothing but the clock.
+ *
+ * Resolved here rather than by teaching the hook helper to send `event`: hooks
+ * are written into settings.json once at install, so the bare-tool form is
+ * already out in every existing config and will keep arriving from helper
+ * vintages this build does not control. The main process is the single place
+ * that sees every payload regardless of who produced it.
+ */
+export function hookEventName(
+  params: { event?: unknown; tool?: unknown } | null | undefined,
+): ClaudeHookEvent | null {
+  const explicit = typeof params?.event === 'string' ? params.event.trim() : '';
+  if (explicit) {
+    return KNOWN_EVENTS.includes(explicit as ClaudeHookEvent) ? (explicit as ClaudeHookEvent) : null;
+  }
+  // No event named, but a tool did run — that is PostToolUse by construction,
+  // since it is the only hook wmux registers by bare tool name.
+  const tool = typeof params?.tool === 'string' ? params.tool.trim() : '';
+  return tool ? 'PostToolUse' : null;
+}
+
+/**
+ * What the pane had already declared when a hook arrived.
+ *
+ * Only `Notification` reads it, and only to tell a real prompt from the ~60s
+ * idle nudge — see that case for why the discriminator is state and not text.
+ */
+export interface HookTurnContext {
+  /**
+   * Whether this pane has a declared record at all. Absent means wmux has
+   * observed nothing about the turn — a main process restarted mid-turn sees
+   * exactly this — so `runDepth` is a default, not an observation.
+   */
+  known: boolean;
+  /** The pane's current declared run refcount. */
+  runDepth: number;
+  /**
+   * Whether the turn-opening hooks are known to be firing at all. False means
+   * `runDepth` carries no information about turn boundaries, so nothing may be
+   * concluded from it.
+   */
+  turnStartTracked: boolean;
+}
 
 /**
  * Map one Claude Code hook event to a report_agent payload, or null to ignore it.
@@ -47,6 +115,7 @@ export type ClaudeHookEvent =
 export function hookToAgentReport(
   event: ClaudeHookEvent,
   message: string | null,
+  ctx: HookTurnContext,
 ): ReportAgentParams | null {
   switch (event) {
     // Claude Code just started (launch, resume, /clear, /compact). Nothing is
@@ -73,14 +142,46 @@ export function hookToAgentReport(
     case 'PreToolUse':
       return { awaitingHuman: false, runDepth: 1 };
 
-    // Claude Code wants the user. This fires both for permission/question
-    // prompts and for the ~60s "still waiting on you" idle nudge, and we park
-    // the pane for both: in either case the agent genuinely is waiting on a
-    // human, which is exactly what `blocked` claims. Sniffing the message text
-    // to tell the two apart was considered and rejected — it would silently
-    // stop working the day Claude Code rewords a prompt, and the failure would
-    // be the dangerous direction (a real prompt read as "not blocked").
+    // Claude Code wants the user. This fires for two different situations: a
+    // permission/question prompt, and the ~60s "Claude is waiting for your
+    // input" idle nudge it arms when a turn ends.
+    //
+    // Only the first is `blocked`. "Needs you" claims there is something to
+    // answer, and after a turn has ended there is nothing — the pane is idle,
+    // and saying otherwise is how a pane nobody has touched starts asking for
+    // attention a minute after it goes quiet. Observed exactly that way: Stop
+    // at T, nudge at T+60s, on a session that had just been /clear'd and left
+    // alone. /clear wipes the transcript but not Claude Code's idle timer, so
+    // the nudge landed on an empty conversation and the pane said "Needs you".
+    //
+    // The two are told apart by STATE, not by the message text. Sniffing the
+    // text was considered and rejected: it would stop working the day Claude
+    // Code rewords a prompt, and would fail in the dangerous direction (a real
+    // permission prompt read as "not blocked"). Run depth cannot drift that way
+    // — a prompt can only occur inside a live turn, and both UserPromptSubmit
+    // and PreToolUse declare depth 1 before Claude Code can ask anything, so
+    // depth 0 at Notification time means the turn is over, which means nudge.
+    //
+    // Gated on `turnStartTracked` because that argument only holds while the
+    // opening hooks are firing. A settings.json written before 0.48.0 carries
+    // only the four terminal hooks, sits at depth 0 through an entire turn, and
+    // would read every real prompt as a nudge — the dangerous direction again.
+    // Until wmux has seen one opening event it declines to draw the distinction
+    // and parks the pane for both, exactly as it did before.
+    //
+    // Gated on `known` for the same reason at the pane level. A pane wmux holds
+    // no record for has a depth of 0 by DEFAULT, not by observation — which is
+    // what a main process restarted in the middle of someone's turn sees, and
+    // what a prompt arriving before any other hook on that pane sees. Reading
+    // that as "the turn is over" would swallow a real prompt.
+    //
+    // This is the other half of noteHumanInput's bargain in agent-state.ts.
+    // That code clears a block when the human types, and leans on "if the
+    // keystroke didn't satisfy the agent, the 60-second nudge puts the pane
+    // back to asking" — which is only sound if the nudge cannot ALSO invent a
+    // block on a pane that is simply idle. It now cannot.
     case 'Notification':
+      if (ctx.known && ctx.turnStartTracked && ctx.runDepth === 0) return null;
       return { awaitingHuman: true, reason: message };
 
     // A tool finished, so a turn is in flight — and nobody is parked on a
@@ -126,10 +227,29 @@ export function hookToAgentReport(
   }
 }
 
-const KNOWN_EVENTS: ClaudeHookEvent[] = [
-  'SessionStart', 'UserPromptSubmit', 'PreToolUse', 'PostToolUse',
-  'Notification', 'Stop', 'SubagentStop', 'SessionEnd',
-];
+/** The events that prove the turn-opening hooks are installed and firing. */
+const TURN_START_EVENTS: ClaudeHookEvent[] = ['SessionStart', 'UserPromptSubmit', 'PreToolUse'];
+
+/**
+ * Whether any pane has ever delivered one of the turn-opening hooks.
+ *
+ * Deliberately global rather than per-surface: what it is really asking is
+ * "does ~/.claude/settings.json carry the 0.48.0 hook set", and that is one
+ * file for every pane. A per-surface flag would answer the narrower "has THIS
+ * pane opened a turn yet", which is false for a pane whose very first turn
+ * opens with a permission prompt — and would then mis-gate it. One opening
+ * event anywhere proves the hooks are live everywhere.
+ *
+ * Starts false, so a fresh main process parks the pane for every Notification
+ * until it has that proof. Safe direction, and it self-corrects on the first
+ * turn anyone starts.
+ */
+let turnStartTracked = false;
+
+/** Test seam: forget what this module has learned about the hook config. */
+export function resetHookBridge(): void {
+  turnStartTracked = false;
+}
 
 /**
  * Apply a Claude Code hook event to the declared agent state for `surfaceId`.
@@ -147,17 +267,25 @@ export function applyHookToAgentState(
   hookAt?: number,
 ): void {
   if (!KNOWN_EVENTS.includes(event as ClaudeHookEvent)) return;
+  const hookEvent = event as ClaudeHookEvent;
+
+  if (TURN_START_EVENTS.includes(hookEvent)) turnStartTracked = true;
 
   // Claude Code exited. Forgetting the pane is right where clearing it is not:
   // a record set to `idle` is a CLAIM, and the sidebar ranks a declared state
   // above its own inference — so an ended session would pin the pane idle
   // forever. Dropping it hands the pane back to the shell's own state.
-  if (event === 'SessionEnd') {
+  if (hookEvent === 'SessionEnd') {
     releaseAgent(surfaceId);
     return;
   }
 
-  const params = hookToAgentReport(event as ClaudeHookEvent, message);
+  const state = getAgentState(surfaceId);
+  const params = hookToAgentReport(hookEvent, message, {
+    known: state !== undefined,
+    runDepth: state?.runDepth ?? 0,
+    turnStartTracked,
+  });
   if (!params) return;
   reportAgent(surfaceId, { ...params, hookAt });
 }

--- a/src/main/agent-hook-bridge.ts
+++ b/src/main/agent-hook-bridge.ts
@@ -111,6 +111,36 @@ export interface HookTurnContext {
  * resolved to `idle`, which for a turn that thinks for a minute or runs one long
  * command is most of the turn (issue #151). The three opening events below are
  * the missing half of the lifecycle.
+ *
+ * ## Who owns the block
+ *
+ * `runDepth` and `awaitingHuman` are two independent facts, and the tool
+ * lifecycle only speaks to the first. A tool starting, finishing, or a subagent
+ * finishing says a turn is in flight; NONE of them is evidence that a question
+ * already on screen has been answered.
+ *
+ * That distinction is not academic, because every hook a pane's agent fires —
+ * including its background shells and its parallel subagents — carries the same
+ * WMUX_SURFACE_ID and lands on the one surface. So an agent that kicks off a
+ * background command and then asks the user a question is, from wmux's side,
+ * a pane that is blocked AND busy at the same time. That is a legitimate state,
+ * and `resolveState` in agent-state.ts already renders it correctly: `blocked`
+ * outranks `runDepth > 0`, so the pane says "needs you" while the work continues
+ * underneath. What broke it was these events retracting the flag on the way past.
+ *
+ * So a block is ended only by something that actually knows a human dealt with it:
+ *
+ *   - `UserPromptSubmit`  — the human replied
+ *   - `Stop`              — the turn ended, so there is nothing left to answer
+ *   - `noteHumanInput`    — the human typed in the pane (agent-state.ts)
+ *   - an explicit `report-agent --unblocked` from the agent
+ *
+ * The cost is that a prompt answered through `wmux answer-agent` — a relay, not
+ * a local keystroke — keeps saying "needs you" until the turn ends rather than
+ * until the next tool. That is answerAgent's rule 3 working as designed: the
+ * agent confirms, wmux does not assume. `answeredAt` is what the UI shows in the
+ * meantime ("sent — waiting for the agent"). A block that lingers is visible and
+ * self-correcting; one that vanishes while the agent is still stuck is the bug.
  */
 export function hookToAgentReport(
   event: ClaudeHookEvent,
@@ -139,8 +169,12 @@ export function hookToAgentReport(
     // A tool is about to run. Fires BEFORE the permission check, so it cannot
     // clear a prompt that has not appeared yet — its job is the long tool: a
     // three-minute test run reported nothing at all until it finished.
+    //
+    // It says nothing about `awaitingHuman` for the same reason, in the other
+    // direction: a tool STARTING is not evidence that a question already on
+    // screen was answered. See the block-ownership note above.
     case 'PreToolUse':
-      return { awaitingHuman: false, runDepth: 1 };
+      return { runDepth: 1 };
 
     // Claude Code wants the user. This fires for two different situations: a
     // permission/question prompt, and the ~60s "Claude is waiting for your
@@ -184,16 +218,24 @@ export function hookToAgentReport(
       if (ctx.known && ctx.turnStartTracked && ctx.runDepth === 0) return null;
       return { awaitingHuman: true, reason: message };
 
-    // A tool finished, so a turn is in flight — and nobody is parked on a
-    // prompt, because a pending permission dialog would have stopped the tool
-    // from running at all.
+    // A tool finished, so a turn is in flight.
+    //
+    // It used to also clear the block, on the premise that "a pending permission
+    // dialog would have stopped the tool from running at all". That premise
+    // holds only for an agent doing one thing at a time, and it is false for the
+    // two things agents do most: a BACKGROUND shell, and PARALLEL SUBAGENTS.
+    // Both carry the pane's WMUX_SURFACE_ID, so their tool lifecycle reports to
+    // the surface that is asking the question — and the pane snapped back to
+    // "Running" with the prompt still on screen and no event left to correct it
+    // (Claude Code arms the 60s idle nudge only after a turn ENDS, and the turn
+    // is still open). See the block-ownership note above.
     //
     // Absolute runDepth rather than a delta: this fires on EVERY tool call and
     // nothing decrements per-call, so `runDelta: +1` would climb forever. An
     // absolute value is idempotent — five hundred tool calls still leave the
     // depth at 1.
     case 'PostToolUse':
-      return { awaitingHuman: false, runDepth: 1 };
+      return { runDepth: 1 };
 
     // One parallel subagent finished. It may SUSTAIN a turn; it may never START
     // one.
@@ -237,7 +279,7 @@ export function hookToAgentReport(
     // not one a subagent's completion should invent.
     case 'SubagentStop':
       if (!ctx.known || ctx.runDepth === 0) return null;
-      return { awaitingHuman: false, runDepth: 1 };
+      return { runDepth: 1 };
 
     // The turn is over: nothing can still be running and nothing can still be
     // waiting on the user. Decisive on purpose — this is the backstop that

--- a/src/main/agent-state.ts
+++ b/src/main/agent-state.ts
@@ -563,13 +563,49 @@ function skipEscapeSequence(data: string, i: number): number {
  * does — a tool, a turn end, or the 60-second idle nudge — reports the truth and
  * the pane goes back to asking. A block that clears a few seconds early is a
  * cosmetic miss; a block that never clears makes the whole sidebar untrustworthy.
+ * (The nudge only re-asserts a block INSIDE a live turn; agent-hook-bridge.ts
+ * stops it inventing one on a pane that has already finished. That is the case
+ * this self-heal needs, and the one it does not.)
  *
- * Returns true when a block was actually cleared, so the caller can tell whether
- * anything happened.
+ * The second thing a keystroke can settle is an INTERRUPT, and that one has no
+ * hook at all: pressing Escape mid-run stops the turn and Claude Code says
+ * nothing about it — measured directly, `updatedAt` is byte-identical before and
+ * after, so it is not a stale report but no report. The pane therefore keeps
+ * asserting `working` for a turn the user cancelled, until the next prompt or
+ * the 15-minute trust window. Handled here rather than by reading the TUI for an
+ * "Interrupted" line, because a keystroke wmux owns cannot break the day Claude
+ * Code rewords its output — the failure this module exists to avoid.
+ *
+ * The Escape test is exact-match rather than isAnsweringInput's "contains a bare
+ * ESC": Alt+key also arrives as ESC followed by a character, and reading that as
+ * an interrupt would retract a run nobody stopped. A real Escape keypress is one
+ * byte on its own.
+ *
+ * Like the block clear, it only ever CLEARS, and only for a pane that has
+ * declared something — a plain shell, where Escape means whatever the shell says
+ * it means, has no record and is left entirely alone. The worst a wrong guess
+ * does is under-report for one event, and the next hook corrects it.
+ *
+ * Returns true when something was actually retracted, so the caller can tell
+ * whether anything happened.
  */
 export function noteHumanInput(surfaceId: SurfaceId, data: string): boolean {
   const record = records.get(surfaceId);
-  if (!record || !record.awaitingHuman) return false;
+  if (!record) return false;
+
+  // Escape, alone, against a live run: the turn was cancelled. Clears the block
+  // too — escaping a permission prompt dismisses the question with it.
+  if (data === '\x1b' && record.runDepth > 0) {
+    record.runDepth = 0;
+    record.awaitingHuman = false;
+    record.blockedReason = null;
+    record.choices = [];
+    record.answeredAt = null;
+    commit(record);
+    return true;
+  }
+
+  if (!record.awaitingHuman) return false;
   if (!isAnsweringInput(data)) return false;
 
   record.awaitingHuman = false;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,7 +16,7 @@ import { initUpdateChecker, getLatestUpdate } from './update-checker';
 import { initAgentIntegration } from './agent-integration';
 import { applyExternalActivity, markSubagentStop, markAllAgentsDone } from './claude-observer';
 import { handleAgentStateV2, setAnswerWriter } from './agent-state-rpc';
-import { applyHookToAgentState } from './agent-hook-bridge';
+import { applyHookToAgentState, hookEventName } from './agent-hook-bridge';
 import { startOrchestrationWatcher } from './orchestration-watcher';
 import { readMarkdownFile } from './markdown-file';
 import { grantMarkdownPath, clearMarkdownGrants } from './markdown-grants';
@@ -430,10 +430,15 @@ function handleHookEvent(params: any): void {
   // Same events, second consumer: declared agent run state (issue #128). This
   // is what makes "which pane is parked on me?" work for Claude Code with no
   // plugin to install — wmux already registers these hooks.
-  if (params?.surfaceId && params?.event) {
+  // The event is resolved, not read straight off the payload: the per-tool
+  // PostToolUse entries invoke the hook helper by bare tool name, so they arrive
+  // with a `tool` and no `event` at all — and gating on `params.event` dropped
+  // every one of them. See hookEventName for what that costs.
+  const hookEvent = hookEventName(params);
+  if (params?.surfaceId && hookEvent) {
     applyHookToAgentState(
       params.surfaceId as SurfaceId,
-      String(params.event),
+      hookEvent,
       params.message ?? null,
       Number.isFinite(params.at) ? Number(params.at) : undefined,
     );

--- a/src/renderer/components/Sidebar/WorkspaceRow.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceRow.tsx
@@ -2,15 +2,13 @@ import React, { useState, useRef, useMemo, useEffect } from 'react';
 import { WorkspaceInfo, SplitNode, PaneId } from '../../../shared/types';
 import { useStore } from '../../store';
 import { useT } from '../../i18n';
-import type { TranslationKey } from '../../i18n';
 import { aggregateProgress } from '../../store/progress-slice';
 import { agentsForWorkspace, resolveAgentLinger, WorkspaceAgentsView } from '../../store/agent-view';
 import { claudeSessionsForWorkspace, HookActivityEntry } from '../../store/claude-session-view';
 import UnreadBadge from './UnreadBadge';
 import PrStatusIcon from './PrStatusIcon';
 import { traceState, toolChannel } from './trace-signals';
-
-type T = (key: TranslationKey, fallback?: string) => string;
+import { resolveStatusText, statusClassFor, type StatusTextInputs, type T } from './workspace-status';
 
 /** Stable empty view — avoids allocating a fresh object every collapsed tick. */
 const EMPTY_AGENTS_VIEW: WorkspaceAgentsView = { lines: [], total: 0, running: 0 };
@@ -54,83 +52,6 @@ function sessionDetailText(session: { working: boolean; blocked: boolean; blocke
   return session.tool ? getToolLabel(session.tool, t) : t('workspaceRow.sessionRunning', 'Running…');
 }
 
-interface StatusTextInputs {
-  statusOverride?: 'running' | 'idle';
-  runningAgentCount: number;
-  agentTotal: number;
-  sessionCount: number;
-  workingSessions: number;
-  blockedSessions: number;
-  currentToolLabel: string | null;
-  claudeIsIdle: boolean;
-  shellState?: string;
-  notificationText?: string;
-}
-
-/** Priorities 0–2: Claude-derived signals. Null → fall through to shell state. */
-function claudeStatusText(s: StatusTextInputs, t: T): string | null {
-  // Priority 0: user pinned the status by hand (issue #81) — detection
-  // heuristics can misread tools that keep the shell "running" while idle.
-  if (s.statusOverride) {
-    return s.statusOverride === 'running' ? t('workspaceRow.running', 'Running') : t('workspaceRow.idle', 'Idle');
-  }
-
-  // Priority 0.25: a session is parked on the user. Ranked above the running
-  // summaries on purpose — everything else describes work that proceeds on its
-  // own, this describes work that has stopped until the user acts (issue #128).
-  if (s.blockedSessions > 0) {
-    return s.blockedSessions > 1
-      ? t('workspaceRow.needsYouCount', 'Needs you · {count}').replace('{count}', String(s.blockedSessions))
-      : t('workspaceRow.needsYou', 'Needs you');
-  }
-
-  // Priority 0.5: agents are running — show the orchestration summary
-  if (s.runningAgentCount > 0) {
-    return (s.agentTotal > 1
-      ? t('workspaceRow.orchestratingMany', 'Orchestrating · {count} agents')
-      : t('workspaceRow.orchestratingOne', 'Orchestrating · {count} agent')
-    ).replace('{count}', String(s.agentTotal));
-  }
-
-  // Priority 0.75: several Claude sessions in this workspace — summarize;
-  // the per-session sub-lines below the status carry the detail.
-  if (s.sessionCount >= 2) {
-    return s.workingSessions > 0
-      ? t('workspaceRow.claudeRunning', 'Claude · {working}/{total} running')
-        .replace('{working}', String(s.workingSessions))
-        .replace('{total}', String(s.sessionCount))
-      : t('workspaceRow.idle', 'Idle');
-  }
-
-  // Priority 1: Claude is actively using a tool
-  if (s.currentToolLabel) return s.currentToolLabel;
-
-  // Priority 2: Claude was working but stopped → idle, not "Running"
-  if (s.claudeIsIdle) return t('workspaceRow.idle', 'Idle');
-
-  return null;
-}
-
-/** Status line priority chain: override > agents > sessions > tool > idle > shell > notification. */
-function resolveStatusText(s: StatusTextInputs, t: T): string {
-  const claude = claudeStatusText(s, t);
-  if (claude) return claude;
-
-  // Priority 3: Shell state from shell integration
-  if (s.shellState === 'running') return t('workspaceRow.running', 'Running');
-  if (s.shellState === 'interrupted') return t('workspaceRow.interrupted', 'Interrupted');
-  if (s.shellState === 'idle') {
-    return s.notificationText
-      ? t('workspaceRow.done', 'Done: {text}').replace('{text}', s.notificationText)
-      : t('workspaceRow.idle', 'Idle');
-  }
-
-  // Priority 4: Notification text without shell state
-  if (s.notificationText) return s.notificationText;
-
-  // Priority 5: Default — always show something
-  return t('workspaceRow.idle', 'Idle');
-}
 
 interface WorkspaceRowProps {
   workspace: WorkspaceInfo;
@@ -397,8 +318,10 @@ export default function WorkspaceRow({
     return false;
   }, [workspace.shellState, sessions, workingSessions, wsActivity, legacyHook, tick]);
 
-  // ── Status text: manual override > tool activity > shell state > default ──
-  const statusText = useMemo(() => resolveStatusText({
+  // One set of inputs feeding BOTH the words and the colour. They are separate
+  // chains that must agree, and they drifted apart once already — sharing the
+  // inputs at least guarantees they are arguing about the same facts.
+  const statusInputs = useMemo<StatusTextInputs>(() => ({
     statusOverride: workspace.statusOverride,
     runningAgentCount,
     agentTotal: wsAgents.total,
@@ -409,28 +332,13 @@ export default function WorkspaceRow({
     claudeIsIdle,
     shellState: workspace.shellState,
     notificationText: workspace.notificationText,
-  }, t), [workspace.statusOverride, runningAgentCount, wsAgents, sessions, workingSessions, blockedSessions, currentToolLabel, claudeIsIdle, workspace.shellState, workspace.notificationText, t]);
+  }), [workspace.statusOverride, runningAgentCount, wsAgents, sessions, workingSessions, blockedSessions, currentToolLabel, claudeIsIdle, workspace.shellState, workspace.notificationText]);
+
+  // ── Status text: manual override > tool activity > shell state > default ──
+  const statusText = useMemo(() => resolveStatusText(statusInputs, t), [statusInputs, t]);
 
   // ── Status color class ──
-  const statusClass = useMemo(() => {
-    if (workspace.statusOverride) {
-      return workspace.statusOverride === 'running'
-        ? 'workspace-row__status--running'
-        : 'workspace-row__status--idle';
-    }
-    if (blockedSessions > 0) return 'workspace-row__status--blocked';
-    if (runningAgentCount > 0) return 'workspace-row__status--working';
-    if (sessions.length >= 2) {
-      return workingSessions > 0 ? 'workspace-row__status--working' : 'workspace-row__status--idle';
-    }
-    if (currentToolLabel) return 'workspace-row__status--working';
-    if (claudeIsIdle) return 'workspace-row__status--idle';
-    const state = workspace.shellState;
-    if (state === 'running') return 'workspace-row__status--running';
-    if (state === 'interrupted') return 'workspace-row__status--interrupted';
-    if (state === 'idle') return 'workspace-row__status--done';
-    return 'workspace-row__status--idle';
-  }, [workspace.statusOverride, blockedSessions, runningAgentCount, sessions.length, workingSessions, currentToolLabel, claudeIsIdle, workspace.shellState]);
+  const statusClass = useMemo(() => statusClassFor(statusInputs), [statusInputs]);
 
   // ── Context line: "branch* · ~/path/to/dir" ──
   const contextLine = useMemo(() => {

--- a/src/renderer/components/Sidebar/workspace-status.ts
+++ b/src/renderer/components/Sidebar/workspace-status.ts
@@ -1,0 +1,137 @@
+/**
+ * The workspace row's status line — which of the competing signals wins.
+ *
+ * Lives beside the component rather than inside it (as reorder.ts and
+ * trace-signals.ts already do) because the precedence chain is the part worth
+ * testing: it arbitrates between a DECLARED agent state, two decaying
+ * heuristics (the TUI scraper and hook activity), and the shell's own idea of
+ * whether it is busy. Getting that order wrong is invisible in a type check and
+ * obvious to anyone watching the sidebar.
+ */
+import type { TranslationKey } from '../../i18n';
+
+export type T = (key: TranslationKey, fallback?: string) => string;
+
+export interface StatusTextInputs {
+  statusOverride?: 'running' | 'idle';
+  runningAgentCount: number;
+  agentTotal: number;
+  sessionCount: number;
+  workingSessions: number;
+  blockedSessions: number;
+  currentToolLabel: string | null;
+  claudeIsIdle: boolean;
+  shellState?: string;
+  notificationText?: string;
+}
+
+/** Priorities 0–2: Claude-derived signals. Null → fall through to shell state. */
+export function claudeStatusText(s: StatusTextInputs, t: T): string | null {
+  // Priority 0: user pinned the status by hand (issue #81) — detection
+  // heuristics can misread tools that keep the shell "running" while idle.
+  if (s.statusOverride) {
+    return s.statusOverride === 'running' ? t('workspaceRow.running', 'Running') : t('workspaceRow.idle', 'Idle');
+  }
+
+  // Priority 0.25: a session is parked on the user. Ranked above the running
+  // summaries on purpose — everything else describes work that proceeds on its
+  // own, this describes work that has stopped until the user acts (issue #128).
+  if (s.blockedSessions > 0) {
+    return s.blockedSessions > 1
+      ? t('workspaceRow.needsYouCount', 'Needs you · {count}').replace('{count}', String(s.blockedSessions))
+      : t('workspaceRow.needsYou', 'Needs you');
+  }
+
+  // Priority 0.5: agents are running — show the orchestration summary
+  if (s.runningAgentCount > 0) {
+    return (s.agentTotal > 1
+      ? t('workspaceRow.orchestratingMany', 'Orchestrating · {count} agents')
+      : t('workspaceRow.orchestratingOne', 'Orchestrating · {count} agent')
+    ).replace('{count}', String(s.agentTotal));
+  }
+
+  // Priority 0.75: several Claude sessions in this workspace — summarize;
+  // the per-session sub-lines below the status carry the detail.
+  if (s.sessionCount >= 2) {
+    return s.workingSessions > 0
+      ? t('workspaceRow.claudeRunning', 'Claude · {working}/{total} running')
+        .replace('{working}', String(s.workingSessions))
+        .replace('{total}', String(s.sessionCount))
+      : t('workspaceRow.idle', 'Idle');
+  }
+
+  // Priority 1: Claude is actively using a tool
+  if (s.currentToolLabel) return s.currentToolLabel;
+
+  // Priority 1.5: the session DECLARED it is working, but no tool label is
+  // live. Ranked below the label because the label says more ("Reading
+  // file…"), and above everything after it because this is the authoritative
+  // signal — the agent's own claim, not a decaying inference.
+  //
+  // The gap this closes: `workingSessions` used to be read only in the
+  // `sessionCount >= 2` branch above, so the common case of ONE agent pane
+  // never consulted it. PostToolUse fires when a tool FINISHES, so during a
+  // stretch of thinking, or one slow tool, the label expires while the turn
+  // runs on; the chain then fell through to the shell, and a shell reporting
+  // idle (the Claude Code TUI is not a "running command") rendered the row
+  // "Idle" mid-turn. The per-session sub-line already got this right — see
+  // sessionDetailText — so the row contradicted the very lines beneath it.
+  if (s.workingSessions > 0) return t('workspaceRow.sessionRunning', 'Running…');
+
+  // Priority 2: Claude was working but stopped → idle, not "Running"
+  if (s.claudeIsIdle) return t('workspaceRow.idle', 'Idle');
+
+  return null;
+}
+
+/**
+ * The status line's modifier class, which must follow the SAME order as
+ * claudeStatusText.
+ *
+ * Kept next to it deliberately: these two chains are written out separately
+ * (one yields words, the other a class name) and drifted apart once already —
+ * `workingSessions` was consulted only under `sessionCount >= 2` in BOTH, so a
+ * single working pane rendered "Idle" in the text and the `--done` style in the
+ * colour. Any priority added to one belongs in the other.
+ */
+export function statusClassFor(s: StatusTextInputs): string {
+  if (s.statusOverride) {
+    return s.statusOverride === 'running'
+      ? 'workspace-row__status--running'
+      : 'workspace-row__status--idle';
+  }
+  if (s.blockedSessions > 0) return 'workspace-row__status--blocked';
+  if (s.runningAgentCount > 0) return 'workspace-row__status--working';
+  if (s.sessionCount >= 2) {
+    return s.workingSessions > 0 ? 'workspace-row__status--working' : 'workspace-row__status--idle';
+  }
+  if (s.currentToolLabel) return 'workspace-row__status--working';
+  // Mirrors Priority 1.5 above — the declared claim, with no live tool label.
+  if (s.workingSessions > 0) return 'workspace-row__status--working';
+  if (s.claudeIsIdle) return 'workspace-row__status--idle';
+  if (s.shellState === 'running') return 'workspace-row__status--running';
+  if (s.shellState === 'interrupted') return 'workspace-row__status--interrupted';
+  if (s.shellState === 'idle') return 'workspace-row__status--done';
+  return 'workspace-row__status--idle';
+}
+
+/** Status line priority chain: override > agents > sessions > tool > idle > shell > notification. */
+export function resolveStatusText(s: StatusTextInputs, t: T): string {
+  const claude = claudeStatusText(s, t);
+  if (claude) return claude;
+
+  // Priority 3: Shell state from shell integration
+  if (s.shellState === 'running') return t('workspaceRow.running', 'Running');
+  if (s.shellState === 'interrupted') return t('workspaceRow.interrupted', 'Interrupted');
+  if (s.shellState === 'idle') {
+    return s.notificationText
+      ? t('workspaceRow.done', 'Done: {text}').replace('{text}', s.notificationText)
+      : t('workspaceRow.idle', 'Idle');
+  }
+
+  // Priority 4: Notification text without shell state
+  if (s.notificationText) return s.notificationText;
+
+  // Priority 5: Default — always show something
+  return t('workspaceRow.idle', 'Idle');
+}

--- a/tests/unit/agent-hook-bridge.test.ts
+++ b/tests/unit/agent-hook-bridge.test.ts
@@ -57,15 +57,15 @@ describe('hookToAgentReport', () => {
       .toBe(true);
   });
 
-  it('PostToolUse asserts a run and clears any block, idempotently', () => {
-    expect(hookToAgentReport('PostToolUse', null, ctx())).toEqual({ awaitingHuman: false, runDepth: 1 });
+  it('PostToolUse asserts a run, idempotently, and leaves the block alone', () => {
+    expect(hookToAgentReport('PostToolUse', null, ctx())).toEqual({ runDepth: 1 });
   });
 
   it('SubagentStop keeps the parent turn running (issue #151)', () => {
     // Not a decrement: subagents share the parent's surface id, so the first one
     // to finish used to drain the refcount and report the pane idle while the
     // parent and its siblings were still working.
-    expect(hookToAgentReport('SubagentStop', null, ctx())).toEqual({ awaitingHuman: false, runDepth: 1 });
+    expect(hookToAgentReport('SubagentStop', null, ctx())).toEqual({ runDepth: 1 });
   });
 
   it('SubagentStop sustains a live turn but never starts one (issue #151)', () => {
@@ -90,7 +90,9 @@ describe('hookToAgentReport', () => {
   });
 
   it('PreToolUse asserts the run before the tool, not after it (issue #151)', () => {
-    expect(hookToAgentReport('PreToolUse', null, ctx())).toEqual({ awaitingHuman: false, runDepth: 1 });
+    // No `awaitingHuman`: a tool starting cannot mean a question was answered,
+    // and under a background shell or parallel subagents it routinely is not.
+    expect(hookToAgentReport('PreToolUse', null, ctx())).toEqual({ runDepth: 1 });
   });
 });
 
@@ -183,13 +185,41 @@ describe('applyHookToAgentState', () => {
     applyHookToAgentState(surf, 'Notification', 'permission to use Bash');
     expect(getAgentState(surf)).toMatchObject({ state: 'blocked', blockedReason: 'permission to use Bash' });
 
-    // The user approved: the next tool ran, which can only happen once the
-    // prompt is gone.
-    applyHookToAgentState(surf, 'PostToolUse', null);
-    expect(getAgentState(surf)).toMatchObject({ state: 'working', blockedReason: null });
+    // The user replied. A tool running is NOT what proves that — see the
+    // background-work tests below — so the block ends on the turn ending.
+    applyHookToAgentState(surf, 'Stop', null);
+    expect(getAgentState(surf)).toMatchObject({ state: 'idle', blockedReason: null });
+  });
 
+  it('background work does not retract a live question (issue #151)', () => {
+    // The reported case: the agent starts a background shell, then asks a
+    // question with options. The background command's own hooks carry the SAME
+    // WMUX_SURFACE_ID, so its tool lifecycle lands on the pane that is asking.
+    // Every one of these used to assert awaitingHuman: false and snap the pane
+    // back to "Running" with the question still on screen.
+    applyHookToAgentState(surf, 'UserPromptSubmit', null);
+    applyHookToAgentState(surf, 'Notification', 'Claude needs your permission');
+    expect(getAgentState(surf)?.state).toBe('blocked');
+
+    for (const event of ['PreToolUse', 'PostToolUse', 'SubagentStop'] as const) {
+      applyHookToAgentState(surf, event, null);
+      expect(getAgentState(surf)).toMatchObject({ state: 'blocked', blockedReason: 'Claude needs your permission' });
+    }
+
+    // And the run is still genuinely in flight underneath — `blocked` outranks
+    // it rather than replacing it, so answering still leaves a live turn.
+    expect(getAgentState(surf)?.runDepth).toBe(1);
     applyHookToAgentState(surf, 'Stop', null);
     expect(getAgentState(surf)?.state).toBe('idle');
+  });
+
+  it('the human replying is what ends the wait, not a tool (issue #151)', () => {
+    applyHookToAgentState(surf, 'UserPromptSubmit', null);
+    applyHookToAgentState(surf, 'Notification', 'permission to use Bash');
+    expect(getAgentState(surf)?.state).toBe('blocked');
+
+    applyHookToAgentState(surf, 'UserPromptSubmit', null);
+    expect(getAgentState(surf)).toMatchObject({ state: 'working', blockedReason: null });
   });
 
   it('hundreds of tool calls do not inflate the run depth', () => {

--- a/tests/unit/agent-hook-bridge.test.ts
+++ b/tests/unit/agent-hook-bridge.test.ts
@@ -68,6 +68,15 @@ describe('hookToAgentReport', () => {
     expect(hookToAgentReport('SubagentStop', null, ctx())).toEqual({ awaitingHuman: false, runDepth: 1 });
   });
 
+  it('SubagentStop sustains a live turn but never starts one (issue #151)', () => {
+    // Measured, twice, on two panes: Claude Code fires SubagentStop 1.8-2.2s
+    // AFTER the parent's Stop, not before it. Asserting depth 1 unconditionally
+    // therefore resurrects the run Stop had just ended — and with a strictly
+    // newer hookAt, so the wall-clock ordering gate waves it through.
+    expect(hookToAgentReport('SubagentStop', null, ctx({ runDepth: 0 }))).toBeNull();
+    expect(hookToAgentReport('SubagentStop', null, ctx({ known: false, runDepth: 0 }))).toBeNull();
+  });
+
   it('Stop is decisive: nothing running, nothing waiting', () => {
     expect(hookToAgentReport('Stop', null, ctx())).toEqual({ awaitingHuman: false, runDepth: 0 });
   });
@@ -225,6 +234,24 @@ describe('applyHookToAgentState', () => {
       expect(getAgentState(surf)?.state).toBe('working');
     }
     applyHookToAgentState(surf, 'Stop', null);
+    expect(getAgentState(surf)?.state).toBe('idle');
+  });
+
+  it('a SubagentStop trailing the parent Stop does not resurrect the turn (issue #151)', () => {
+    // The real wire order, with the real stamps: Stop at T, SubagentStop at
+    // T+2s. The later stamp is what makes this bite — acceptHookAt orders by
+    // hookAt, so the trailing report is newer and cannot be dropped as a replay.
+    applyHookToAgentState(surf, 'UserPromptSubmit', null, 1000);
+    applyHookToAgentState(surf, 'PostToolUse', null, 2000);
+    applyHookToAgentState(surf, 'Stop', null, 3000);
+    expect(getAgentState(surf)?.state).toBe('idle');
+
+    applyHookToAgentState(surf, 'SubagentStop', null, 5000);
+    expect(getAgentState(surf)?.state).toBe('idle');
+
+    // And the 60s idle nudge that follows must still read as a nudge, not as a
+    // prompt — the resurrection defeated that gate too.
+    applyHookToAgentState(surf, 'Notification', 'Claude is waiting for your input', 65000);
     expect(getAgentState(surf)?.state).toBe('idle');
   });
 });

--- a/tests/unit/agent-hook-bridge.test.ts
+++ b/tests/unit/agent-hook-bridge.test.ts
@@ -4,52 +4,107 @@ vi.mock('electron', () => ({
   BrowserWindow: { getAllWindows: () => [] },
 }));
 
-import { hookToAgentReport, applyHookToAgentState } from '../../src/main/agent-hook-bridge';
+import { hookToAgentReport, applyHookToAgentState, hookEventName, resetHookBridge } from '../../src/main/agent-hook-bridge';
 import { getAgentState, resetAgentState } from '../../src/main/agent-state';
 import { SurfaceId } from '../../src/shared/types';
 
 const surf = 'surf-hook-1' as SurfaceId;
 
-beforeEach(() => resetAgentState());
+beforeEach(() => {
+  resetAgentState();
+  resetHookBridge();
+});
+
+/**
+ * Turn context for the pure mapper. Defaults to a mid-turn pane on the 0.48.0
+ * hook set, which is what every event other than Notification ignores anyway.
+ */
+const ctx = (over: Partial<Parameters<typeof hookToAgentReport>[2]> = {}) =>
+  ({ known: true, runDepth: 1, turnStartTracked: true, ...over });
 
 describe('hookToAgentReport', () => {
   it('Notification parks the pane on the user and keeps the message as the reason', () => {
-    expect(hookToAgentReport('Notification', 'Claude needs your permission to use Bash'))
+    expect(hookToAgentReport('Notification', 'Claude needs your permission to use Bash', ctx()))
       .toEqual({ awaitingHuman: true, reason: 'Claude needs your permission to use Bash' });
   });
 
-  it('the 60s idle nudge also counts as blocked', () => {
-    // Deliberate: the agent genuinely is waiting on the user. Text-sniffing to
-    // tell a nudge from a permission prompt would break on any rewording, and
-    // would fail in the dangerous direction.
-    expect(hookToAgentReport('Notification', 'Claude is waiting for your input')?.awaitingHuman).toBe(true);
+  it('the 60s idle nudge after a finished turn is NOT blocked (issue #151)', () => {
+    // Same hook, different situation. A prompt can only exist inside a live
+    // turn, so depth 0 at Notification time means this is the idle nudge — and
+    // "Needs you" on a pane with nothing to answer is how a session that was
+    // /clear'd and left alone starts asking for attention a minute later.
+    expect(hookToAgentReport('Notification', 'Claude is waiting for your input', ctx({ runDepth: 0 })))
+      .toBeNull();
+  });
+
+  it('a prompt inside a live turn is still blocked', () => {
+    expect(hookToAgentReport('Notification', 'permission to use Bash', ctx({ runDepth: 1 }))?.awaitingHuman)
+      .toBe(true);
+  });
+
+  it('parks the pane for both when the opening hooks are not installed', () => {
+    // A settings.json written before 0.48.0 sits at depth 0 through an entire
+    // turn, so the discriminator carries no information — and guessing would
+    // fail in the dangerous direction, swallowing a real permission prompt.
+    expect(hookToAgentReport('Notification', 'permission to use Bash', ctx({ runDepth: 0, turnStartTracked: false }))?.awaitingHuman)
+      .toBe(true);
+  });
+
+  it('parks the pane for a surface it holds no record for', () => {
+    // Depth 0 by default rather than by observation — what a main process
+    // restarted in the middle of someone's turn sees.
+    expect(hookToAgentReport('Notification', 'permission to use Bash', ctx({ known: false, runDepth: 0 }))?.awaitingHuman)
+      .toBe(true);
   });
 
   it('PostToolUse asserts a run and clears any block, idempotently', () => {
-    expect(hookToAgentReport('PostToolUse', null)).toEqual({ awaitingHuman: false, runDepth: 1 });
+    expect(hookToAgentReport('PostToolUse', null, ctx())).toEqual({ awaitingHuman: false, runDepth: 1 });
   });
 
   it('SubagentStop keeps the parent turn running (issue #151)', () => {
     // Not a decrement: subagents share the parent's surface id, so the first one
     // to finish used to drain the refcount and report the pane idle while the
     // parent and its siblings were still working.
-    expect(hookToAgentReport('SubagentStop', null)).toEqual({ awaitingHuman: false, runDepth: 1 });
+    expect(hookToAgentReport('SubagentStop', null, ctx())).toEqual({ awaitingHuman: false, runDepth: 1 });
   });
 
   it('Stop is decisive: nothing running, nothing waiting', () => {
-    expect(hookToAgentReport('Stop', null)).toEqual({ awaitingHuman: false, runDepth: 0 });
+    expect(hookToAgentReport('Stop', null, ctx())).toEqual({ awaitingHuman: false, runDepth: 0 });
   });
 
   it('SessionStart registers the pane as an idle session (issue #151)', () => {
-    expect(hookToAgentReport('SessionStart', null)).toEqual({ awaitingHuman: false, runDepth: 0 });
+    expect(hookToAgentReport('SessionStart', null, ctx())).toEqual({ awaitingHuman: false, runDepth: 0 });
   });
 
   it('UserPromptSubmit starts the turn and ends the wait (issue #151)', () => {
-    expect(hookToAgentReport('UserPromptSubmit', null)).toEqual({ awaitingHuman: false, runDepth: 1 });
+    expect(hookToAgentReport('UserPromptSubmit', null, ctx())).toEqual({ awaitingHuman: false, runDepth: 1 });
   });
 
   it('PreToolUse asserts the run before the tool, not after it (issue #151)', () => {
-    expect(hookToAgentReport('PreToolUse', null)).toEqual({ awaitingHuman: false, runDepth: 1 });
+    expect(hookToAgentReport('PreToolUse', null, ctx())).toEqual({ awaitingHuman: false, runDepth: 1 });
+  });
+});
+
+describe('hookEventName', () => {
+  it('reads the event when the payload names one', () => {
+    expect(hookEventName({ event: 'Stop' })).toBe('Stop');
+  });
+
+  it('resolves a bare tool payload to PostToolUse (issue #151)', () => {
+    // The per-tool PostToolUse entries invoke the hook helper by bare tool
+    // name, so they arrive with a `tool` and no `event` at all. Gating on
+    // `params.event` dropped every one of them and made the PostToolUse case
+    // unreachable.
+    expect(hookEventName({ tool: 'Bash' })).toBe('PostToolUse');
+  });
+
+  it('ignores an event outside the model', () => {
+    expect(hookEventName({ event: 'PreCompact' })).toBeNull();
+  });
+
+  it('ignores a payload that names neither', () => {
+    expect(hookEventName({})).toBeNull();
+    expect(hookEventName(null)).toBeNull();
   });
 });
 
@@ -139,6 +194,25 @@ describe('applyHookToAgentState', () => {
     applyHookToAgentState(surf, 'Notification', 'waiting');
     applyHookToAgentState(surf, 'Stop', null);
     expect(getAgentState(surf)).toMatchObject({ state: 'idle', blockedReason: null });
+  });
+
+  it('the idle nudge does not resurrect a finished turn (issue #151)', () => {
+    // The sequence that produced the report: a session is /clear'd and left
+    // alone. /clear wipes the transcript but not Claude Code's idle timer, so
+    // 60s after the Stop the nudge lands on an empty conversation.
+    applyHookToAgentState(surf, 'SessionStart', null);
+    applyHookToAgentState(surf, 'UserPromptSubmit', null);
+    applyHookToAgentState(surf, 'Stop', null);
+    expect(getAgentState(surf)?.state).toBe('idle');
+
+    applyHookToAgentState(surf, 'Notification', 'Claude is waiting for your input');
+    expect(getAgentState(surf)).toMatchObject({ state: 'idle', blockedReason: null });
+  });
+
+  it('but a permission prompt mid-turn still parks the pane', () => {
+    applyHookToAgentState(surf, 'UserPromptSubmit', null);
+    applyHookToAgentState(surf, 'Notification', 'permission to use Bash');
+    expect(getAgentState(surf)).toMatchObject({ state: 'blocked', blockedReason: 'permission to use Bash' });
   });
 
   it('a subagent finishing does not end the outer turn (issue #151)', () => {

--- a/tests/unit/agent-human-input.test.ts
+++ b/tests/unit/agent-human-input.test.ts
@@ -102,3 +102,51 @@ describe('noteHumanInput', () => {
     expect(getAgentState(SID)).toMatchObject({ state: 'blocked', blockedReason: 'still waiting' });
   });
 });
+
+describe('Escape interrupts a run (issue #151)', () => {
+  beforeEach(() => resetAgentState());
+
+  it('retracts a run the user cancelled', () => {
+    // Claude Code fires NO hook on interrupt — measured directly, `updatedAt`
+    // is identical before and after. Without this the pane keeps claiming
+    // `working` for a turn that is over, until the next prompt or the 15-minute
+    // trust window.
+    reportAgent(SID, { awaitingHuman: false, runDepth: 1 });
+    expect(noteHumanInput(SID, '')).toBe(true);
+    expect(getAgentState(SID)?.state).toBe('idle');
+  });
+
+  it('escaping a permission prompt clears the prompt with the run', () => {
+    reportAgent(SID, { awaitingHuman: true, reason: 'permission to use Bash', runDepth: 1 });
+    noteHumanInput(SID, '');
+    expect(getAgentState(SID)).toMatchObject({ state: 'idle', blockedReason: null, choices: [] });
+  });
+
+  it('an arrow key is not an interrupt', () => {
+    // Being sent to a pane and scrolling to see what it wants is the normal
+    // first move; it must not retract the run that sent you there.
+    reportAgent(SID, { awaitingHuman: false, runDepth: 1 });
+    expect(noteHumanInput(SID, '[A')).toBe(false);
+    expect(getAgentState(SID)?.state).toBe('working');
+  });
+
+  it('Alt+key is not an interrupt', () => {
+    // Alt+b arrives as ESC followed by a character, which is why the test is an
+    // exact match on the single byte rather than isAnsweringInput's "contains a
+    // bare ESC".
+    reportAgent(SID, { awaitingHuman: false, runDepth: 1 });
+    expect(noteHumanInput(SID, 'b')).toBe(false);
+    expect(getAgentState(SID)?.state).toBe('working');
+  });
+
+  it('leaves a plain shell alone', () => {
+    expect(noteHumanInput('surf-shell' as SurfaceId, '')).toBe(false);
+    expect(getAgentState('surf-shell' as SurfaceId)).toBeUndefined();
+  });
+
+  it('never asserts anything — an idle pane stays idle', () => {
+    reportAgent(SID, { awaitingHuman: false, runDepth: 0 });
+    expect(noteHumanInput(SID, '')).toBe(false);
+    expect(getAgentState(SID)?.state).toBe('idle');
+  });
+});

--- a/tests/unit/workspace-status.test.ts
+++ b/tests/unit/workspace-status.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+
+import { resolveStatusText, statusClassFor, StatusTextInputs } from '../../src/renderer/components/Sidebar/workspace-status';
+
+/** The component passes the real translator; the fallback text is what we assert on. */
+const t = ((_key: string, fallback?: string) => fallback ?? _key) as never;
+
+function inputs(over: Partial<StatusTextInputs> = {}): StatusTextInputs {
+  return {
+    runningAgentCount: 0,
+    agentTotal: 0,
+    sessionCount: 0,
+    workingSessions: 0,
+    blockedSessions: 0,
+    currentToolLabel: null,
+    claudeIsIdle: false,
+    ...over,
+  };
+}
+
+describe('resolveStatusText — declared work outranks the shell', () => {
+  // The regression. One agent pane, which has DECLARED runDepth>0 over the
+  // pipe, mid-turn. No tool label is live because PostToolUse only fires when a
+  // tool FINISHES — during a stretch of thinking, or one slow tool, the label's
+  // freshness window lapses while the turn is very much still running.
+  //
+  // `workingSessions` used to be consulted ONLY inside the `sessionCount >= 2`
+  // branch, so a single session fell past it, past the null tool label, past
+  // claudeIsIdle (false — it early-returns unless the shell says "running"),
+  // and landed on the shell's own state. A shell reporting idle (the Claude
+  // Code TUI is not a "running command") then rendered the row "Idle" while the
+  // agent worked — the authoritative signal computed, then dropped.
+  it('a single working session is not reported as Idle by the shell state', () => {
+    const s = inputs({ sessionCount: 1, workingSessions: 1, shellState: 'idle' });
+    expect(resolveStatusText(s, t)).toBe('Running…');
+  });
+
+  it('holds even when the shell says nothing at all', () => {
+    const s = inputs({ sessionCount: 1, workingSessions: 1 });
+    expect(resolveStatusText(s, t)).toBe('Running…');
+  });
+
+  it('a live tool label is kept — it is strictly more informative', () => {
+    const s = inputs({
+      sessionCount: 1, workingSessions: 1, currentToolLabel: 'Reading file...', shellState: 'idle',
+    });
+    expect(resolveStatusText(s, t)).toBe('Reading file...');
+  });
+
+  it('a done notification still wins once the session stops working', () => {
+    const s = inputs({ sessionCount: 1, workingSessions: 0, shellState: 'idle', notificationText: 'build ok' });
+    expect(resolveStatusText(s, t)).toBe('Done: build ok');
+  });
+});
+
+describe('resolveStatusText — established precedence is unchanged', () => {
+  it('a manual override beats everything', () => {
+    expect(resolveStatusText(inputs({ statusOverride: 'idle', sessionCount: 1, workingSessions: 1 }), t)).toBe('Idle');
+    expect(resolveStatusText(inputs({ statusOverride: 'running' }), t)).toBe('Running');
+  });
+
+  it('a blocked pane outranks a working one — it is the thing needing the user', () => {
+    const s = inputs({ sessionCount: 2, workingSessions: 1, blockedSessions: 1 });
+    expect(resolveStatusText(s, t)).toBe('Needs you');
+    expect(resolveStatusText({ ...s, blockedSessions: 3 }, t)).toBe('Needs you · 3');
+  });
+
+  it('orchestration summary outranks the session summary', () => {
+    const s = inputs({ runningAgentCount: 2, agentTotal: 3, sessionCount: 1, workingSessions: 1 });
+    expect(resolveStatusText(s, t)).toBe('Orchestrating · 3 agents');
+  });
+
+  it('multiple sessions still summarize rather than showing one row Running', () => {
+    expect(resolveStatusText(inputs({ sessionCount: 3, workingSessions: 2 }), t))
+      .toBe('Claude · 2/3 running');
+    // Every session stopped — the summary is the authority, not the shell.
+    expect(resolveStatusText(inputs({ sessionCount: 3, workingSessions: 0, shellState: 'running' }), t))
+      .toBe('Idle');
+  });
+
+  it('claudeIsIdle stops a busy shell from reading as Running', () => {
+    const s = inputs({ sessionCount: 1, workingSessions: 0, claudeIsIdle: true, shellState: 'running' });
+    expect(resolveStatusText(s, t)).toBe('Idle');
+  });
+
+  it('falls back to the shell when no session is tracked at all', () => {
+    expect(resolveStatusText(inputs({ shellState: 'running' }), t)).toBe('Running');
+    expect(resolveStatusText(inputs({ shellState: 'interrupted' }), t)).toBe('Interrupted');
+    expect(resolveStatusText(inputs(), t)).toBe('Idle');
+  });
+});
+
+describe('statusClassFor — the colour must not contradict the words', () => {
+  // The two chains are written out separately and drifted apart once already.
+  // A single working session used to render "Idle" in text AND the `--done`
+  // style in colour; both had `workingSessions` gated behind `sessionCount>=2`.
+  it('a single working session is styled working, not done', () => {
+    const s = inputs({ sessionCount: 1, workingSessions: 1, shellState: 'idle' });
+    expect(statusClassFor(s)).toBe('workspace-row__status--working');
+  });
+
+  it('never says Running… while painting an idle/done colour', () => {
+    const cases: StatusTextInputs[] = [
+      inputs({ sessionCount: 1, workingSessions: 1, shellState: 'idle' }),
+      inputs({ sessionCount: 1, workingSessions: 1 }),
+      inputs({ sessionCount: 1, workingSessions: 1, shellState: 'running' }),
+      inputs({ sessionCount: 2, workingSessions: 1, shellState: 'idle' }),
+    ];
+    for (const s of cases) {
+      const text = resolveStatusText(s, t);
+      const cls = statusClassFor(s);
+      expect({ text, cls }).toMatchObject({ cls: 'workspace-row__status--working' });
+      expect(text).not.toBe('Idle');
+    }
+  });
+
+  it('blocked is its own colour, outranking a concurrent run', () => {
+    expect(statusClassFor(inputs({ sessionCount: 2, workingSessions: 1, blockedSessions: 1 })))
+      .toBe('workspace-row__status--blocked');
+  });
+
+  it('an idle session with a busy shell stays idle, not running', () => {
+    const s = inputs({ sessionCount: 1, workingSessions: 0, claudeIsIdle: true, shellState: 'running' });
+    expect(statusClassFor(s)).toBe('workspace-row__status--idle');
+    expect(resolveStatusText(s, t)).toBe('Idle');
+  });
+
+  it('with no session tracked the shell still drives the colour', () => {
+    expect(statusClassFor(inputs({ shellState: 'running' }))).toBe('workspace-row__status--running');
+    expect(statusClassFor(inputs({ shellState: 'interrupted' }))).toBe('workspace-row__status--interrupted');
+    expect(statusClassFor(inputs({ shellState: 'idle' }))).toBe('workspace-row__status--done');
+    expect(statusClassFor(inputs())).toBe('workspace-row__status--idle');
+  });
+});


### PR DESCRIPTION
Follow-up to #151, on top of the 0.48.0 rewrite.

That change is what made the rest of this findable — once wmux could hear a turn *start*, the status became reliable enough that the remaining wrong readings had a shape instead of feeling random. I've been running it as my daily driver since, first on 0.48.0 and then on 0.50.0, mostly with several Claude panes going at once. Four narrower paths turned up in that use, and each one still surfaces as a symptom from my original report.

None of this changes the model 0.48.0 established. It's the same hook-driven design, extended to a few shapes that don't come up until you lean on it: one agent pane instead of several, background shells, parallel subagents, and interrupts.

Four commits, in dependency order. They're independent enough to be reviewed one at a time, and I'm happy to split any of them out.

| # | Edge case | What you see |
|---|---|---|
| 1 | Single-session path doesn't reach `workingSessions` | one agent pane reads **Idle** mid-turn |
| 2 | Three cases in the hook bridge | turns age out of `working`; **Needs you** on a pane nobody touched; Escape leaves `working` set |
| 3 | `SubagentStop` can arrive after `Stop` | pane stays on **Running** after the agent is idle |
| 4 | Tool-lifecycle events clear `awaitingHuman` | a question on screen while the row says **Running…** |

---

## 1. Read declared session state in the single-session case

`workingSessions` — the count of panes whose *declared* state is `working` — is consulted inside the `sessionCount >= 2` branch of `claudeStatusText`. The single-pane case, which is the common shape, doesn't reach it yet.

It falls through to priority 1, the tool label. `PostToolUse` fires when a tool *finishes*, so during a stretch of thinking or one slow tool the label expires while the turn runs on. The chain then reaches shell state at priority 3, and the Claude Code TUI isn't a "running command" as far as shell integration is concerned — so the row renders **Idle** mid-turn.

The per-session sub-line directly beneath it reads "Running…" at that same moment, from the same store, because `sessionDetailText` already consults it. So the data is there and correct; it's the workspace-level chain that doesn't reach it.

Priority 1.5 closes it: below the tool label, which says more ("Reading file…"), and above everything after it, so the agent's own claim outranks the decaying inferences wmux makes about it.

**Why this commit is ~280 lines and not 3.** The status *text* chain and the status *colour* chain are written out twice in `WorkspaceRow.tsx`, and the single-session case sits in both — which is why this shows up as a colour mismatch about as often as a wrong word. I pulled both into `src/renderer/components/Sidebar/workspace-status.ts` and fed them from one shared input object, with the invariant written down. Side by side in one file, a priority added to one is visibly missing from the other. It's also the part worth testing and it couldn't be tested inside the component; 15 tests now pin it, including that the two chains agree.

Pure extraction otherwise — no behaviour change beyond priority 1.5. `WorkspaceRow.tsx` gets ~110 lines shorter as a result.

If you'd rather keep the chains inline, the behavioural part is a few lines and I can resubmit it that way.

## 2. Three edge cases in the hook bridge

**The per-tool `PostToolUse` hooks don't reach agent state.** `handleHookEvent` gates on `params.event`, and the `PostToolUse` entries `claude-context.ts` installs invoke the hook helper by bare tool name, which sends `{ tool }` with no `event` field. Those get dropped before reaching the bridge, so `case 'PostToolUse'` in `agent-hook-bridge.ts` isn't currently reached.

Since 0.48.0 that no longer costs the run itself — matcher-less `PreToolUse` declares it at the start of every tool, which is the important half. It still costs the other end: `PostToolUse` is the only report that arrives between approving a permission prompt and the turn closing, and it carries the freshness stamp that keeps a long turn inside the trust window. Without it, a turn spent in tracked tools ages out of `working` on the clock alone.

I handled it in the main process rather than by teaching the helper to send `event`, since hooks are written into `settings.json` once at install — the bare-tool form is already out in every existing config, and will keep arriving from helper vintages this build doesn't control. Open to the other direction if you'd prefer the helper be the source of truth.

**The 60s idle nudge reads as "Needs you".** `Notification` covers two unrelated things: a permission/question prompt, and the ~60s "Claude is waiting for your input" nudge armed when a turn *ends*. Parking the pane for both means a pane nobody has touched starts asking for attention a minute after it goes quiet. I hit it that way: a session was `/clear`'d and left alone, and 60s after its `Stop` the sidebar read **Needs you** with an empty conversation and nothing to answer.

Told apart by **state, not by message text**. Text-sniffing would break the day Claude Code rewords a prompt, and it would fail in the dangerous direction. A prompt can only occur inside a live turn, and `UserPromptSubmit`/`PreToolUse` both declare depth 1 before Claude Code can ask anything — so depth 0 means the turn is over.

Gated twice against reading too much into a default: on having seen an opening hook fire at all (a pre-0.48.0 `settings.json` sits at depth 0 through a whole turn), and on the pane actually having a record (a main process restarted mid-turn has none). In either of those cases it parks the pane, exactly as today.

That gating is also what keeps `noteHumanInput`'s bargain sound. It clears a block when the human types, and leans on "if the keystroke didn't satisfy the agent, the 60-second nudge puts the pane back to asking" — which works as long as the nudge doesn't also assert a block on a pane that has finished. The nudge still re-asserts inside a live turn, which is the case self-heal needs, and no longer outside one.

**Escape can leave a run asserted.** `noteHumanInput` treats a bare Escape as answering, so it clears `blocked` — but an interrupt mid-run leaves `working` set for a turn the user cancelled. Claude Code fires no hook on interrupt: `updatedAt` is byte-identical before and after, so there's no report to act on rather than a stale one. The pane keeps claiming `working` until the next prompt or the 15-minute trust window.

I matched on the single ESC byte exactly, rather than reusing `isAnsweringInput`'s "contains a bare ESC": Alt+key also arrives as ESC followed by a character, and reading that as an interrupt would retract a run nobody stopped. It only ever *clears*, and only for a pane that has declared something — so a plain shell is untouched, and a wrong guess under-reports for exactly one event.

## 3. Guard against a trailing `SubagentStop`

`SubagentStop` maps to an unconditional `runDepth: 1`, which is right when Claude Code fires the parent's `Stop` only after every subagent has stopped.

Traced at the hook helper on two independent panes here, the wire order came out the other way round: `Stop` first, `SubagentStop` **1.8–2.2s later**. In that order the trailing report re-asserts the run `Stop` had just ended, and the pane stays on **Running** — with the agent idle at its prompt — until the 15-minute trust window expires.

I'd expect this ordering to vary by Claude Code version and by how the subagent exits, so I wrote it as a **guard on top of the existing mapping rather than a replacement for it**: when `Stop` hasn't fired, behaviour is exactly as before. A subagent finishing may *sustain* a turn; it may never *start* one, and the current depth is the fact that separates the two.

I looked at whether the wall-clock gate in `agent-state.ts` could cover it, and I don't think it should. That gate drops reports *older* than what's been accepted, which is the right defence against two hook processes racing to the pipe — and this isn't a race, the trailing report is genuinely newer.

This also covers a second symptom that follows from the re-assertion: with depth back at 1, the 60s idle `Notification` no longer qualified as a nudge under (2), so a pane with nothing to answer went on to claim **Needs you** a minute later.

## 4. Keep a live question while background work runs

This is the one that finally explained my original report to me. An agent that starts a background shell and then asks the user a question shows **Running…** with the question still on screen, and nothing corrects it until the turn ends.

`PreToolUse`, `PostToolUse` and `SubagentStop` each report `awaitingHuman: false` alongside their run depth. For `PostToolUse` the reasoning in the comment is sound as written — a pending permission dialog would have stopped the tool from running at all — and it holds for an agent doing one thing at a time. It comes apart for the two things agents do most: a background shell and a parallel subagent both inherit the pane's `WMUX_SURFACE_ID`, so their tool lifecycle reports to the surface that's asking, and each event clears the block on the way past. Nothing re-asserts it, because the 60s idle `Notification` is only armed after a turn *ends*, and the turn is still open.

Those three events now report `runDepth` only. `runDepth` and `awaitingHuman` are independent facts, and the tool lifecycle speaks to the first. A block is ended by `UserPromptSubmit`, `Stop`, a keystroke in the pane (`noteHumanInput`), or an explicit report — the things that know a human dealt with it.

`resolveState` already ranks `blocked` above `runDepth > 0`, so a pane reads "needs you" **while** its background work keeps running, which is the state my report was describing.

**One trade-off I want to put in front of you rather than bury:** a prompt answered through `wmux answer-agent` (a relay, not a local keystroke) keeps saying "needs you" until the turn ends, rather than until the next tool. That's `answerAgent`'s rule 3 working as designed — answering never clears `blocked` — and `answeredAt` is what the UI shows in the meantime. I think it errs on the right side, but it *is* a change on the relay path, and it's your call. Happy to drop this commit and ship the other three if you'd rather keep the current behaviour there.

---

## Verification

- `npx vitest run` → **915 passed, 78 files** (881 in 77 on `master`). 34 tests added.
- `npm run build:main` clean.
- `npm run lint` → 17 errors / 15 warnings, **identical to unmodified `master`**. All pre-existing — I left them alone rather than mix a lint sweep into this.
- Rebased onto `master` at 0.50.0 (`8122b69`), no conflicts.

Live end-to-end, on a build of this branch: started two background shells, then asked a question. Polled `wmux agent-state` 300×: 72 samples `working`, then 228 samples `blocked "Claude needs your permission"`, with `runDepth` staying `1` throughout the blocked stretch, returning to `working` only after I answered. Sidebar read **Needs you** the whole time. That's (4).

(3) was traced at the hook helper across two panes; (2)'s Escape case by comparing `updatedAt` byte-for-byte before and after an interrupt.

## Not in this PR

- **No version bump.** `package.json` and `package-lock.json` are untouched.
- **No renderer test harness.** The 15 status tests cover the extracted chains as pure functions; the component wiring isn't tested, because vitest runs `environment: 'node'` with no jsdom here and adding one isn't a bug fix. Glad to do it as its own PR if you want that pinned down.
- **A notification-ring issue** I found while testing this — the attention ring not clearing when you type into the pane it's pointing at. Unrelated to agent state and shares no files, so it's a separate PR rather than a passenger here.

Thanks for 0.48.0 and for the detailed write-up on the issue — that's what let me go looking in the right places. Happy to rework any of this to fit how you'd rather it be shaped.
