### PR TITLE
fix(terminal): route OSC 8 hyperlinks through wmux

### DIFF
--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -12,7 +12,7 @@ import { useT } from '../i18n';
 import { collectActiveTerminalSurfaceIds } from '../store/split-utils';
 import { SplitNode, ThemeConfig } from '../../shared/types';
 import { UserColorScheme } from '../store/settings-slice';
-import { openInWmuxBrowser } from '../utils/open-in-browser';
+import { activateTerminalLink, terminalLinkHandler } from '../utils/terminal-links';
 import { attachVisibleRenderer, RendererHandle } from '../utils/terminal-renderer';
 import { trimTrailingWhitespace } from '../utils/copy-text';
 import { handleShiftEnter, isShiftEnter } from './terminal-keys';
@@ -392,6 +392,7 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
       // enabled, or toggling it would require recreating every terminal.
       allowTransparency: true,
       allowProposedApi: true,
+      linkHandler: terminalLinkHandler,
       scrollback: prefs.scrollbackLines || 10000,
     });
 
@@ -408,10 +409,7 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
 
     // Create and load addons
     const fitAddon = new FitAddon();
-    const webLinksAddon = new WebLinksAddon((event, uri) => {
-      const forceExternal = !!(event as MouseEvent)?.ctrlKey || !!(event as MouseEvent)?.metaKey;
-      openInWmuxBrowser(uri, { forceExternal });
-    });
+    const webLinksAddon = new WebLinksAddon(activateTerminalLink);
     const searchAddon = new SearchAddon();
     const unicode11Addon = new Unicode11Addon();
     const imageAddon = new ImageAddon();

--- a/src/renderer/utils/terminal-links.ts
+++ b/src/renderer/utils/terminal-links.ts
@@ -1,0 +1,23 @@
+import type { ILinkHandler } from '@xterm/xterm';
+import { openInWmuxBrowser } from './open-in-browser';
+
+/** Route terminal links through wmux instead of xterm's window.open fallback. */
+export function activateTerminalLink(event: MouseEvent, uri: string): void {
+  let protocol: string;
+  try {
+    protocol = new URL(uri).protocol;
+  } catch {
+    return;
+  }
+
+  if (protocol !== 'http:' && protocol !== 'https:') return;
+
+  openInWmuxBrowser(uri, {
+    forceExternal: !!event?.ctrlKey || !!event?.metaKey,
+  });
+}
+
+/** xterm's OSC 8 link provider reads this from Terminal.options.linkHandler. */
+export const terminalLinkHandler: ILinkHandler = {
+  activate: activateTerminalLink,
+};

--- a/tests/unit/terminal-links.test.ts
+++ b/tests/unit/terminal-links.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { openInWmuxBrowser } = vi.hoisted(() => ({
+  openInWmuxBrowser: vi.fn(),
+}));
+
+vi.mock('../../src/renderer/utils/open-in-browser', () => ({
+  openInWmuxBrowser,
+}));
+
+import {
+  activateTerminalLink,
+  terminalLinkHandler,
+} from '../../src/renderer/utils/terminal-links';
+
+function mouseEvent(modifiers: Partial<Pick<MouseEvent, 'ctrlKey' | 'metaKey'>> = {}): MouseEvent {
+  return {
+    ctrlKey: false,
+    metaKey: false,
+    ...modifiers,
+  } as MouseEvent;
+}
+
+describe('terminal link handling', () => {
+  beforeEach(() => {
+    openInWmuxBrowser.mockReset();
+  });
+
+  it('opens ordinary HTTP(S) clicks in the wmux browser', () => {
+    activateTerminalLink(mouseEvent(), 'https://example.com/path');
+
+    expect(openInWmuxBrowser).toHaveBeenCalledWith('https://example.com/path', {
+      forceExternal: false,
+    });
+  });
+
+  it.each([
+    { ctrlKey: true },
+    { metaKey: true },
+  ])('opens modified clicks externally: %o', modifiers => {
+    activateTerminalLink(mouseEvent(modifiers), 'https://example.com');
+
+    expect(openInWmuxBrowser).toHaveBeenCalledWith('https://example.com', {
+      forceExternal: true,
+    });
+  });
+
+  it.each([
+    'javascript:alert(1)',
+    'data:text/html,<script>1</script>',
+    'file:///C:/Windows/win.ini',
+    'not a URL',
+  ])('rejects unsafe or invalid targets: %s', uri => {
+    activateTerminalLink(mouseEvent(), uri);
+
+    expect(openInWmuxBrowser).not.toHaveBeenCalled();
+  });
+
+  it('uses the same activation function for OSC 8 links', () => {
+    expect(terminalLinkHandler.activate).toBe(activateTerminalLink);
+  });
+});


### PR DESCRIPTION
## Summary

- route xterm OSC 8 hyperlinks through wmux's browser-opening path
- share the same activation callback with `WebLinksAddon` so detected and explicit terminal links behave consistently
- accept only HTTP(S) targets and preserve Ctrl/Meta-click external opening
- add focused unit coverage for routing, modifiers, and unsafe targets

Fixes #162.

## Root cause

Plain-text URLs are detected by `WebLinksAddon`, which already receives a wmux-specific callback. OSC 8 hyperlinks take xterm's separate OSC link-provider path and read `Terminal.options.linkHandler` instead.

Because wmux did not configure `linkHandler`, OSC 8 activation fell back to xterm's confirmation and `window.open()` behavior. That fallback does not route through wmux's Electron/browser handling, so accepting the dialog did not navigate anywhere.

## User impact

Links emitted by coding agents and other terminal applications now behave like ordinary detected URLs:

- normal click opens in the wmux browser
- Ctrl/Meta-click opens externally
- unsupported or malformed schemes are ignored

## Validation

- `npm test` — 884 passed, 5 skipped
- `npm run typecheck`
- `npm run build:main`
- `npm run build:renderer`
- `npm exec -- electron-builder --dir`
- packaged Windows manual test:
  - plain-text and OSC 8 PowerShell links open
  - agent-emitted OSC 8 links open from Codex/Claude running inside herdr
  - herdr terminal mouse interaction remains functional

`npm run lint` still reports the repository's existing baseline findings (17 errors and 15 warnings); the new helper passes focused linting and the modified lines introduce no new lint finding.