### PR TITLE
fix(security): use safer defaults for agent integrations

### DIFF
--- a/resources/wmux-orchestrator/README.md
+++ b/resources/wmux-orchestrator/README.md
@@ -55,6 +55,21 @@ Run it:
 /wmux:orchestrate "Refactor the auth system to use JWT tokens"
 ```
 
+Claude workers keep their normal tool permission prompts by default. To bypass
+them for a trusted task, opt in explicitly before starting wmux:
+
+```powershell
+[Environment]::SetEnvironmentVariable('WMUX_ORCHESTRATOR_SKIP_PERMISSIONS', '1', 'User')
+```
+
+This makes orchestrated Claude workers start with
+`--dangerously-skip-permissions`. Remove the variable to restore the safe
+default:
+
+```powershell
+[Environment]::SetEnvironmentVariable('WMUX_ORCHESTRATOR_SKIP_PERMISSIONS', $null, 'User')
+```
+
 What happens next:
 
 1. The orchestrator analyzes your codebase and builds a wave plan

--- a/resources/wmux-orchestrator/scripts/launch-agent.js
+++ b/resources/wmux-orchestrator/scripts/launch-agent.js
@@ -10,36 +10,46 @@
 const { execFileSync } = require('child_process');
 const fs = require('fs');
 
-const promptFile = process.argv[2];
-if (!promptFile) {
-  console.error('Usage: node launch-agent.js <prompt-file>');
-  process.exit(1);
-}
-
-if (!fs.existsSync(promptFile)) {
-  console.error(`Prompt file not found: ${promptFile}`);
-  process.exit(1);
-}
-
-const prompt = fs.readFileSync(promptFile, 'utf8');
-
-const agentCmd = (process.env.WMUX_AGENT_CMD || 'claude').toLowerCase();
-
-try {
-  if (agentCmd === 'opencode') {
-    // opencode run streams formatted progress; the user can watch.
-    // '--' stops flag parsing from consuming the prompt.
-    execFileSync('opencode', ['run', '--', prompt], { stdio: 'inherit' });
-  } else {
-    // --dangerously-skip-permissions: auto-approve all tools (interactive mode)
-    // '--' stops Commander.js variadic flags from consuming the prompt
-    // NOTE: do NOT use --bare — it skips keychain/OAuth and causes "Not logged in"
-    execFileSync('claude', [
-      '--dangerously-skip-permissions',
-      '--',
-      prompt
-    ], { stdio: 'inherit' });
+/** Build Claude's argv without bypassing its permission boundary by default. */
+function buildClaudeArgs(prompt, env = process.env) {
+  const args = [];
+  if (env.WMUX_ORCHESTRATOR_SKIP_PERMISSIONS === '1') {
+    args.push('--dangerously-skip-permissions');
   }
-} catch (e) {
-  process.exit(e.status || 1);
+  // '--' stops Commander.js variadic flags from consuming the prompt.
+  args.push('--', prompt);
+  return args;
 }
+
+function main() {
+  const promptFile = process.argv[2];
+  if (!promptFile) {
+    console.error('Usage: node launch-agent.js <prompt-file>');
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(promptFile)) {
+    console.error(`Prompt file not found: ${promptFile}`);
+    process.exit(1);
+  }
+
+  const prompt = fs.readFileSync(promptFile, 'utf8');
+  const agentCmd = (process.env.WMUX_AGENT_CMD || 'claude').toLowerCase();
+
+  try {
+    if (agentCmd === 'opencode') {
+      // opencode run streams formatted progress; the user can watch.
+      // '--' stops flag parsing from consuming the prompt.
+      execFileSync('opencode', ['run', '--', prompt], { stdio: 'inherit' });
+    } else {
+      // NOTE: do NOT use --bare — it skips keychain/OAuth and causes "Not logged in".
+      execFileSync('claude', buildClaudeArgs(prompt), { stdio: 'inherit' });
+    }
+  } catch (e) {
+    process.exit(e.status || 1);
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = { buildClaudeArgs };

--- a/src/main/agent-integration.ts
+++ b/src/main/agent-integration.ts
@@ -3,9 +3,9 @@
  *
  * wmux integrates with Claude Code, OpenCode and Kiro by editing files in the
  * user's home: it appends a block to ~/.claude/CLAUDE.md and
- * ~/.config/opencode/AGENTS.md, writes ~/.kiro/steering/wmux.md, registers four
- * hooks in ~/.claude/settings.json, points chrome-devtools-mcp at its own CDP
- * proxy, and installs the orchestrator plugin into Claude Code's plugin cache.
+ * ~/.config/opencode/AGENTS.md, writes ~/.kiro/steering/wmux.md, registers eight
+ * hook families in ~/.claude/settings.json, points chrome-devtools-mcp at its
+ * own CDP proxy, and installs Claude Code and OpenCode orchestrator plugins.
  *
  * All of that used to happen unconditionally on every launch, with no prompt and
  * no record of a decision — so deleting any of it was futile, because the next
@@ -76,6 +76,25 @@ const ALL_ON: Record<IntegrationFeature, boolean> = {
 };
 
 export const DEFAULT_CONSENT: IntegrationConsent = { decision: 'unset', features: { ...ALL_ON } };
+
+/** Exact disclosure shown before wmux writes outside its own data directory. */
+export const INTEGRATION_CONSENT_DETAIL =
+  'wmux can teach your coding agents to drive its browser panel, markdown views ' +
+  'and sidebar status. Doing so edits files in your home directory:\n\n' +
+  '  • ~/.claude/CLAUDE.md and ~/.config/opencode/AGENTS.md\n' +
+  '      a wmux section, between markers, leaving your own text untouched\n' +
+  '  • ~/.kiro/steering/wmux.md\n' +
+  '      a steering file of wmux\'s own; your other Kiro steering is untouched\n' +
+  '  • ~/.claude/settings.json\n' +
+  '      eight hook families: PostToolUse, Notification, Stop, SubagentStop,\n' +
+  '      SessionStart, UserPromptSubmit, PreToolUse and SessionEnd\n' +
+  '  • ~/.claude/plugins/ and ~/.config/opencode/plugin/wmux.js\n' +
+  '      the wmux-orchestrator plugins\n' +
+  '  • ~/.claude/settings.json\n' +
+  '      a pinned chrome-devtools-mcp pointed at the browser panel instead of its own Chrome\n\n' +
+  '"Not now" asks again next launch. "Never" writes nothing and removes anything ' +
+  'a previous version added. You can change this any time, feature by feature, ' +
+  'in Settings → General.';
 
 /**
  * Normalise whatever is on disk into a usable consent record.
@@ -173,22 +192,7 @@ export async function promptForConsent(parent?: Electron.BrowserWindow): Promise
       cancelId: 1,
       title: 'wmux — agent integration',
       message: 'Let wmux set up Claude Code, OpenCode and Kiro?',
-      detail:
-        'wmux can teach your coding agents to drive its browser panel, markdown views ' +
-        'and sidebar status. Doing so edits files in your home directory:\n\n' +
-        '  • ~/.claude/CLAUDE.md and ~/.config/opencode/AGENTS.md\n' +
-        '      a wmux section, between markers, leaving your own text untouched\n' +
-        '  • ~/.kiro/steering/wmux.md\n' +
-        '      a steering file of wmux\'s own; your other Kiro steering is untouched\n' +
-        '  • ~/.claude/settings.json\n' +
-        '      four hooks that drive the sidebar and "needs you" notifications\n' +
-        '  • ~/.claude/plugins/\n' +
-        '      the wmux-orchestrator plugin\n' +
-        '  • ~/.claude/settings.json\n' +
-        '      chrome-devtools-mcp pointed at the browser panel instead of its own Chrome\n\n' +
-        '"Not now" asks again next launch. "Never" writes nothing and removes anything ' +
-        'a previous version added. You can change this any time, feature by feature, ' +
-        'in Settings → General.',
+      detail: INTEGRATION_CONSENT_DETAIL,
       noLink: true,
     };
     // Parent it to the app window when there is one, so the question arrives

--- a/src/main/claude-context.ts
+++ b/src/main/claude-context.ts
@@ -442,6 +442,21 @@ export function removeClaudeHooks(): void {
 }
 
 /**
+ * Version selected for this wmux release. Do not use a mutable npm dist-tag
+ * here: this command is persisted in Claude's settings and may execute long
+ * after the wmux release that wrote it.
+ */
+export const CHROME_DEVTOOLS_MCP_PACKAGE = 'chrome-devtools-mcp@1.7.0';
+
+/** Build the custom MCP server entry written to Claude's settings. */
+export function buildChromeDevtoolsMcpServer(): { command: string; args: string[] } {
+  return {
+    command: 'npx',
+    args: ['-y', CHROME_DEVTOOLS_MCP_PACKAGE, '--browserUrl=http://127.0.0.1:9222'],
+  };
+}
+
+/**
  * Configures chrome-devtools-mcp to connect to wmux's CDP proxy on localhost:9222.
  * Disables the plugin version and adds a custom MCP server in settings.json with
  * --browserUrl pointing to wmux. This is more reliable than modifying the plugin cache.
@@ -467,11 +482,9 @@ export function ensureChromeDevtoolsConfig(): void {
     // Add as custom MCP server with --browserUrl
     if (!settings.mcpServers) settings.mcpServers = {};
     const existing = settings.mcpServers['chrome-devtools'];
-    if (!existing || !JSON.stringify(existing).includes('9222')) {
-      settings.mcpServers['chrome-devtools'] = {
-        command: 'npx',
-        args: ['-y', 'chrome-devtools-mcp@latest', '--browserUrl=http://127.0.0.1:9222'],
-      };
+    const desired = buildChromeDevtoolsMcpServer();
+    if (JSON.stringify(existing) !== JSON.stringify(desired)) {
+      settings.mcpServers['chrome-devtools'] = desired;
       changed = true;
     }
 

--- a/tests/unit/agent-integration.test.ts
+++ b/tests/unit/agent-integration.test.ts
@@ -1,8 +1,23 @@
 import { describe, it, expect } from 'vitest';
-import { applyWmuxHooks, removeWmuxHooks, stripWmuxBlock } from '../../src/main/claude-context';
-import { parseConsent, INTEGRATION_FEATURES } from '../../src/main/agent-integration';
+import { createRequire } from 'node:module';
+import {
+  applyWmuxHooks,
+  buildChromeDevtoolsMcpServer,
+  CHROME_DEVTOOLS_MCP_PACKAGE,
+  removeWmuxHooks,
+  stripWmuxBlock,
+} from '../../src/main/claude-context';
+import {
+  parseConsent,
+  INTEGRATION_CONSENT_DETAIL,
+  INTEGRATION_FEATURES,
+} from '../../src/main/agent-integration';
 
 const HOOK = '/res/cli/wmux-hook.js';
+const require = createRequire(import.meta.url);
+const { buildClaudeArgs } = require('../../resources/wmux-orchestrator/scripts/launch-agent.js') as {
+  buildClaudeArgs: (prompt: string, env?: NodeJS.ProcessEnv) => string[];
+};
 
 // Issue #132: wmux wrote into ~/.claude on every launch with no prompt and no
 // record of a decision, so deleting any of it was futile — the next launch put
@@ -129,5 +144,38 @@ describe('parseConsent (issue #132)', () => {
   it('ignores a non-boolean feature value rather than trusting it', () => {
     const c = parseConsent({ decision: 'granted', features: { hooks: 'nope' } });
     expect(c.features.hooks).toBe(true);
+  });
+});
+
+describe('safe agent integration defaults', () => {
+  it('pins chrome-devtools-mcp to an exact version', () => {
+    expect(CHROME_DEVTOOLS_MCP_PACKAGE).toMatch(/^chrome-devtools-mcp@\d+\.\d+\.\d+$/);
+    expect(CHROME_DEVTOOLS_MCP_PACKAGE).not.toContain('@latest');
+    expect(buildChromeDevtoolsMcpServer()).toEqual({
+      command: 'npx',
+      args: ['-y', CHROME_DEVTOOLS_MCP_PACKAGE, '--browserUrl=http://127.0.0.1:9222'],
+    });
+  });
+
+  it('keeps Claude permission prompts by default', () => {
+    expect(buildClaudeArgs('do the task', {})).toEqual(['--', 'do the task']);
+  });
+
+  it('only bypasses permissions after an explicit opt-in', () => {
+    expect(buildClaudeArgs('do the task', { WMUX_ORCHESTRATOR_SKIP_PERMISSIONS: 'true' }))
+      .toEqual(['--', 'do the task']);
+    expect(buildClaudeArgs('do the task', { WMUX_ORCHESTRATOR_SKIP_PERMISSIONS: '1' }))
+      .toEqual(['--dangerously-skip-permissions', '--', 'do the task']);
+  });
+
+  it('discloses every hook family and modified plugin path', () => {
+    for (const event of [
+      'PostToolUse', 'Notification', 'Stop', 'SubagentStop',
+      'SessionStart', 'UserPromptSubmit', 'PreToolUse', 'SessionEnd',
+    ]) {
+      expect(INTEGRATION_CONSENT_DETAIL).toContain(event);
+    }
+    expect(INTEGRATION_CONSENT_DETAIL).toContain('~/.config/opencode/plugin/wmux.js');
+    expect(INTEGRATION_CONSENT_DETAIL).toContain('pinned chrome-devtools-mcp');
   });
 });


### PR DESCRIPTION
## Summary

- pin `chrome-devtools-mcp` to `1.7.0` instead of persisting the mutable `@latest` npm tag
- keep Claude's normal permission prompts for orchestrated workers by default
- retain `--dangerously-skip-permissions` behind the explicit `WMUX_ORCHESTRATOR_SKIP_PERMISSIONS=1` opt-in
- disclose all eight Claude hook families and the OpenCode plugin path in the integration consent dialog
- document the opt-in and add regression coverage for these defaults

## Why

The custom MCP command is stored in the user's global Claude settings and may run long after the wmux release that created it. Using `npx -y ...@latest` means future package contents can be downloaded and executed without a corresponding wmux code change.

The orchestrator also passed `--dangerously-skip-permissions` to every Claude worker. That removes the user confirmation boundary for shell commands and file access, including when an agent processes an untrusted repository or prompt.

This change preserves both capabilities while making the safer behavior the default.

## User impact

- Existing browser integration entries managed by wmux migrate from `@latest` to the pinned package version when integration settings are reconciled.
- Orchestrated Claude workers may ask for tool approval. Users who accept the risk for a trusted task can restore the former behavior by setting `WMUX_ORCHESTRATOR_SKIP_PERMISSIONS=1` before starting wmux.
- The first-run consent dialog now accurately lists every hook family and plugin file wmux installs.

## Validation

- `npm run typecheck` — passed
- `npm test -- --run tests/unit/agent-integration.test.ts` — 23/23 passed
- `node --check resources/wmux-orchestrator/scripts/launch-agent.js` — passed
- full `npm test -- --reporter=dot` — 880 passed, 5 failed

The five full-suite failures are all in `tests/unit/orchestration-status-vocab.test.ts` and reproduce the existing Bash path failure on this Windows environment (`bash: : No such file or directory`). They are unrelated to the files changed here.

## Out of scope

CDP authentication, dynamic CDP port propagation, updater signing enforcement and release-workflow hardening should remain separate changes because they require broader architectural or release-policy decisions.
