### PR TITLE
fix(notifications): dismiss the attention ring on interaction, not on refocus

### DIFF
--- a/src/renderer/components/SplitPane/PaneWrapper.tsx
+++ b/src/renderer/components/SplitPane/PaneWrapper.tsx
@@ -8,6 +8,7 @@ import DiffPane from '../Diff/DiffPane';
 import NotificationRing from '../Terminal/NotificationRing';
 import SurfaceTabBar from './SurfaceTabBar';
 import { useStore } from '../../store';
+import { keyDismissesAttention } from './attention-dismiss';
 import type { SurfaceDragCommitOptions, SurfaceDragPayload, SurfaceDragPreviewTarget } from './drag-preview-types';
 import {
   getSurfaceDragDropDecision,
@@ -64,6 +65,9 @@ export default function PaneWrapper({
 
   const surfaceIds = useMemo(() => surfaces.map((s) => s.id), [surfaces]);
 
+  // Root element — the attention ring's interaction listeners hang off it.
+  const paneRef = useRef<HTMLDivElement>(null);
+
   const hasUnread = useMemo(
     () => notifications.some((n) => !n.read && surfaceIds.includes(n.surfaceId as SurfaceId)),
     [notifications, surfaceIds],
@@ -99,14 +103,54 @@ export default function PaneWrapper({
     prevUnreadCount.current = currentCount;
   }, [unreadCount]);
 
-  // When pane receives focus, mark all surfaces as read
+  const markPaneRead = useCallback(() => {
+    for (const surfaceId of surfaceIds) markRead(surfaceId as SurfaceId);
+  }, [surfaceIds, markRead]);
+
+  // When pane receives focus, mark all surfaces as read.
+  //
+  // Deliberately keyed on the focus TRANSITION and nothing else. Adding
+  // `hasUnread` here is the tempting one-word fix for the stuck ring below, and
+  // it is wrong: the effect would then run on the same render the notification
+  // arrives, so a pane you are already looking at would clear its ring before
+  // ever painting it — no glow, and the 950ms flash above cut off mid-animation.
+  // That trades a ring that will not leave for one you can never see.
+  //
+  // Still needed alongside the interaction listener: switching panes by keyboard
+  // (Ctrl+Alt+arrow) lands no click and no keystroke inside the new pane.
   useEffect(() => {
-    if (isFocused && hasUnread) {
-      for (const surfaceId of surfaceIds) {
-        markRead(surfaceId as SurfaceId);
-      }
-    }
+    if (isFocused && hasUnread) markPaneRead();
   }, [isFocused]);
+
+  // ...and clear it on actual INTERACTION, which is the case focus alone misses.
+  //
+  // A notification that arrives while the pane is ALREADY focused never changes
+  // `isFocused`, so the effect above does not re-run and the ring sits there
+  // while the user types into the very pane it is pointing at. The only way out
+  // was to click another pane and click back — manufacturing the transition by
+  // hand.
+  //
+  // Capture phase is load-bearing for keydown: xterm's hidden helper textarea is
+  // a descendant of this element and consumes the event, so a bubble-phase
+  // listener here would never see a keystroke — only clicks would dismiss, and
+  // typing (the exact case reported) still would not.
+  //
+  // Attached only while there is something to dismiss, so the common case costs
+  // no listeners at all.
+  useEffect(() => {
+    const el = paneRef.current;
+    if (!hasUnread || !el) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (keyDismissesAttention(e.key)) markPaneRead();
+    };
+    el.addEventListener('keydown', onKeyDown, true);
+    el.addEventListener('mousedown', markPaneRead, true);
+    return () => {
+      el.removeEventListener('keydown', onKeyDown, true);
+      el.removeEventListener('mousedown', markPaneRead, true);
+    };
+  }, [hasUnread, markPaneRead]);
 
   // Keyboard shortcut listeners for find (Ctrl+F) and copy mode (Ctrl+Alt+[)
   useEffect(() => {
@@ -570,7 +614,10 @@ export default function PaneWrapper({
   };
 
   return (
-    <div className={`pane-wrapper ${isFocused ? 'pane-wrapper--focused' : ''} ${dragActive ? 'pane-wrapper--drag-active' : ''}`}>
+    <div
+      ref={paneRef}
+      className={`pane-wrapper ${isFocused ? 'pane-wrapper--focused' : ''} ${dragActive ? 'pane-wrapper--drag-active' : ''}`}
+    >
       <SurfaceTabBar
         paneId={paneId}
         workspaceShell={workspace?.shell}

--- a/src/renderer/components/SplitPane/attention-dismiss.ts
+++ b/src/renderer/components/SplitPane/attention-dismiss.ts
@@ -1,0 +1,31 @@
+/**
+ * What counts as "the user dealt with this pane" for the attention ring.
+ *
+ * Extracted from PaneWrapper for the same reason as workspace-status.ts: the
+ * rule is the part worth testing, and it is invisible in a type check. The ring
+ * is a claim that a pane wants you; anything that dismisses it is asserting the
+ * user has seen it, so a rule that is too eager silently swallows the one signal
+ * the feature exists to deliver.
+ */
+
+/**
+ * Keys that are only ever pressed on the way to something else.
+ *
+ * A bare modifier is not an interaction with the pane — it is the first half of
+ * a chord, and plenty of those (Ctrl+Alt+arrow to switch panes, Alt to reach a
+ * menu) are the user leaving rather than engaging. Dismissing on keydown of the
+ * modifier itself would clear the ring a beat before the user's attention
+ * actually arrives, which is the failure this set exists to prevent.
+ *
+ * The chord's own terminating key still dismisses, and that is correct: it was
+ * typed into this pane.
+ */
+const BARE_MODIFIERS = new Set([
+  'Shift', 'Control', 'Alt', 'Meta', 'AltGraph', 'OS',
+  'CapsLock', 'NumLock', 'ScrollLock', 'Fn', 'FnLock', 'Hyper', 'Super',
+]);
+
+/** True when a keydown of `key` should clear the pane's attention ring. */
+export function keyDismissesAttention(key: string): boolean {
+  return !!key && !BARE_MODIFIERS.has(key);
+}

--- a/tests/unit/attention-dismiss.test.ts
+++ b/tests/unit/attention-dismiss.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { keyDismissesAttention } from '../../src/renderer/components/SplitPane/attention-dismiss';
+
+describe('keyDismissesAttention', () => {
+  it('ordinary typing dismisses the ring', () => {
+    for (const key of ['a', 'Z', '1', ' ', 'Enter', 'Backspace', 'ArrowDown', 'F5', 'Escape']) {
+      expect(keyDismissesAttention(key)).toBe(true);
+    }
+  });
+
+  it('a bare modifier does not', () => {
+    // The first half of a chord is not engagement with the pane. Several of
+    // those chords are the user LEAVING it (Ctrl+Alt+arrow switches panes), so
+    // dismissing on the modifier's own keydown clears the ring a beat before
+    // the user's attention actually arrives.
+    for (const key of ['Shift', 'Control', 'Alt', 'Meta', 'AltGraph', 'CapsLock']) {
+      expect(keyDismissesAttention(key)).toBe(false);
+    }
+  });
+
+  it('the terminating key of a chord still does — it was typed into this pane', () => {
+    // Ctrl+C arrives as two events: 'Control' (ignored above) then 'c'.
+    expect(keyDismissesAttention('c')).toBe(true);
+  });
+
+  it('an empty key is not an interaction', () => {
+    expect(keyDismissesAttention('')).toBe(false);
+  });
+});


### PR DESCRIPTION
Small one. The blue attention ring stays lit while you type into the very pane it's pointing at — the way to clear it is to click a different pane and click back.

Unrelated to #151 (this is the notification ring, not the sidebar status). I found it while testing that work and split it out, since it shares no files.

## Cause

`PaneWrapper`'s clear-on-focus effect reads `hasUnread` but lists only `[isFocused]` as its dependency, so it runs on the focus *transition*:

```ts
useEffect(() => {
  if (isFocused && hasUnread) { /* mark read */ }
}, [isFocused]);
```

A notification that arrives while the pane is *already* focused flips `hasUnread` true without touching `isFocused`, so the effect doesn't re-run and the ring stays. Clicking away and back is the user manufacturing that missing transition by hand — which is why the workaround works.

## Why I didn't take the one-line version

Adding `hasUnread` to that dependency array is the obvious fix, but it trades one problem for another: the effect would then run on the same render the notification arrives, so a pane you're already looking at clears its ring before ever painting it. No glow, and the 950ms `justFired` flash cut off mid-animation. That swaps a ring that won't leave for a ring you can never see.

## Fix

The ring is dismissed by **interaction**, which is closer to what "I dealt with it" means: a keydown or mousedown inside the pane, via listeners attached only while there's something to dismiss.

Two details in there are load-bearing:

**Capture phase for keydown.** xterm's hidden helper textarea is a descendant of the pane element and consumes the event, so a bubble-phase listener would see clicks but never a keystroke — which would leave the reported case (typing) broken while looking fixed.

**Bare modifiers don't dismiss** (`attention-dismiss.ts`). A lone Shift or Control is the first half of a chord, and several of those chords are the user *leaving* the pane — Ctrl+Alt+arrow switches panes — so clearing on the modifier's own keydown would drop the ring just before the user's attention arrives. The chord's terminating key still dismisses, because that was typed here.

The rule lives in its own module because it's the part worth testing and it's invisible in a type check.

## What stays the same

The focus effect is kept as-is — it isn't redundant, since switching panes by keyboard lands no click and no keystroke inside the pane it moves to.

Marking every surface in the pane read is unchanged from the existing focus behaviour, and deliberate: the ring's visibility is per-pane, so clearing only the active tab would leave it lit after the user had plainly interacted.

## Verification

- `npx vitest run` → **885 passed, 78 files** (881 in 77 on `master`). 4 tests added, covering the dismissal rule.
- `npm run build:main` clean.
- `npm run lint` → 17 errors / 15 warnings, identical to unmodified `master`. All pre-existing.
- Based directly on `master` at 0.50.0 (`8122b69`); no `package.json` changes.

**Coverage gap I'd rather flag than have you find:** the 4 new tests cover the dismissal *rule* (`keyDismissesAttention`, a pure function — which is why it's in its own module), but not the listener wiring. There's no renderer test harness here — vitest runs `environment: 'node'` with no jsdom — and introducing one seemed out of scope for a bug fix.

So the capture-phase behaviour is verified by hand rather than by CI: on Windows 11, a pane ringed while already focused clears on the next keystroke. That's the case that matters, because a click-only check would pass even if the capture-phase detail were wrong — xterm's helper textarea would still let the mousedown through — while the reported behaviour stayed broken.

If you'd like a jsdom harness added so this can be pinned properly, happy to do that as its own PR rather than fold it in here.
