### PR TITLE
feat(devcontainer): drive wmux from a container over the TCP bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,12 @@ wmux --remote 127.0.0.1:9787 --token <TOKEN> list-workspaces
 wmux --remote 127.0.0.1:9787 --token <TOKEN> new-workspace --title "api"
 # Or set once: WMUX_REMOTE=127.0.0.1:9787 and WMUX_REMOTE_TOKEN=<TOKEN>
 
+# From a devcontainer — same transport, no SSH tunnel. Run the bridge in WSL2
+# (--wsl binds 0.0.0.0 there, reachable from the container, not from the LAN):
+wmux bridge --wsl                  # relays to \\.\pipe\wmux via npiperelay.exe
+# Then in the container: WMUX_REMOTE=host.docker.internal:9787 + WMUX_REMOTE_TOKEN
+# Full setup: docs/DEVCONTAINER.md
+
 # Agents
 wmux agent spawn --cmd "claude --resume abc" --label "Research"
 wmux agent spawn-batch --json '[{"cmd":"claude","label":"Agent 1"},{"cmd":"claude","label":"Agent 2"}]'
@@ -345,9 +351,14 @@ Connect to `\\.\pipe\wmux` for programmatic control. Two protocols supported:
 report_pwd <surface_id> <path>
 report_git_branch <surface_id> <branch> [dirty]
 report_shell_state <surface_id> idle|running|interrupted
+report_startup_command <surface_id> <command>   # how to restore this surface; must be cwd-independent
 notify <surface_id> <text>
 ping
 ```
+
+`wmux raw-v1 "<line>"` sends any of these through the CLI's transport, which is
+what lets a shell with no reachable pipe — inside a devcontainer — still report.
+See [docs/DEVCONTAINER.md](docs/DEVCONTAINER.md).
 
 **V2** (JSON-RPC, used by CLI and automation):
 ```json

--- a/docs/DEVCONTAINER.md
+++ b/docs/DEVCONTAINER.md
@@ -1,0 +1,256 @@
+# Driving wmux from a devcontainer
+
+wmux runs on Windows, but a Claude Code session often does not: it runs in a
+Linux devcontainer on top of WSL2 + Docker. Nothing in that container can open
+`\\.\pipe\wmux`, so the `wmux` CLI, the Claude Code hooks and the shell
+integration all fail silently — panes show no cwd or git branch, the sidebar
+never leaves "Running", and `wmux agent spawn` cannot reach the app at all.
+
+This guide sets up a path from the container to that pipe. It needs no Bosch
+feature, no vendor tooling and no code you have to write: one binary, one
+long-running command, and two environment variables.
+
+## How it fits together
+
+```
+  Devcontainer (Linux)                WSL2 distro                     Windows
+ ┌──────────────────────┐   TCP    ┌────────────────────┐  interop  ┌─────────┐
+ │ claude               │ ───────► │ wmux bridge --wsl  │ ────────► │ wmux    │
+ │  wmux CLI            │  :9787   │  listens 0.0.0.0   │           │         │
+ │  wmux-hook.js        │          │  npiperelay.exe ×N │ ═════════ │ \\.\pipe│
+ │  bash integration    │ ◄─────── │  (warm pool)       │ ◄──────── │  \wmux  │
+ └──────────────────────┘          └────────────────────┘           └─────────┘
+   WMUX_REMOTE=                      wmux bridge is a byte relay:
+   host.docker.internal:9787         no parsing, no auth of its own
+```
+
+Three hops, one protocol. The container speaks the same JSON-RPC (V2) and
+line (V1) protocol it would speak to a local pipe; only the socket underneath
+changes. Auth is unchanged end to end — every request still carries the wmux
+instance's pipe token, which `wmux bridge` forwards without inspecting.
+
+The bridge deliberately runs **inside WSL2**, not on Windows. From there,
+`0.0.0.0` is the WSL2 network namespace, which the container reaches through
+the Docker host gateway and the LAN does not. A Windows-side bind would expose
+the pipe to the corporate network and need a firewall rule; this needs neither.
+
+The WSL2 → Windows hop is [npiperelay.exe](https://github.com/albertony/npiperelay),
+a ~2 MB MIT-licensed binary that forwards a named pipe to its own stdin/stdout.
+WSL2 runs Windows executables via interop, so the bridge spawns it and treats
+its stdio as the socket. AF_VSOCK, a TCP listener on the Windows side and
+cross-boundary Unix sockets were all tried first: HCS-managed WSL2 VMs ignore
+`GuestCommunicationServices`, gateway IPs and firewall policy are unreliable on
+managed networks, and 9P does not forward `AF_UNIX`.
+
+## Setup
+
+### 1. Install npiperelay in the WSL2 distro
+
+Once per distro. The download is SHA-256 pinned against the release's own
+checksums file, and re-running is a no-op:
+
+```bash
+bash scripts/install-npiperelay.sh     # → ~/.local/bin/npiperelay.exe
+```
+
+The CLI also finds it on `PATH`, in `/usr/local/bin` or in `/usr/bin`, if you
+prefer to install it yourself.
+
+### 2. Start the bridge in WSL2
+
+Run this in the WSL2 distro that hosts your Docker daemon, with wmux already
+running on Windows. It stays in the foreground:
+
+```bash
+wmux bridge --wsl --port 9787
+```
+
+`--wsl` binds `0.0.0.0` instead of `127.0.0.1`. If `wmux` is not on your
+`PATH` inside WSL2, invoke the shipped CLI directly — any wmux pane exports
+`WMUX_CLI` for exactly this:
+
+```bash
+node "$WMUX_CLI" bridge --wsl --port 9787
+```
+
+### 3. Read the instance token
+
+On Windows, or in any WSL2 shell that can reach the pipe:
+
+```bash
+wmux token
+```
+
+This is the running instance's pipe token. It changes when wmux restarts.
+
+### 4. Point the container at the bridge
+
+Two variables. Add them to your `devcontainer.json`:
+
+```jsonc
+{
+  "containerEnv": {
+    "WMUX_REMOTE": "host.docker.internal:9787",
+    "WMUX_REMOTE_TOKEN": "${localEnv:WMUX_REMOTE_TOKEN}"
+  },
+  // Docker Desktop resolves host.docker.internal already; plain Docker on
+  // Linux/WSL2 does not, so map it to the gateway explicitly.
+  "runArgs": ["--add-host=host.docker.internal:host-gateway"]
+}
+```
+
+Export `WMUX_REMOTE_TOKEN` on the host before launching, so the token is not
+committed to the repo. The equivalent for a hand-rolled `docker run`:
+
+```bash
+docker run --add-host=host.docker.internal:host-gateway \
+  -e WMUX_REMOTE=host.docker.internal:9787 \
+  -e WMUX_REMOTE_TOKEN="$(wmux token)" \
+  …
+```
+
+### 5. Get the CLI and the plugin into the container
+
+Outside a container wmux installs both for you. Inside one it cannot: wmux is
+not running there, so `ensureOrchestratorPlugin()` never executes. This is the
+one step the native case gets for free.
+
+Mount them read-only from the wmux install directory (`resources/` next to
+`wmux.exe`, or the repo checkout):
+
+```jsonc
+"mounts": [
+  "source=${localEnv:WMUX_RESOURCES}/cli,target=/opt/wmux/cli,type=bind,readonly",
+  "source=${localEnv:WMUX_RESOURCES}/wmux-orchestrator,target=/home/vscode/.claude/plugins/wmux-orchestrator,type=bind,readonly"
+],
+"containerEnv": {
+  "WMUX_CLI": "/opt/wmux/cli/wmux.js"
+}
+```
+
+Then give the container a `wmux` command and let the shell integration report
+to it, in the image or in `postCreateCommand`:
+
+```bash
+printf 'wmux() { node "$WMUX_CLI" "$@"; }\nexport -f wmux\n' >> ~/.bashrc
+```
+
+Copying instead of mounting works equally well and survives the host path
+moving; mounting keeps the container in step when wmux updates.
+
+### 6. Verify
+
+```bash
+wmux ping           # → pong
+wmux list-workspaces
+```
+
+`pong` means all three hops are up. A hang or `ECONNREFUSED` means the bridge
+is not listening or `host.docker.internal` does not resolve; `unauthorized`
+means the token is stale — wmux was restarted, so re-read `wmux token`.
+
+## What now works
+
+Everything routes through the same transport, with no per-tool configuration:
+
+| In the container | Reaches wmux via |
+|---|---|
+| `wmux <any command>` | the CLI's `--remote` / `WMUX_REMOTE` support (issue #78) |
+| `wmux-hook.js` (Claude Code hooks) | its own TCP branch on `WMUX_REMOTE` — this is what unsticks the sidebar |
+| `wmux-bash-integration.sh` | `wmux raw-v1 <line>`, instead of the WSL temp-file drop it cannot write to |
+| wmux-orchestrator | the `wmux` shim above; the plugin itself is unaware of any of this |
+
+With `WMUX_REMOTE` unset, every one of these falls back to the local named
+pipe exactly as before. The transport is additive.
+
+## Latency and the warm relay pool
+
+Spawning `npiperelay.exe` is not free. On a corporate-managed host where AV/EDR
+scans the binary on every exec, spawn + pipe attach measures up to ~7 seconds —
+and a hook fires on every tool call, in every pane.
+
+So `wmux bridge` keeps relays spawned and attached ahead of demand. A client
+arriving gets one that is already live, and the bridge immediately starts
+another to replace it. Tune with:
+
+| Variable | Default | Effect |
+|---|---|---|
+| `WMUX_BRIDGE_WARM` | `2` | Relays kept warm. `0` restores spawn-per-connection. |
+| `WMUX_BRIDGE_DRAIN_MS` | `15000` | How long a relay may keep draining after its client hangs up. |
+| `WMUX_RPC_TIMEOUT_MS` | `30000` | CLI deadline floor on a remote/npiperelay transport. |
+
+The pool is deliberately N exclusive relays rather than one multiplexed relay:
+multiplexing would force the bridge to parse frames and rewrite JSON-RPC ids,
+which V1 lines (`pong`, `ok`, `unauthorized`) carry no id to be rewritten by —
+and would make every client a casualty of one relay dying.
+
+The 30-second floor exists because the CLI's normal 5-second deadline sits
+*below* that 7-second worst case: without it, a container reported `timed out`
+for calls that had already succeeded.
+
+## Session restore: `report_startup_command`
+
+A restored pane is a fresh WSL shell on the Windows host. It has no idea it
+used to be inside a container, so by default it comes back as a plain WSL
+prompt and the container session is gone.
+
+`report_startup_command` is how a shell says how to bring itself back. Report
+it once, from inside the container, and wmux stores it on that surface and
+replays it into the pane it restores:
+
+```bash
+_wmux_report "report_startup_command ${WMUX_SURFACE_ID} cd '/home/me/project' && ./relaunch.sh"
+```
+
+Or from anywhere with a CLI:
+
+```bash
+wmux raw-v1 "report_startup_command $WMUX_SURFACE_ID cd '/home/me/project' && ./relaunch.sh"
+```
+
+It is stored per surface, so two containers sharing one pane restore to two
+different containers. Sending it with no command clears it.
+
+> **The command must be cwd-independent.** This is a hard requirement, not a
+> precaution.
+
+wmux replays the command into a freshly spawned login shell, and makes no
+promise about where that shell starts. `wsl.exe --cd <dir>` is applied *before*
+the shell reads its rc files, so a distro whose `/etc/profile` or `~/.profile`
+ends in `$HOME` — common on managed images — silently discards it:
+
+```console
+$ wsl --cd /tmp -- pwd     # non-interactive → /tmp   (--cd holds)
+$ wsl --cd /tmp            # interactive login → ~    (the rc wins)
+```
+
+A relative `./relaunch.sh` therefore dies with "No such file or directory" and
+the container is never re-entered. Lead with an absolute `cd`, as above.
+
+Two details that bite:
+
+- **Expand the path where you send the report**, not where it runs. The stored
+  string must hold a literal host-side path; a `$WORKSPACE` in it would be
+  expanded by the restored shell, which has never heard of it.
+- **Single-quote the path.** It is replayed as a shell line, so an unquoted
+  space splits it and an unquoted `$` expands.
+
+The same asymmetry applies to `report_pwd`: `$(pwd)` inside a container is a
+container path that means nothing to Windows or WSL. Report the host-side
+workspace path instead.
+
+## Security
+
+- The bridge binds inside the WSL2 network namespace. It is reachable from
+  containers on that host and not from the LAN, and it needs no Windows
+  firewall rule. `--host` overrides this; the CLI warns when you do, because a
+  Windows-side bind really does expose the pipe to the network.
+- The bridge authenticates nothing and parses nothing — it copies bytes. wmux's
+  own pipe server verifies the per-instance token on every request, V1
+  (`auth <token> …`) and V2 (`token` field) alike, so the bridge grants no
+  access that the token does not already grant.
+- The token is per-instance and rotates on restart. Pass it through the
+  environment; do not commit it.
+- `npiperelay.exe` is fetched over HTTPS from a pinned release tag, and its
+  SHA-256 is checked against a checksums file whose own hash is pinned in the
+  install script.

--- a/resources/cli/wmux-hook.js
+++ b/resources/cli/wmux-hook.js
@@ -16,6 +16,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * Reads stdin for the Claude Code hook payload (JSON):
  *   - PostToolUse Edit/Write → extracts tool_input.file_path
  *   - Notification           → extracts the `message` (what the agent is waiting for)
+ *   - PreToolUse             → extracts `tool_name` (registered matcher-less)
  * WMUX_SURFACE_ID (set by wmux in each pane's shell) ties the event to its pane.
  */
 const net_1 = __importDefault(require("net"));
@@ -28,16 +29,77 @@ if (argv[0] === '--event') {
 else {
     tool = argv[0] || 'unknown';
 }
+/**
+ * When Claude Code fired this hook, near enough (issue #151).
+ *
+ * Taken at process start rather than at send time because the interesting delay
+ * is everything after: node boot, reading stdin, connecting to the pipe. Each
+ * hook is its own process and they race, so a `PostToolUse` can reach wmux after
+ * the `Stop` that followed it and re-assert a run that has already ended. wmux
+ * orders reports by this stamp instead of by arrival.
+ */
+const firedAt = Date.now();
 const pipePath = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
-const token = process.env.WMUX_PIPE_TOKEN || '';
 const surfaceId = process.env.WMUX_SURFACE_ID || '';
+/**
+ * TCP transport for a hook firing where the pipe does not exist (issue #19).
+ *
+ * Inside a devcontainer, Claude Code runs on Linux while wmux runs on the
+ * Windows host: `\\.\pipe\wmux` is unreachable, so every hook failed silently
+ * and the sidebar never left "Running". WMUX_REMOTE points at a `wmux bridge`
+ * (issue #78) instead — same JSON-RPC frame, same auth, different socket. The
+ * env-var form is deliberate: Claude Code owns this process's argv, so there is
+ * nowhere to put a --remote flag.
+ *
+ * The token is the REMOTE instance's, which is not this machine's: on the
+ * container side WMUX_PIPE_TOKEN is either absent or something else entirely.
+ */
+const remote = (() => {
+    const spec = process.env.WMUX_REMOTE?.trim();
+    if (!spec)
+        return null;
+    const idx = spec.lastIndexOf(':');
+    const port = idx === -1 ? NaN : parseInt(spec.slice(idx + 1), 10);
+    return Number.isFinite(port) && port > 0 && port <= 65535
+        ? { host: spec.slice(0, idx) || '127.0.0.1', port }
+        : { host: spec, port: 9787 };
+})();
+const token = (remote ? process.env.WMUX_REMOTE_TOKEN : process.env.WMUX_PIPE_TOKEN) || '';
 let stdinData = '';
 let sent = false;
 const MAX_STDIN = 64 * 1024; // 64KB cap
+/**
+ * Backstop ceiling on this process's lifetime once it starts talking to the
+ * pipe. Every other way out of here is event-driven; this is the one that does
+ * not depend on an event arriving.
+ *
+ * Deliberately a backstop and not a fix for an observed hang: measured against
+ * an absent, a responsive and a wedged (accepts, never answers) server, the
+ * hook exits on its own in every case, because on Windows named pipes `end()`
+ * tears the connection down rather than half-closing it. The wmux CLI has
+ * always armed this same 5s timer before connecting (see sendV1/sendV2); the
+ * hook helper was the one client without it, and matching costs nothing.
+ *
+ * The bridge path gets longer: there the frame crosses a TCP hop and then
+ * npiperelay over WSL interop, which measures ~7s worst case on a corporate
+ * host. Firing at 5s there would destroy() the socket mid-flight and drop the
+ * very event this process exists to deliver.
+ */
+const PIPE_DEADLINE_MS = remote ? 30000 : 5000;
+/** Cleared once we stop reading, so the happy path is not held open by it. */
+let stdinTimer = null;
 function sendHook() {
     if (sent)
         return;
     sent = true;
+    if (stdinTimer) {
+        clearTimeout(stdinTimer);
+        stdinTimer = null;
+    }
+    // stdin is a live handle that keeps the event loop alive on its own. If the
+    // caller opened it and never closes it, exiting would otherwise wait on a
+    // stream nobody is going to end.
+    process.stdin.pause();
     let file = '';
     let message = '';
     try {
@@ -50,12 +112,17 @@ function sendHook() {
                 || '';
             // The Notification hook payload carries the prompt text in `message`.
             message = data.message || '';
+            // PreToolUse is registered matcher-less (one entry for every tool rather
+            // than one entry per tracked tool), so the tool name arrives on stdin
+            // instead of on argv.
+            if (!tool && typeof data.tool_name === 'string')
+                tool = data.tool_name;
         }
     }
     catch {
         // stdin wasn't valid JSON — that's fine.
     }
-    const params = {};
+    const params = { at: firedAt };
     if (event)
         params.event = event;
     if (tool)
@@ -66,12 +133,27 @@ function sendHook() {
         params.message = message;
     if (surfaceId)
         params.surfaceId = surfaceId;
-    const client = net_1.default.connect({ path: pipePath }, () => {
+    const client = net_1.default.connect(remote ? { host: remote.host, port: remote.port } : { path: pipePath }, () => {
         const msg = JSON.stringify({ method: 'hook.event', params, id: 1, token });
         client.write(msg + '\n', () => client.end());
+        // Drain the reply we do not care about. This is not cosmetic: wmux answers
+        // but never closes the connection (pipe-server.ts), and a socket left in
+        // paused mode never reads far enough to see EOF — so it never emits 'end',
+        // never auto-destroys, and never emits 'close'. Without this the deadline
+        // below becomes the ONLY way out and every hook takes the full 5s.
+        client.resume();
     });
+    // Referenced, not unref'd: it has to be able to fire while the pending socket
+    // is what is holding the loop open. 'close' covers both a clean end and a
+    // destroy, so the happy path clears it immediately rather than lingering.
+    const deadline = setTimeout(() => {
+        client.destroy();
+        process.exit(0);
+    }, PIPE_DEADLINE_MS);
+    client.on('close', () => clearTimeout(deadline));
     client.on('error', () => {
         // wmux not running — silently ignore.
+        clearTimeout(deadline);
         process.exit(0);
     });
 }
@@ -82,7 +164,13 @@ process.stdin.on('data', (chunk) => { if (stdinData.length < MAX_STDIN)
 process.stdin.on('end', sendHook);
 process.stdin.on('error', sendHook);
 // Timeout: if no stdin arrives within 1s, send without payload info.
-setTimeout(sendHook, 1000);
+//
+// Held in a variable so sendHook can clear it (issue #139). Left armed, this
+// one timer kept EVERY hook process — including the ones whose work finished in
+// ~90ms — resident for the full second: measured 1049ms before, 101ms after.
+// Claude Code fires a hook per tool call in every pane, so under a few busy
+// agents that is a standing population of node.exe doing nothing.
+stdinTimer = setTimeout(sendHook, 1000);
 // If stdin is already ended (e.g. no pipe), send immediately.
 if (process.stdin.readableEnded)
     sendHook();

--- a/resources/cli/wmux.js
+++ b/resources/cli/wmux.js
@@ -104,10 +104,11 @@ function findNpiperelay() {
             return false;
         }
     };
-    const fromPath = (process.env.PATH || '')
-        .split(':')
-        .map((d) => path_1.default.join(d, 'npiperelay.exe'))
-        .find(readable);
+    const binPaths = (process.env.PATH || process.env.Path || '')
+        .split(path_1.default.delimiter)
+        .filter(Boolean)
+        .map((d) => path_1.default.join(d, 'npiperelay.exe'));
+    const fromPath = binPaths.find(readable);
     if (fromPath)
         return fromPath;
     return ([
@@ -524,7 +525,11 @@ async function cmdConfig(args) {
             // No reachable instance — fall through to a local guess. path.join at least
             // keeps it self-consistent with whichever filesystem we are actually on.
         }
-        console.log(path_1.default.join(os_1.default.homedir(), '.wmux', 'config.toml'));
+        const home = process.env.HOME || process.env.USERPROFILE || os_1.default.homedir();
+        const fallbackPath = home.includes('/') && !home.includes('\\')
+            ? path_1.default.posix.join(home, '.wmux', 'config.toml')
+            : path_1.default.join(home, '.wmux', 'config.toml');
+        console.log(fallbackPath);
     }
     else {
         console.error('Usage: wmux config <show|reload|path>');
@@ -545,8 +550,11 @@ async function cmdLocales(args) {
         print(await sendV2('config.reload'));
     }
     else if (sub === 'path') {
-        const home = process.env.USERPROFILE || process.env.HOME || '';
-        console.log(`${home}\\.wmux\\locales`);
+        const home = process.env.HOME || process.env.USERPROFILE || '';
+        const fallbackPath = home.includes('/') && !home.includes('\\')
+            ? path_1.default.posix.join(home, '.wmux', 'locales')
+            : path_1.default.join(home, '.wmux', 'locales');
+        console.log(fallbackPath);
     }
     else {
         console.error('Usage: wmux locales [list|reload|path]');

--- a/resources/cli/wmux.js
+++ b/resources/cli/wmux.js
@@ -4,13 +4,171 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.timeoutMessage = timeoutMessage;
+exports.browserRequest = browserRequest;
+exports.subcommandError = subcommandError;
 const net_1 = __importDefault(require("net"));
 const fs_1 = __importDefault(require("fs"));
 const os_1 = __importDefault(require("os"));
 const path_1 = __importDefault(require("path"));
+const child_process_1 = require("child_process");
+const stream_1 = require("stream");
 // Respect WMUX_PIPE when set (e.g. by a parent wmux running with WMUX_INSTANCE),
 // so the CLI talks to the same instance that spawned the shell.
 const PIPE_PATH = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
+// ─── Remote transport (issue #78: remote wmux management) ────────────────────
+// When --remote host[:port] (or WMUX_REMOTE) is set, every command connects
+// over TCP instead of the local named pipe — typically through an SSH tunnel
+// (`ssh -L 9787:127.0.0.1:9787 user@host`) to a `wmux bridge` running on the
+// remote machine. Auth is unchanged: the remote instance's pipe token must be
+// supplied via --token or WMUX_REMOTE_TOKEN (print it there with `wmux token`).
+const DEFAULT_BRIDGE_PORT = 9787;
+let remoteTarget = null;
+// How long `wmux bridge` lets a relay keep draining after its client socket has
+// closed, before forcing teardown. Must exceed the pipe round-trip, or the frame
+// a write-then-close client just sent is discarded mid-flight. Measured worst
+// case inside a devcontainer on a corporate-managed Windows host is ~7s (a fresh
+// npiperelay.exe is spawned per connection over WSL interop, and AV/EDR scans it
+// on every exec), so the default leaves generous headroom. The relay normally
+// exits on its own well before this — the timer is only the backstop.
+const BRIDGE_DRAIN_GRACE_MS = parseInt(process.env.WMUX_BRIDGE_DRAIN_MS || '', 10) || 15000;
+// How many npiperelay relays `wmux bridge` keeps spawned and attached to the pipe
+// ahead of demand (see the pool in cmdBridge). 0 disables pre-warming and restores
+// spawn-per-connection. Only ever used on the npiperelay path — the Unix-socket and
+// native-pipe transports connect instantly and have nothing to pre-warm.
+const BRIDGE_WARM_RELAYS = (() => {
+    const raw = process.env.WMUX_BRIDGE_WARM?.trim();
+    if (!raw)
+        return 2;
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) && n >= 0 ? n : 2;
+})();
+function parseRemoteTarget(spec) {
+    const idx = spec.lastIndexOf(':');
+    if (idx === -1)
+        return { host: spec, port: DEFAULT_BRIDGE_PORT };
+    const port = parseInt(spec.slice(idx + 1), 10);
+    if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+        console.error(`Invalid --remote target: ${spec} (expected host[:port])`);
+        process.exit(1);
+    }
+    return { host: spec.slice(0, idx) || '127.0.0.1', port };
+}
+// ─── WSL2 transport: reach the Windows \\.\pipe\wmux from inside WSL2 ─────────
+//
+// A wmux CLI (or `wmux bridge`) running inside WSL2 needs to talk to the wmux
+// process on the Windows host over the \\.\pipe\wmux named pipe. AF_VSOCK,
+// TCP-over-gateway and cross-boundary Unix sockets were all evaluated and
+// rejected (HCS-managed WSL2 UVMs ignore GuestCommunicationServices; gateway
+// IPs/firewall policy are unreliable on corporate networks; 9P does not forward
+// AF_UNIX). The chosen mechanism is npiperelay.exe:
+//
+//   npiperelay.exe is a tiny (~2MB) open-source Windows binary that forwards a
+//   named pipe to its own stdin/stdout. WSL2 executes Windows binaries via
+//   interop, so from inside WSL2 we spawn it and use its stdio as the transport
+//   duplex — zero pre-setup, no socat needed. Install it (SHA-256 pinned) with
+//   scripts/install-npiperelay.sh; see docs/DEVCONTAINER.md for the full setup.
+//   Source: https://github.com/albertony/npiperelay (MIT, fork of jstarks/npiperelay)
+//   Pinned version: v1.11.4  SHA-256: cea82cf5c9c22a28bef8075750acb7958f766393baebff4597cf21442f71c4b3
+//
+//   Transport selection order:
+//     0. remoteTarget set (--remote / WMUX_REMOTE) → TCP (the devcontainer path,
+//        served by a `wmux bridge` reachable at host.docker.internal:9787)
+//     1. WMUX_PIPE starts with '/' → use as a Unix socket path
+//     2. WSL_DISTRO_NAME / WSLENV set → spawn npiperelay.exe automatically
+//     3. native Windows → connect directly to the named pipe
+// ─────────────────────────────────────────────────────────────────────────────
+function connectTransport(onConnect) {
+    if (remoteTarget)
+        return net_1.default.connect({ host: remoteTarget.host, port: remoteTarget.port }, onConnect);
+    if (PIPE_PATH.startsWith('/'))
+        return net_1.default.connect({ path: PIPE_PATH }, onConnect);
+    if (process.env.WSL_DISTRO_NAME || process.env.WSLENV)
+        return connectViaNpiperelay(PIPE_PATH, onConnect);
+    return net_1.default.connect({ path: PIPE_PATH }, onConnect);
+}
+// Mirrors the selection order above: true when connectTransport() will take the
+// npiperelay branch. That is the only transport whose setup costs anything worth
+// pre-warming — a Unix socket or a native named pipe connects in microseconds.
+function usesNpiperelay() {
+    return (!remoteTarget && !PIPE_PATH.startsWith('/') && Boolean(process.env.WSL_DISTRO_NAME || process.env.WSLENV));
+}
+// Search common installation locations for npiperelay.exe.
+function findNpiperelay() {
+    const readable = (p) => {
+        try {
+            fs_1.default.accessSync(p);
+            return true;
+        }
+        catch {
+            return false;
+        }
+    };
+    const fromPath = (process.env.PATH || '')
+        .split(':')
+        .map((d) => path_1.default.join(d, 'npiperelay.exe'))
+        .find(readable);
+    if (fromPath)
+        return fromPath;
+    return ([
+        path_1.default.join(os_1.default.homedir(), '.local', 'bin', 'npiperelay.exe'),
+        '/usr/local/bin/npiperelay.exe',
+        '/usr/bin/npiperelay.exe',
+    ].find(readable) ?? null);
+}
+// Spawn npiperelay.exe and expose its stdin/stdout as a Duplex stream.
+function connectViaNpiperelay(pipePath, onConnect) {
+    const bin = findNpiperelay();
+    if (!bin) {
+        console.error('wmux: npiperelay.exe not found.');
+        console.error('  Install it with scripts/install-npiperelay.sh, or fetch it from:');
+        console.error('  https://github.com/albertony/npiperelay/releases/latest');
+        process.exit(1);
+    }
+    // npiperelay names the pipe with forward slashes: \\.\pipe\wmux → //./pipe/wmux
+    const child = (0, child_process_1.spawn)(bin, ['-ei', '-s', pipePath.replace(/\\/g, '/')], {
+        stdio: ['pipe', 'pipe', 'inherit'],
+    });
+    const duplex = new stream_1.Duplex({
+        read() { },
+        write(chunk, enc, cb) {
+            if (!child.stdin?.writable) {
+                cb(new Error('npiperelay stdin closed'));
+                return;
+            }
+            child.stdin.write(chunk, enc, cb);
+        },
+        final(cb) {
+            child.stdin?.end();
+            cb();
+        },
+        // Kills the relay, discarding anything still buffered in its stdin. Callers
+        // must only reach here on error or after the stream has drained — see the
+        // teardown in cmdBridge.
+        destroy(err, cb) {
+            child.kill();
+            cb(err);
+        },
+        allowHalfOpen: true,
+    });
+    child.stdout?.on('data', (chunk) => duplex.push(chunk));
+    child.stdout?.on('end', () => duplex.push(null));
+    child.on('error', (err) => duplex.destroy(err));
+    child.on('exit', (code) => {
+        if (code !== 0 && code !== null)
+            duplex.destroy(new Error(`npiperelay exited with code ${code}`));
+    });
+    // "Ready" here means the relay process exists — NOT that it has attached to the
+    // named pipe, which over WSL interop can take seconds longer. onConnect must
+    // still fire now regardless: callers write their request from inside it, and the
+    // Duplex buffers those bytes until the pipe is live. (Deferring it until the
+    // first byte comes back would deadlock — nothing would ever be written.)
+    //
+    // The cost is that a caller's deadline starts before the pipe is up, so it has
+    // to cover the attach latency too — that is what SLOW_TRANSPORT_FLOOR_MS is for.
+    process.nextTick(onConnect);
+    return duplex;
+}
 // Auth token for privileged (V2) pipe requests. wmux injects WMUX_PIPE_TOKEN
 // into the shells it spawns; for CLIs launched elsewhere, fall back to the
 // token file in the instance's APPDATA dir (readable only by this user).
@@ -27,29 +185,101 @@ function readPipeToken() {
         return '';
     }
 }
-const PIPE_TOKEN = readPipeToken();
+// Mutable: overridden by --token / WMUX_REMOTE_TOKEN when talking to a remote
+// instance, whose token differs from this machine's.
+let PIPE_TOKEN = readPipeToken();
 function sendV1(command) {
+    // V1 state updates authenticate with an "auth <token> " prefix (issue #72).
+    const line = PIPE_TOKEN ? `auth ${PIPE_TOKEN} ${command}` : command;
     return new Promise((resolve, reject) => {
-        const client = net_1.default.connect({ path: PIPE_PATH }, () => {
-            client.write(command + '\n');
+        const client = connectTransport(() => {
+            client.write(line + '\n');
         });
         let data = '';
-        client.on('data', (chunk) => { data += chunk.toString(); });
-        client.on('end', () => resolve(data.trim()));
-        client.on('error', (err) => reject(err));
-        setTimeout(() => { client.end(); resolve(data.trim()); }, 5000);
+        const timer = setTimeout(() => { client.end(); resolve(data.trim()); }, deadline(5000));
+        const finish = () => { clearTimeout(timer); resolve(data.trim()); };
+        client.on('data', (chunk) => {
+            data += chunk.toString();
+            // V1 replies are a single newline-terminated line (pong/ok/unauthorized).
+            // Resolve as soon as it arrives instead of blocking on the server closing
+            // the socket (it doesn't) — otherwise every call waited the full 5s timer.
+            if (data.includes('\n')) {
+                client.end();
+                finish();
+            }
+        });
+        client.on('end', finish);
+        client.on('error', (err) => { clearTimeout(timer); reject(err); });
     });
 }
-function sendV2(method, params = {}) {
+/**
+ * How long to wait for a V2 reply before giving up.
+ *
+ * This deadline has to stay LARGER than whatever budget the main process spends
+ * serving the same request. When it is shorter the CLI loses a race it should
+ * never have been in: a command that succeeds late is reported as a failure, and
+ * the server's own diagnosis ('Could not open browser panel', 'browser_not_open',
+ * 'ref_not_found: …') is discarded unread because it arrives after we hung up.
+ * Only the browser verbs currently need more than this — see BROWSER_CMDS.
+ */
+const DEFAULT_V2_TIMEOUT_MS = 5000;
+/**
+ * A floor under every deadline, for transports slower than a local named pipe.
+ *
+ * The budgets above are all sized for a pipe on the same machine, where a
+ * round-trip is sub-millisecond and the whole deadline is the server's own
+ * thinking time. Neither transport this file grew for issue #19 is that: TCP to
+ * a `wmux bridge` from inside a devcontainer, and npiperelay over WSL interop,
+ * both measure ~7s worst case on a corporate-managed host — above the 5s default
+ * on their own, before wmux has done anything. Every request from a container
+ * therefore reported a timeout for a call that had already succeeded.
+ *
+ * A floor rather than a replacement, so a browser verb keeps the longer budget
+ * it asked for, and a local run keeps master's timings unchanged (floor 0).
+ */
+const SLOW_TRANSPORT_FLOOR_MS = 30000;
+/** `base`, raised to the slow-transport floor when the transport is a slow one. */
+function deadline(base) {
+    const override = parseInt(process.env.WMUX_RPC_TIMEOUT_MS || '', 10);
+    if (Number.isFinite(override) && override > 0)
+        return Math.max(base, override);
+    return remoteTarget || usesNpiperelay() ? Math.max(base, SLOW_TRANSPORT_FLOOR_MS) : base;
+}
+/**
+ * What a stalled request says when it gives up.
+ *
+ * The bare 'timeout' this used to reject with named neither the method nor the
+ * deadline, so an operation that was merely slow was indistinguishable from a
+ * broken install — and since the deadline was also shorter than the server's own
+ * budget, it was usually the *only* thing a slow browser command ever printed.
+ */
+function timeoutMessage(method, timeoutMs) {
+    return `${method} timed out after ${timeoutMs}ms — wmux accepted the request but sent no reply. The command may still have completed.`;
+}
+function sendV2(method, params = {}, timeoutMs = DEFAULT_V2_TIMEOUT_MS) {
+    // Every command carries the caller's surface (WMUX_SURFACE_ID). Browser
+    // commands use it to route each agent to its OWN browser pane, so concurrent
+    // agents no longer share and clobber one browser window (issue #62); the
+    // workspace/pane/surface commands use it to answer about the window the
+    // calling shell actually lives in rather than an arbitrary one (issue #141).
+    if (params.caller === undefined && process.env.WMUX_SURFACE_ID) {
+        params = { ...params, caller: process.env.WMUX_SURFACE_ID };
+    }
     return new Promise((resolve, reject) => {
-        const client = net_1.default.connect({ path: PIPE_PATH }, () => {
+        const client = connectTransport(() => {
             const request = JSON.stringify({ method, params, id: 1, token: PIPE_TOKEN });
             client.write(request + '\n');
         });
         let data = '';
+        const deadlineMs = deadline(timeoutMs);
+        const timer = setTimeout(() => {
+            client.end();
+            reject(new Error(timeoutMessage(method, deadlineMs)));
+        }, deadlineMs);
         client.on('data', (chunk) => {
             data += chunk.toString();
             if (data.includes('\n')) {
+                clearTimeout(timer);
                 client.end();
                 try {
                     const response = JSON.parse(data.trim());
@@ -63,8 +293,7 @@ function sendV2(method, params = {}) {
                 }
             }
         });
-        client.on('error', (err) => reject(err));
-        setTimeout(() => { client.end(); reject(new Error('timeout')); }, 5000);
+        client.on('error', (err) => { clearTimeout(timer); reject(err); });
     });
 }
 // Simple flag helpers shared across commands.
@@ -82,441 +311,1130 @@ function stripFlag(args, name) {
     copy.splice(i, i === args.length - 1 ? 1 : 2);
     return copy;
 }
-async function main() {
-    const args = process.argv.slice(2);
-    const command = args[0];
-    if (!command) {
+const print = (v) => console.log(JSON.stringify(v, null, 2));
+/**
+ * Server-side budgets a browser command can legitimately spend before it is even
+ * able to reply. Mirrored from the main process so the CLI can outwait it:
+ *
+ *   BROWSER_READY_MS   v2-browser.ts readies a browser first — it splits a pane
+ *                      and then polls up to 5s for CDP to attach.
+ *   CDP_NAVIGATE_MS    cdp-bridge.ts navigate() waits for did-finish-load.
+ *   CDP_WAIT_MS        cdp-bridge.ts wait() polls for a ref.
+ *
+ * Both cdp-bridge budgets already exceeded the old flat 5s CLI deadline on their
+ * own, so `browser open` on any slow page and `browser wait` on any absent ref
+ * could not report anything but 'timeout' — including when they went on to
+ * succeed. Keep these in step if the main-process defaults change.
+ */
+const BROWSER_READY_MS = 5000;
+const CDP_NAVIGATE_MS = 30000;
+const CDP_WAIT_MS = 10000;
+/** Pane split plus the executeJavaScript round-trips around it. */
+const BROWSER_SLACK_MS = 5000;
+/** The CLI deadline for a browser verb whose own server-side budget is `verbMs`. */
+const browserDeadline = (verbMs) => BROWSER_READY_MS + verbMs + BROWSER_SLACK_MS;
+// Each browser subcommand maps to the V2 request it issues.
+const BROWSER_CMDS = {
+    open: (args) => ({
+        method: 'browser.navigate',
+        params: { url: args[2] },
+        timeoutMs: browserDeadline(CDP_NAVIGATE_MS),
+    }),
+    snapshot: () => ({ method: 'browser.snapshot', params: {}, timeoutMs: browserDeadline(0) }),
+    click: (args) => ({ method: 'browser.click', params: { ref: args[2] }, timeoutMs: browserDeadline(0) }),
+    type: (args) => ({
+        method: 'browser.type',
+        params: { ref: args[2], text: args.slice(3).join(' ') },
+        timeoutMs: browserDeadline(0),
+    }),
+    fill: (args) => ({
+        method: 'browser.fill',
+        params: { ref: args[2], value: args.slice(3).join(' ') },
+        timeoutMs: browserDeadline(0),
+    }),
+    screenshot: (args) => ({
+        method: 'browser.screenshot',
+        params: { fullPage: args.includes('--full') },
+        timeoutMs: browserDeadline(0),
+    }),
+    'get-text': (args) => ({ method: 'browser.get_text', params: { ref: args[2] }, timeoutMs: browserDeadline(0) }),
+    eval: (args) => ({ method: 'browser.eval', params: { js: args.slice(2).join(' ') }, timeoutMs: browserDeadline(0) }),
+    wait: (args) => {
+        const explicit = parseInt(args[3]) || undefined;
+        return {
+            method: 'browser.wait',
+            params: { ref: args[2], timeout: explicit },
+            // An explicit ms is the budget the server will honour; outwait that one.
+            timeoutMs: browserDeadline(explicit ?? CDP_WAIT_MS),
+        };
+    },
+    back: () => ({ method: 'browser.back', params: {}, timeoutMs: browserDeadline(0) }),
+    forward: () => ({ method: 'browser.forward', params: {}, timeoutMs: browserDeadline(0) }),
+    reload: () => ({ method: 'browser.reload', params: {}, timeoutMs: browserDeadline(0) }),
+};
+/**
+ * Resolve `wmux browser <verb> …` to the request it issues. Null for an unknown
+ * verb. Pure, so the deadlines and the caller wiring are testable without a
+ * running app.
+ *
+ * `caller` is the *terminal* surface the command is issued on behalf of, not a
+ * browser surface: the main process maps it to that pane's own browser, which is
+ * what keeps concurrent agents isolated (issue #62). Passing it explicitly does
+ * not change that routing — it only supplies from a flag what a shell inside a
+ * pane supplies from $WMUX_SURFACE_ID.
+ */
+function browserRequest(args, caller) {
+    const build = BROWSER_CMDS[args[1]];
+    if (!build)
+        return null;
+    const req = build(args);
+    return caller ? { ...req, params: { ...req.params, caller } } : req;
+}
+/**
+ * What a group command says when its subcommand is missing or unknown.
+ *
+ * `browser`, `agent`, `pane` and `layout` all dispatched on `args[1]` and
+ * interpolated it into the error unchecked, so a bare `wmux browser` — the
+ * natural thing to type when you want to know the verbs — answered
+ * `Unknown browser command: undefined` (issue #156). That reads like the CLI
+ * malfunctioned rather than like a usage error, and it was a dead end: nothing
+ * in it pointed at `wmux help browser`, and `wmux browser --help` cannot fill
+ * the gap because browser is passthrough (`--help` is text to send, not a
+ * request for usage). `markdown` and `config` already printed usage here.
+ */
+function subcommandError(command, sub) {
+    return sub === undefined || sub === ''
+        ? `wmux ${command} needs a subcommand.`
+        : `Unknown ${command} subcommand: ${sub}`;
+}
+/** Print why the subcommand was rejected, then that group's usage, then exit 1. */
+function failSubcommand(command, sub) {
+    return fail(command, COMMAND_SPECS[command], subcommandError(command, sub));
+}
+async function cmdBrowser(args) {
+    // --surface says which pane's browser to drive, mirroring send / read-screen /
+    // agent-activity. Strip it before the verb reads its positional args, or
+    // `browser type e5 --surface surf-x hi` would type the flag into the page.
+    const caller = getFlag(args, '--surface') || process.env.WMUX_SURFACE_ID;
+    const rest = stripFlag(args, '--surface');
+    const req = browserRequest(rest, caller);
+    if (!req)
+        failSubcommand('browser', rest[1]);
+    print(await sendV2(req.method, req.params, req.timeoutMs));
+}
+function agentSpawn(args) {
+    const params = {};
+    // Valueless flags must be stripped before the pairwise --flag value loop.
+    const rest = args.slice(2).filter((a) => {
+        if (a === '--replace-tab') {
+            params.replaceTab = true;
+            return false;
+        }
+        return true;
+    });
+    for (let i = 0; i < rest.length; i += 2) {
+        if (rest[i] === '--cmd')
+            params.cmd = rest[i + 1];
+        if (rest[i] === '--label')
+            params.label = rest[i + 1];
+        if (rest[i] === '--cwd')
+            params.cwd = rest[i + 1];
+        if (rest[i] === '--pane')
+            params.paneId = rest[i + 1];
+        if (rest[i] === '--workspace')
+            params.workspaceId = rest[i + 1];
+    }
+    if (!params.cmd) {
+        console.error('--cmd is required');
+        process.exit(1);
+    }
+    if (!params.label)
+        params.label = params.cmd.split(/\s+/)[0];
+    return sendV2('agent.spawn', params);
+}
+function agentSpawnBatch(args) {
+    const jsonIdx = args.indexOf('--json');
+    if (jsonIdx === -1) {
+        console.error('Usage: wmux agent spawn-batch --json \'[...]\'');
+        process.exit(1);
+    }
+    const parsed = JSON.parse(args[jsonIdx + 1]);
+    const strategy = args.find((a, i) => args[i - 1] === '--strategy') || 'distribute';
+    return sendV2('agent.spawn_batch', { agents: parsed, strategy });
+}
+const AGENT_CMDS = {
+    spawn: agentSpawn,
+    'spawn-batch': agentSpawnBatch,
+    status: (args) => sendV2('agent.status', { agentId: args[2] }),
+    list: (args) => sendV2('agent.list', { workspaceId: args.find((a, i) => args[i - 1] === '--workspace') }),
+    kill: (args) => sendV2('agent.kill', { agentId: args[2] }),
+};
+async function cmdAgent(args) {
+    const handler = AGENT_CMDS[args[1]];
+    if (!handler)
+        failSubcommand('agent', args[1]);
+    print(await handler(args));
+}
+async function cmdPane(args) {
+    const sub = args[1];
+    if (sub === 'new' || sub === 'split') {
+        const rest = args.slice(2);
+        const direction = rest.includes('--down') ? 'down' : 'right';
+        const type = getFlag(rest, '--type') || 'terminal';
+        const colorScheme = getFlag(rest, '--color-scheme');
+        print(await sendV2('pane.split', { direction, type, ...(colorScheme ? { colorScheme } : {}) }));
+    }
+    else if (sub === 'close') {
+        print(await sendV2('pane.close', { id: args[2] }));
+    }
+    else if (sub === 'focus') {
+        print(await sendV2('pane.focus', { id: args[2] }));
+    }
+    else if (sub === 'list') {
+        print(await sendV2('pane.list', { workspaceId: getFlag(args, '--workspace') }));
+    }
+    else {
+        failSubcommand('pane', sub);
+    }
+}
+async function cmdConfig(args) {
+    const sub = args[1];
+    if (sub === 'show' || sub === 'get') {
+        print(await sendV2('config.get'));
+    }
+    else if (sub === 'reload') {
+        print(await sendV2('config.reload'));
+    }
+    else if (sub === 'path') {
+        const home = process.env.USERPROFILE || process.env.HOME || '';
+        console.log(`${home}\\.wmux\\config.toml`);
+    }
+    else {
+        console.error('Usage: wmux config <show|reload|path>');
+        process.exit(1);
+    }
+}
+/**
+ * Community translations (issue #147). `list` is the default because the whole
+ * point is telling a translator which of their files loaded and which were
+ * rejected — silence on a typo'd filename is the failure mode to avoid.
+ */
+async function cmdLocales(args) {
+    const sub = args[1];
+    if (!sub || sub === 'list' || sub === 'show') {
+        print(await sendV2('locales.get'));
+    }
+    else if (sub === 'reload') {
+        print(await sendV2('config.reload'));
+    }
+    else if (sub === 'path') {
+        const home = process.env.USERPROFILE || process.env.HOME || '';
+        console.log(`${home}\\.wmux\\locales`);
+    }
+    else {
+        console.error('Usage: wmux locales [list|reload|path]');
+        process.exit(1);
+    }
+}
+async function cmdLayout(args) {
+    if (args[1] !== 'grid')
+        failSubcommand('layout', args[1]);
+    const params = {};
+    for (let i = 2; i < args.length; i += 2) {
+        if (args[i] === '--count')
+            params.count = parseInt(args[i + 1], 10);
+        if (args[i] === '--type')
+            params.type = args[i + 1];
+        if (args[i] === '--anchor-surface')
+            params.anchorSurfaceId = args[i + 1];
+        if (args[i] === '--anchor-pane')
+            params.anchorPaneId = args[i + 1];
+        if (args[i] === '--workspace')
+            params.workspaceId = args[i + 1];
+    }
+    if (!params.count || params.count < 1) {
+        console.error('--count <N> is required and must be >= 1');
+        process.exit(1);
+    }
+    // If no explicit anchor, fall back to the current shell's surface so the command "just works" from inside a pane.
+    if (!params.anchorSurfaceId && !params.anchorPaneId && process.env.WMUX_SURFACE_ID) {
+        params.anchorSurfaceId = process.env.WMUX_SURFACE_ID;
+    }
+    print(await sendV2('layout.grid', params));
+}
+async function cmdMarkdown(args) {
+    const sub = args[1];
+    if (sub === 'set') {
+        // Existing behaviour: target an existing surface by id.
+        const surfaceId = args[2];
+        const contentFlag = args.indexOf('--content');
+        const fileFlag = args.indexOf('--file');
+        const titleFlag = args.indexOf('--title');
+        const title = titleFlag !== -1 ? args[titleFlag + 1] : undefined;
+        if (contentFlag !== -1) {
+            // Stop at --title so it isn't swallowed into the content when it comes last.
+            const end = titleFlag > contentFlag ? titleFlag : args.length;
+            print(await sendV2('markdown.set_content', {
+                surfaceId, markdown: args.slice(contentFlag + 1, end).join(' '), title,
+            }));
+        }
+        else if (fileFlag !== -1) {
+            // Resolve against the terminal's cwd — the main-process cwd differs.
+            const filePath = path_1.default.resolve(process.cwd(), args[fileFlag + 1] || '');
+            print(await sendV2('markdown.load_file', { surfaceId, filePath }));
+        }
+        else {
+            console.error('Usage: wmux markdown set <id> --content <text> [--title T] | --file <path>');
+            process.exit(1);
+        }
+    }
+    else if (sub === 'get') {
+        // Read a surface's buffer back out — mirrors `read-screen` for terminals.
+        print(await sendV2('markdown.get_content', { surfaceId: args[2] }));
+    }
+    else if (sub) {
+        // One-shot: `wmux markdown <file>` — create a markdown surface and load the
+        // file into it. Relative paths resolve against the caller's cwd.
+        const filePath = path_1.default.resolve(process.cwd(), sub);
+        const created = await sendV2('surface.create', { type: 'markdown' });
+        const surfaceId = created?.surfaceId;
+        if (!surfaceId) {
+            console.error('Failed to create markdown surface');
+            process.exit(1);
+        }
+        print(await sendV2('markdown.load_file', { surfaceId, filePath }));
+    }
+    else {
+        console.error('Usage: wmux markdown <file>  |  wmux markdown set <id> --content <text> [--title T] | --file <path>  |  wmux markdown get <id>');
+        process.exit(1);
+    }
+}
+async function cmdNewWorkspace(args) {
+    const params = {};
+    for (let i = 1; i < args.length; i += 2) {
+        if (args[i] === '--title')
+            params.title = args[i + 1];
+        if (args[i] === '--shell')
+            params.shell = args[i + 1];
+        if (args[i] === '--cwd')
+            params.cwd = args[i + 1];
+    }
+    print(await sendV2('workspace.create', params));
+}
+// Remote terminal (issue #78): open a workspace whose shell is the OpenSSH
+// client connecting to <target>. Everything that isn't a wmux flag is passed
+// through to ssh, so `wmux ssh -p 2222 user@host` works as expected.
+async function cmdSsh(args) {
+    const title = getFlag(args, '--title');
+    const sshArgs = [];
+    for (let i = 1; i < args.length; i++) {
+        if (args[i] === '--title') {
+            i++;
+            continue;
+        }
+        sshArgs.push(args[i]);
+    }
+    if (sshArgs.length === 0) {
+        console.error('Usage: wmux ssh [ssh options] <user@host> [--title T]');
+        process.exit(1);
+    }
+    // Title heuristic: the last non-flag token is the destination (`-p 2222
+    // user@host` → "user@host"), matching how ssh itself orders its argv.
+    const target = [...sshArgs].reverse().find((a) => !a.startsWith('-')) ?? sshArgs[sshArgs.length - 1];
+    print(await sendV2('workspace.create', {
+        title: title || `ssh ${target}`,
+        shell: `ssh ${sshArgs.join(' ')}`,
+    }));
+}
+// TCP↔pipe bridge (issue #78): exposes this machine's wmux pipe on a TCP port
+// so a remote CLI can drive it through an SSH tunnel. Pure byte relay — no
+// parsing, no auth of its own; the pipe token is still verified end-to-end by
+// wmux's pipe server, so the bridge grants nothing by itself.
+async function cmdBridge(args) {
+    const port = parseInt(getFlag(args, '--port') || '', 10) || DEFAULT_BRIDGE_PORT;
+    // --wsl binds 0.0.0.0 so a container on the Windows host can reach a bridge
+    // running inside WSL2 (issue #19). WSL2's NAT gives the distro an address the
+    // container resolves as host.docker.internal, but 127.0.0.1 inside the distro
+    // is not it. The pipe token still authenticates every request end to end.
+    const wslMode = args.includes('--wsl');
+    const host = getFlag(args, '--host') || (wslMode ? '0.0.0.0' : '127.0.0.1');
+    if (host !== '127.0.0.1' && host !== 'localhost') {
+        console.warn('WARNING: binding beyond localhost exposes the wmux pipe to the network.');
+        console.warn(`Prefer the default 127.0.0.1 + an SSH tunnel: ssh -L ${port}:127.0.0.1:${port} user@host`);
+    }
+    // ── Warm relay pool ─────────────────────────────────────────────────────────
+    // Spawn-per-connection made every request pay the relay's whole startup: a fresh
+    // npiperelay.exe launched over WSL interop (AV/EDR scans the binary on each exec
+    // on a corporate-managed host) and then the pipe dial. Measured worst case from a
+    // devcontainer is ~7s — on every hook. Keeping relays open ahead of demand moves
+    // that cost off the request path: a warm relay has already spawned AND attached
+    // by the time a client arrives, so hand-off is just pipe().
+    //
+    // Deliberately a POOL of exclusive relays, not one shared relay multiplexed
+    // across clients. Multiplexing would force the bridge to parse frames and rewrite
+    // JSON-RPC ids to route replies back to the right socket, which:
+    //   * breaks V1 entirely — `pong` / `ok` / `unauthorized` carry no id to route on;
+    //   * makes every client a casualty when the single relay dies;
+    //   * costs the bridge its one real virtue, being a transparent byte pipe (any
+    //     future streaming or server-pushed method would have to be taught to it).
+    // Pooling buys the same latency win and the bridge stays dumb.
+    //
+    // Only on the npiperelay path — elsewhere this would hold idle sockets open to
+    // buy nothing.
+    const warmSize = usesNpiperelay() ? BRIDGE_WARM_RELAYS : 0;
+    const warm = [];
+    let warmFailures = 0;
+    let refillTimer = null;
+    const scheduleRefill = (delayMs) => {
+        if (refillTimer || warm.length >= warmSize)
+            return;
+        refillTimer = setTimeout(() => {
+            refillTimer = null;
+            fillWarm();
+        }, delayMs);
+        refillTimer.unref();
+    };
+    function fillWarm() {
+        while (warm.length < warmSize) {
+            const stream = connectTransport(() => { });
+            const entry = { stream, claim: () => { } };
+            // Dying before being claimed means the upstream isn't there — wmux not
+            // running, or the pipe gone. npiperelay exits immediately in that case, so
+            // without a backoff the bridge would respawn a Windows process in a tight
+            // loop for as long as wmux stays down.
+            const onDead = () => {
+                const i = warm.indexOf(entry);
+                if (i === -1)
+                    return; // already claimed — the client's teardown owns it now
+                warm.splice(i, 1);
+                warmFailures = Math.min(warmFailures + 1, 6);
+                scheduleRefill(Math.min(30000, 500 * 2 ** warmFailures));
+            };
+            entry.claim = () => {
+                stream.off('error', onDead);
+                stream.off('close', onDead);
+            };
+            stream.on('error', onDead);
+            stream.on('close', onDead);
+            warm.push(entry);
+        }
+    }
+    // An idle relay reads nothing, so anything the upstream sent while it waited stays
+    // buffered in the stream and is delivered the moment the client pipes it — no need
+    // to drain before hand-off.
+    const takeWarm = () => {
+        while (warm.length) {
+            const entry = warm.pop();
+            entry.claim();
+            // wmux may have restarted since this relay attached.
+            if (!entry.stream.destroyed && entry.stream.writable) {
+                warmFailures = 0;
+                return entry.stream;
+            }
+            entry.stream.destroy();
+        }
+        return null;
+    };
+    const server = net_1.default.createServer((sock) => {
+        // Connect to the local wmux through the same selector the CLI uses. In the
+        // bridge process remoteTarget is always null, so this resolves to a Unix
+        // socket, npiperelay (inside WSL2), or the named pipe directly — which is
+        // what lets `wmux bridge` run inside WSL2 and still reach the Windows pipe.
+        // A warm relay is the same thing, already connected.
+        const pipe = takeWarm() ?? connectTransport(() => { });
+        // Replace what we just consumed so the next client is served warm too.
+        scheduleRefill(0);
+        sock.pipe(pipe);
+        pipe.pipe(sock);
+        // Teardown is half-close-aware on purpose. Destroying BOTH sides on either
+        // 'close' silently ate hook events: wmux-hook.js writes its frame and end()s
+        // immediately, and over npiperelay the Duplex's destroy() is child.kill() —
+        // so the relay died with the frame still buffered in its stdin and never
+        // forwarded it. Clients that write-then-close are the normal case here
+        // (every Claude Code hook is one), not an abort.
+        //
+        // 'end' (peer finished sending) therefore FLUSHES rather than destroys: end()
+        // the other side so its buffered bytes drain and the pipe sees a clean EOF.
+        // destroy() is reserved for 'error', where there is nothing left to save.
+        let done = false;
+        const destroyBoth = () => {
+            if (done)
+                return;
+            done = true;
+            sock.destroy();
+            pipe.destroy();
+        };
+        // A closed socket can no longer drain anything, so 'close' still tears down —
+        // but only after a grace period, giving an in-flight relay time to finish
+        // forwarding what it already holds.
+        const closeAfterDrain = () => {
+            if (done)
+                return;
+            setTimeout(destroyBoth, BRIDGE_DRAIN_GRACE_MS).unref();
+        };
+        sock.on('error', destroyBoth);
+        pipe.on('error', destroyBoth);
+        sock.on('end', () => { pipe.end(); });
+        pipe.on('end', () => { sock.end(); });
+        sock.on('close', closeAfterDrain);
+        pipe.on('close', closeAfterDrain);
+    });
+    server.on('error', (err) => { console.error(`bridge error: ${err.message}`); process.exit(1); });
+    // Warm relays hold a live pipe connection (and an npiperelay.exe) for as long as
+    // the bridge runs, so retire them on the way out rather than orphaning them.
+    const shutdown = () => {
+        if (refillTimer)
+            clearTimeout(refillTimer);
+        warm.splice(0).forEach((e) => { e.claim(); e.stream.destroy(); });
+        process.exit(0);
+    };
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+    server.listen(port, host, () => {
+        console.log(`wmux bridge listening on ${host}:${port} ↔ ${PIPE_PATH}`);
+        if (warmSize > 0) {
+            fillWarm();
+            console.log(`Keeping ${warmSize} npiperelay relay(s) warm (WMUX_BRIDGE_WARM=0 to disable).`);
+        }
+        if (wslMode) {
+            console.log('WSL2 mode. From a container on this host:');
+            console.log(`  WMUX_REMOTE=host.docker.internal:${port}`);
+            console.log("  WMUX_REMOTE_TOKEN=<run 'wmux token' here>");
+        }
+        else {
+            console.log('From another machine:');
+            console.log(`  ssh -L ${port}:127.0.0.1:${port} <user>@<this-host>`);
+            console.log(`  wmux --remote 127.0.0.1:${port} --token <run 'wmux token' here> list-workspaces`);
+        }
+        console.log('Ctrl+C to stop.');
+    });
+}
+// Prints this instance's pipe auth token so it can be passed to --token /
+// WMUX_REMOTE_TOKEN on the machine that will drive this one remotely.
+function cmdToken() {
+    if (!PIPE_TOKEN) {
+        console.error('No pipe token found — has wmux been started on this machine?');
+        process.exit(1);
+    }
+    console.log(PIPE_TOKEN);
+}
+async function cmdSetColorScheme(args) {
+    // Two forms:
+    //   wmux set-color-scheme <scheme>             → apply to current surface
+    //   wmux set-color-scheme <surfaceId> <scheme> → apply to a specific surface
+    let surfaceId = args[1];
+    let scheme = args[2];
+    if (!scheme) {
+        scheme = surfaceId;
+        surfaceId = process.env.WMUX_SURFACE_ID || '';
+    }
+    if (!surfaceId) {
+        console.error('No surface id. Pass one as argument or run inside a wmux pane.');
+        process.exit(1);
+    }
+    if (!scheme) {
+        console.error('Usage: wmux set-color-scheme [surfaceId] <scheme>');
+        process.exit(1);
+    }
+    print(await sendV2('surface.set_color_scheme', { surfaceId, colorScheme: scheme }));
+}
+async function cmdSend(args) {
+    // Drop --surface <id> (and its value) from the free-form text args.
+    const surfaceId = getFlag(args, '--surface') || process.env.WMUX_SURFACE_ID;
+    const textArgs = stripFlag(args.slice(1), '--surface');
+    const payload = { text: textArgs.join(' ') };
+    if (surfaceId)
+        payload.surfaceId = surfaceId;
+    print(await sendV2('surface.send_text', payload));
+}
+async function cmdSendKey(args) {
+    const key = args[1];
+    const modifiers = [];
+    if (args.includes('--ctrl'))
+        modifiers.push('ctrl');
+    if (args.includes('--shift'))
+        modifiers.push('shift');
+    if (args.includes('--alt'))
+        modifiers.push('alt');
+    const surfaceId = getFlag(args, '--surface') || process.env.WMUX_SURFACE_ID;
+    const payload = { key, modifiers };
+    if (surfaceId)
+        payload.surfaceId = surfaceId;
+    print(await sendV2('surface.send_key', payload));
+}
+async function cmdNotify(args) {
+    const titleIdx = args.indexOf('--title');
+    const bodyIdx = args.indexOf('--body');
+    const body = bodyIdx !== -1 ? args[bodyIdx + 1] : undefined;
+    const text = args.filter((_, i) => i > 0 && ![titleIdx, titleIdx + 1, bodyIdx, bodyIdx + 1].includes(i)).join(' ') || body || '';
+    await sendV1(`notify ${process.env.WMUX_SURFACE_ID || ''} ${text}`);
+    console.log('Notification sent');
+}
+async function cmdHook(args) {
+    const params = {};
+    for (let i = 1; i < args.length; i += 2) {
+        if (args[i] === '--event')
+            params.event = args[i + 1];
+        if (args[i] === '--tool')
+            params.tool = args[i + 1];
+        if (args[i] === '--agent')
+            params.agentId = args[i + 1];
+    }
+    await sendV2('hook.event', params);
+}
+async function cmdAgentActivity(args) {
+    const surfaceId = getFlag(args, '--surface') || process.env.WMUX_SURFACE_ID;
+    if (!surfaceId) {
+        console.error('agent-activity: --surface or WMUX_SURFACE_ID required');
+        process.exit(1);
+    }
+    const params = { surfaceId };
+    const tool = getFlag(args, '--tool');
+    if (tool)
+        params.tool = tool;
+    const skill = getFlag(args, '--skill');
+    if (skill)
+        params.skill = skill;
+    if (args.includes('--done'))
+        params.done = true;
+    if (args.includes('--active'))
+        params.done = false;
+    await sendV2('agent.activity', params);
+}
+// Generic V1 passthrough (issue #19: devcontainer support). Lets a caller send
+// any raw V1 command line (report_pwd, report_git_branch, report_shell_state,
+// report_startup_command, …) without the CLI growing a near-identical wrapper
+// for each. wmux-bash-integration.sh writes those lines straight to the local
+// pipe when it can reach one; inside a devcontainer it can't, so it calls
+// `wmux raw-v1` instead and gets the CLI's transport — including TCP via
+// --remote / WMUX_REMOTE to a `wmux bridge` (issue #78) — for free. Auth is
+// unchanged: sendV1 still prefixes `auth <token>`.
+async function cmdRawV1(args) {
+    const line = args.slice(1).join(' ');
+    if (!line) {
+        console.error('Usage: wmux raw-v1 <command> [surfaceId] [args...]');
+        process.exit(1);
+    }
+    console.log(await sendV1(line));
+}
+// ─── Declared agent state (issue #128) ───────────────────────────────────────
+// The reporting side of the protocol. An agent running inside a wmux pane can
+// call these with no arguments beyond the state itself — WMUX_SURFACE_ID is
+// already in its environment, so it never has to discover which pane it is in.
+/** Resolve the pane this command is about: --surface, else the ambient pane. */
+function reportingSurface(args, command) {
+    const surfaceId = getFlag(args, '--surface') || process.env.WMUX_SURFACE_ID;
+    if (!surfaceId) {
+        console.error(`${command}: --surface or WMUX_SURFACE_ID required`);
+        process.exit(1);
+    }
+    return surfaceId;
+}
+/** Optional monotonic sequence — wmux drops any report at or below the last seen. */
+function seqFlag(args) {
+    const raw = getFlag(args, '--seq');
+    if (!raw)
+        return undefined;
+    const seq = Number(raw);
+    return Number.isFinite(seq) ? seq : undefined;
+}
+async function cmdReportAgent(args) {
+    const surfaceId = reportingSurface(args, 'report-agent');
+    const params = { surfaceId, seq: seqFlag(args) };
+    // --blocked [reason] parks the pane on the user; --unblocked releases it.
+    if (args.includes('--blocked')) {
+        params.awaitingHuman = true;
+        params.reason = getFlag(args, '--blocked') || getFlag(args, '--reason') || null;
+    }
+    else if (args.includes('--unblocked')) {
+        params.awaitingHuman = false;
+    }
+    if (args.includes('--run-start'))
+        params.runDelta = 1;
+    if (args.includes('--run-end'))
+        params.runDelta = -1;
+    const depth = getFlag(args, '--run-depth');
+    if (depth !== undefined)
+        params.runDepth = Number(depth);
+    // --choices declares what wmux may offer as an answer (issue #128). JSON
+    // rather than a packed string because each choice carries four fields and the
+    // payload is exact bytes — the one place a cramped syntax would be a bug
+    // waiting to happen. Mirrors `agent spawn-batch --json`.
+    const choices = getFlag(args, '--choices');
+    if (choices !== undefined) {
+        try {
+            params.choices = JSON.parse(choices);
+        }
+        catch (err) {
+            console.error(`report-agent: --choices is not valid JSON: ${err.message}`);
+            process.exit(1);
+        }
+    }
+    print(await sendV2('pane.report_agent', params));
+}
+/**
+ * `answer-agent` — reply to a blocked pane from outside it (issue #128).
+ *
+ * Note this one defaults to NO ambient surface: the other verbs are an agent
+ * describing itself, where WMUX_SURFACE_ID is exactly right, but answering is
+ * aimed at a DIFFERENT pane — the whole point is to not be in it. Defaulting to
+ * the caller's own pane would make `wmux answer-agent --choice allow` type into
+ * whatever terminal you happen to be sitting in.
+ */
+async function cmdAnswerAgent(args) {
+    const surfaceId = getFlag(args, '--surface');
+    if (!surfaceId) {
+        console.error('answer-agent: --surface required (run `wmux agent-state` to see which panes are blocked)');
+        process.exit(1);
+    }
+    const choiceId = getFlag(args, '--choice') ?? args[1];
+    print(await sendV2('pane.answer_agent', { surfaceId, choiceId: choiceId ?? null }));
+}
+async function cmdReportMetadata(args) {
+    const surfaceId = reportingSurface(args, 'report-metadata');
+    const params = { surfaceId, seq: seqFlag(args) };
+    const model = getFlag(args, '--model');
+    if (model)
+        params.model = model;
+    const tokens = getFlag(args, '--tokens');
+    if (tokens)
+        params.tokens = tokens;
+    const pct = getFlag(args, '--context-pct');
+    if (pct)
+        params.contextPct = Number(pct);
+    const ttl = getFlag(args, '--ttl');
+    if (ttl)
+        params.ttlMs = Number(ttl);
+    print(await sendV2('pane.report_metadata', params));
+}
+// Keys stay inferred (no Record<string, …> annotation) so spreading this into
+// COMMANDS still satisfies the exhaustive Record<CommandName, …> check.
+const AGENT_STATE_COMMANDS = {
+    'report-agent': cmdReportAgent,
+    'report-metadata': cmdReportMetadata,
+    'report-session': async (args) => {
+        const surfaceId = reportingSurface(args, 'report-session');
+        print(await sendV2('pane.report_agent_session', {
+            surfaceId,
+            seq: seqFlag(args),
+            sessionId: getFlag(args, '--session') ?? args[1] ?? null,
+        }));
+    },
+    'answer-agent': cmdAnswerAgent,
+    'release-agent': async (args) => {
+        const surfaceId = reportingSurface(args, 'release-agent');
+        print(await sendV2('pane.release_agent', { surfaceId, seq: seqFlag(args) }));
+    },
+    // No --surface → the whole picture, including a `blocked` list that answers
+    // "which pane needs me?" in one call.
+    'agent-state': async (args) => {
+        const surfaceId = getFlag(args, '--surface');
+        print(await sendV2('pane.agent_state', surfaceId ? { surfaceId } : {}));
+    },
+};
+const SURFACE_NOTE = '(surface defaults to $WMUX_SURFACE_ID inside a pane)';
+const COMMAND_SPECS = {
+    // System
+    ping: { usage: 'wmux ping' },
+    identify: { usage: 'wmux identify' },
+    capabilities: { usage: 'wmux capabilities' },
+    'list-windows': { usage: 'wmux list-windows' },
+    'focus-window': { usage: 'wmux focus-window <windowId>' },
+    'new-window': { usage: 'wmux new-window' },
+    // Remote management (issue #78)
+    bridge: {
+        usage: [
+            'wmux bridge [--port P] [--host H] [--wsl]   (expose this wmux\'s pipe over TCP, default 127.0.0.1:9787)',
+            '  --wsl   bind 0.0.0.0 so a container on this host can reach a bridge running in WSL2',
+        ].join('\n'),
+        value: ['--port', '--host'],
+        bool: ['--wsl'],
+    },
+    token: { usage: 'wmux token   (print this instance\'s pipe auth token)' },
+    // Workspace
+    'new-workspace': {
+        usage: 'wmux new-workspace [--title T] [--shell S] [--cwd D]',
+        value: ['--title', '--shell', '--cwd'],
+    },
+    ssh: { usage: 'wmux ssh [ssh options] <user@host> [--title T]', passthrough: true },
+    'close-workspace': { usage: 'wmux close-workspace [workspaceId]' },
+    'select-workspace': { usage: 'wmux select-workspace <workspaceId>' },
+    'rename-workspace': { usage: 'wmux rename-workspace <workspaceId> <title>', passthrough: true },
+    'list-workspaces': { usage: 'wmux list-workspaces' },
+    // Surface
+    'new-surface': {
+        usage: 'wmux new-surface [--type terminal|browser|markdown] [--color-scheme NAME]',
+        value: ['--type', '--color-scheme'],
+    },
+    'close-surface': { usage: 'wmux close-surface [surfaceId]' },
+    'rename-surface': {
+        usage: 'wmux rename-surface [surfaceId] <title>   (renames the current surface inside a pane)',
+        passthrough: true,
+    },
+    'focus-surface': { usage: 'wmux focus-surface <surfaceId>' },
+    'list-surfaces': {
+        usage: 'wmux list-surfaces [--pane <paneId>] [--workspace <workspaceId>]',
+        value: ['--pane', '--workspace'],
+    },
+    'set-color-scheme': { usage: 'wmux set-color-scheme [surfaceId] <scheme>' },
+    'clear-color-scheme': { usage: 'wmux clear-color-scheme [surfaceId]' },
+    'list-themes': { usage: 'wmux list-themes' },
+    themes: { usage: 'wmux themes   (alias of list-themes)' },
+    // User config
+    'reload-config': { usage: 'wmux reload-config' },
+    config: { usage: 'wmux config <show|reload|path>' },
+    locales: { usage: 'wmux locales [list|reload|path]' },
+    // Pane
+    split: {
+        usage: 'wmux split [--down] [--type terminal|browser|markdown] [--color-scheme NAME]',
+        value: ['--type', '--color-scheme'],
+        bool: ['--down'],
+    },
+    pane: {
+        usage: [
+            'wmux pane new [--down] [--type T] [--color-scheme NAME]',
+            'wmux pane close <paneId> | focus <paneId> | list [--workspace <id>]',
+        ].join('\n'),
+        value: ['--type', '--color-scheme', '--workspace'],
+        bool: ['--down'],
+    },
+    'close-pane': { usage: 'wmux close-pane [paneId]' },
+    'focus-pane': { usage: 'wmux focus-pane <paneId>' },
+    'zoom-pane': { usage: 'wmux zoom-pane [paneId]' },
+    'list-panes': { usage: 'wmux list-panes [--workspace <workspaceId>]', value: ['--workspace'] },
+    tree: { usage: 'wmux tree [--workspace <workspaceId>]', value: ['--workspace'] },
+    // Layout
+    layout: {
+        usage: 'wmux layout grid --count <N> [--type T] [--anchor-surface <id>] [--anchor-pane <id>] [--workspace <id>]',
+        value: ['--count', '--type', '--anchor-surface', '--anchor-pane', '--workspace'],
+    },
+    // Terminal interaction
+    send: { usage: 'wmux send [--surface <id>] <text>', passthrough: true },
+    'send-key': {
+        usage: 'wmux send-key <key> [--ctrl] [--shift] [--alt] [--surface <id>]',
+        value: ['--surface'],
+        bool: ['--ctrl', '--shift', '--alt'],
+    },
+    'read-screen': {
+        usage: `wmux read-screen [--lines N] [--surface <id>]   ${SURFACE_NOTE}`,
+        value: ['--lines', '--surface'],
+    },
+    'trigger-flash': { usage: 'wmux trigger-flash [surfaceId]' },
+    // Browser (free-form text for type/fill/eval)
+    browser: {
+        usage: [
+            'wmux browser open <url> | snapshot | click <ref> | type <ref> <text> | fill <ref> <value>',
+            'wmux browser screenshot [--full] | get-text [ref] | eval <js> | wait <ref> [ms]',
+            'wmux browser back | forward | reload',
+            `  [--surface <id>]   ${SURFACE_NOTE}`,
+        ].join('\n'),
+        passthrough: true,
+    },
+    // Agent
+    agent: {
+        usage: [
+            'wmux agent spawn --cmd <C> [--label L] [--cwd D] [--pane P] [--workspace W] [--replace-tab]',
+            'wmux agent spawn-batch --json \'[...]\' [--strategy distribute|stack|split]',
+            'wmux agent status <agentId> | list [--workspace <id>] | kill <agentId>',
+        ].join('\n'),
+        value: ['--cmd', '--label', '--cwd', '--pane', '--workspace', '--json', '--strategy'],
+        bool: ['--replace-tab'],
+    },
+    // Markdown (--content takes free-form text)
+    markdown: {
+        usage: [
+            'wmux markdown <file>                                   (open a file in a new markdown view)',
+            'wmux markdown set <id> --content <text> [--title T]',
+            'wmux markdown set <id> --file <path>',
+            'wmux markdown get <id>',
+        ].join('\n'),
+        passthrough: true,
+    },
+    // Notifications
+    notify: { usage: 'wmux notify <text>', passthrough: true },
+    'list-notifications': { usage: 'wmux list-notifications' },
+    'clear-notifications': { usage: 'wmux clear-notifications [notificationId]' },
+    // Sidebar
+    'set-status': {
+        usage: [
+            'wmux set-status --workspace <id> --state <idle|running|interrupted> [--text "<label>"]',
+            'wmux set-status <key> <value>                          (legacy positional form)',
+        ].join('\n'),
+        value: ['--workspace', '--state', '--text'],
+    },
+    'set-progress': { usage: 'wmux set-progress <value> [--label L]', value: ['--label'] },
+    log: { usage: 'wmux log <level> <message>', passthrough: true },
+    'sidebar-state': { usage: 'wmux sidebar-state' },
+    diff: { usage: 'wmux diff [--file <path>]', value: ['--file'] },
+    hook: {
+        usage: 'wmux hook --event <type> --tool <name> [--agent <id>]',
+        value: ['--event', '--tool', '--agent'],
+    },
+    'agent-activity': {
+        usage: `wmux agent-activity [--tool T] [--skill S] [--done|--active] [--surface <id>]   ${SURFACE_NOTE}`,
+        value: ['--tool', '--skill', '--surface'],
+        bool: ['--done', '--active'],
+    },
+    'raw-v1': {
+        usage: 'wmux raw-v1 <command> [surfaceId] [args...]   (send a raw V1 line; used by shell integration)',
+        passthrough: true,
+    },
+    // Declared agent state (issue #128)
+    'report-agent': {
+        usage: [
+            'wmux report-agent --blocked [reason] [--choices <json>] | --unblocked',
+            'wmux report-agent --run-start | --run-end | --run-depth <N>',
+            `  [--seq N] [--surface <id>]   ${SURFACE_NOTE}`,
+        ].join('\n'),
+        // --blocked's reason is optional; treating it as value-taking only ever
+        // skips one token that a later flag would have re-validated anyway.
+        value: ['--blocked', '--reason', '--choices', '--run-depth', '--seq', '--surface'],
+        bool: ['--unblocked', '--run-start', '--run-end'],
+    },
+    'report-metadata': {
+        usage: `wmux report-metadata [--model M] [--tokens T] [--context-pct N] [--ttl ms] [--seq N] [--surface <id>]   ${SURFACE_NOTE}`,
+        value: ['--model', '--tokens', '--context-pct', '--ttl', '--seq', '--surface'],
+    },
+    'report-session': {
+        usage: `wmux report-session <sessionId> [--seq N] [--surface <id>]   ${SURFACE_NOTE}`,
+        value: ['--session', '--seq', '--surface'],
+    },
+    'answer-agent': {
+        usage: 'wmux answer-agent --surface <id> --choice <choiceId>   (reply to ANOTHER pane; no ambient default)',
+        value: ['--surface', '--choice'],
+    },
+    'release-agent': {
+        usage: `wmux release-agent [--seq N] [--surface <id>]   ${SURFACE_NOTE}`,
+        value: ['--seq', '--surface'],
+    },
+    'agent-state': {
+        usage: 'wmux agent-state [--surface <id>]   (no --surface → every pane, plus the blocked list)',
+        value: ['--surface'],
+    },
+};
+/**
+ * Reject flags the command does not declare, instead of running with defaults.
+ *
+ * Only `--` flags are judged: single-dash tokens belong to passthrough commands
+ * (ssh options) and bare words are positional arguments.
+ */
+function checkFlags(command, args, spec) {
+    if (spec.passthrough)
+        return;
+    const takesValue = new Set(spec.value ?? []);
+    const standalone = new Set(spec.bool ?? []);
+    for (let i = 1; i < args.length; i++) {
+        const arg = args[i];
+        if (!arg.startsWith('--'))
+            continue;
+        if (standalone.has(arg))
+            continue;
+        if (takesValue.has(arg)) {
+            // A trailing value flag is the same silent default in a different
+            // costume: `getFlag` returns undefined and the command runs anyway.
+            // --blocked is the one flag whose value is genuinely optional.
+            if (i === args.length - 1 && arg !== '--blocked') {
+                fail(command, spec, `Flag '${arg}' needs a value.`);
+            }
+            i++;
+            continue;
+        }
+        fail(command, spec, `Unknown flag for '${command}': ${arg}`);
+    }
+}
+/** Print why the argv was rejected, then that command's usage, then exit 1. */
+function fail(command, spec, message) {
+    console.error(message);
+    console.error('');
+    console.error(spec.usage);
+    process.exit(1);
+}
+/** `wmux help [command]` — the only help route that works for passthrough commands. */
+function cmdHelp(args) {
+    const topic = args[1];
+    if (!topic) {
         printUsage();
+        return;
+    }
+    const spec = COMMAND_SPECS[topic];
+    if (!spec) {
+        console.error(`Unknown command: ${topic}`);
+        printUsage();
+        process.exit(1);
+    }
+    console.log(spec.usage);
+}
+// Command dispatch table. Each handler receives the raw argv (args[0] is the
+// command name). Replaces a single giant switch so each command stays small and
+// independently testable. Typed against COMMAND_SPECS so the compiler — not a
+// bug report — catches a command that ships without usage text, or usage text
+// for a command that no longer exists.
+const COMMANDS = {
+    // System
+    ping: async () => console.log(await sendV1('ping')),
+    identify: async () => print(await sendV2('system.identify')),
+    capabilities: async () => print(await sendV2('system.capabilities')),
+    'list-windows': async () => print(await sendV2('window.list')),
+    'focus-window': async (args) => print(await sendV2('window.focus', { id: args[1] })),
+    'new-window': async () => print(await sendV2('window.create')),
+    // Remote management (issue #78)
+    bridge: cmdBridge,
+    token: cmdToken,
+    // Workspace
+    'new-workspace': cmdNewWorkspace,
+    ssh: cmdSsh,
+    'close-workspace': async (args) => print(await sendV2('workspace.close', { id: args[1] })),
+    'select-workspace': async (args) => print(await sendV2('workspace.select', { id: args[1] })),
+    'rename-workspace': async (args) => print(await sendV2('workspace.rename', { id: args[1], title: args[2] })),
+    'list-workspaces': async () => print(await sendV2('workspace.list')),
+    // Surface
+    'new-surface': async (args) => {
+        const type = getFlag(args, '--type') || 'terminal';
+        const colorScheme = getFlag(args, '--color-scheme');
+        print(await sendV2('surface.create', { type, ...(colorScheme ? { colorScheme } : {}) }));
+    },
+    'close-surface': async (args) => print(await sendV2('surface.close', { id: args[1] })),
+    // `rename-surface <id> <title>`, or `rename-surface <title>` from inside a
+    // pane (renames the current surface via WMUX_SURFACE_ID).
+    'rename-surface': async (args) => {
+        let id = args[1];
+        let title = args[2];
+        if (title === undefined && process.env.WMUX_SURFACE_ID) {
+            title = id;
+            id = process.env.WMUX_SURFACE_ID;
+        }
+        print(await sendV2('surface.rename', { id, title }));
+    },
+    'focus-surface': async (args) => print(await sendV2('surface.focus', { id: args[1] })),
+    'list-surfaces': async (args) => print(await sendV2('surface.list', {
+        paneId: getFlag(args, '--pane'),
+        workspaceId: getFlag(args, '--workspace'),
+    })),
+    'set-color-scheme': cmdSetColorScheme,
+    'clear-color-scheme': async (args) => {
+        const surfaceId = args[1] || process.env.WMUX_SURFACE_ID || '';
+        if (!surfaceId) {
+            console.error('No surface id. Pass one as argument or run inside a wmux pane.');
+            process.exit(1);
+        }
+        print(await sendV2('surface.set_color_scheme', { surfaceId, colorScheme: null }));
+    },
+    'list-themes': async () => print(await sendV2('theme.list')),
+    themes: async () => print(await sendV2('theme.list')),
+    // User config (~/.wmux/config.toml)
+    'reload-config': async () => print(await sendV2('config.reload')),
+    config: cmdConfig,
+    // Community translations (~/.wmux/locales/*.json)
+    locales: cmdLocales,
+    // Pane
+    split: async (args) => {
+        const direction = args.includes('--down') ? 'down' : 'right';
+        const type = getFlag(args, '--type') || 'terminal';
+        const colorScheme = getFlag(args, '--color-scheme');
+        print(await sendV2('pane.split', { direction, type, ...(colorScheme ? { colorScheme } : {}) }));
+    },
+    pane: cmdPane,
+    'close-pane': async (args) => print(await sendV2('pane.close', { id: args[1] })),
+    'focus-pane': async (args) => print(await sendV2('pane.focus', { id: args[1] })),
+    'zoom-pane': async (args) => print(await sendV2('pane.zoom', { id: args[1] })),
+    'list-panes': async (args) => print(await sendV2('pane.list', { workspaceId: getFlag(args, '--workspace') })),
+    // `--workspace` used to be parsed by nobody: the flag was accepted on the
+    // command line and silently dropped here, so every call reported the ACTIVE
+    // workspace's tree whatever id you passed (issue #141).
+    tree: async (args) => print(await sendV2('system.tree', { workspaceId: getFlag(args, '--workspace') })),
+    // Layout
+    layout: cmdLayout,
+    // Terminal interaction
+    send: cmdSend,
+    'send-key': cmdSendKey,
+    'read-screen': async (args) => {
+        const lines = args.find((a, i) => args[i - 1] === '--lines');
+        // Same targeting rule as send/send-key: inside a pane the caller's own
+        // surface is the default; cross-pane reads take --surface explicitly.
+        const surfaceId = getFlag(args, '--surface') || process.env.WMUX_SURFACE_ID;
+        print(await sendV2('surface.read_text', {
+            ...(surfaceId ? { surfaceId } : {}),
+            lines: lines ? parseInt(lines) : 50,
+        }));
+    },
+    'trigger-flash': async (args) => print(await sendV2('surface.trigger_flash', { id: args[1] })),
+    // Browser
+    browser: cmdBrowser,
+    // Agent
+    agent: cmdAgent,
+    // Markdown
+    markdown: cmdMarkdown,
+    // Notifications
+    notify: cmdNotify,
+    'list-notifications': async () => print(await sendV2('notification.list')),
+    'clear-notifications': async (args) => print(await sendV2('notification.clear', { id: args[1] })),
+    // Sidebar
+    'set-status': async (args) => {
+        // `set-status --workspace <id> --state <idle|running|interrupted> [--text "<label>"]`
+        // sets a named workspace's sidebar status from anywhere (works outside a
+        // pane, unlike the surface-scoped shell integration). Without --workspace it
+        // falls back to the legacy positional `set-status <key> <value>` form.
+        const workspaceId = getFlag(args, '--workspace');
+        if (workspaceId) {
+            const state = getFlag(args, '--state');
+            const valid = ['idle', 'running', 'interrupted'];
+            if (!state || !valid.includes(state)) {
+                console.error(`set-status --workspace requires --state <${valid.join('|')}>`);
+                process.exit(1);
+            }
+            const text = getFlag(args, '--text');
+            print(await sendV2('workspace.set_status', { workspaceId, state, ...(text ? { text } : {}) }));
+            return;
+        }
+        print(await sendV2('sidebar.set_status', { key: args[1], value: args[2] }));
+    },
+    'set-progress': async (args) => {
+        const label = args.find((a, i) => args[i - 1] === '--label');
+        print(await sendV2('sidebar.set_progress', { value: parseFloat(args[1]), label }));
+    },
+    log: async (args) => print(await sendV2('sidebar.log', { level: args[1], message: args.slice(2).join(' ') })),
+    'sidebar-state': async () => print(await sendV2('sidebar.get_state')),
+    diff: async (args) => {
+        const file = args.find((a, i) => args[i - 1] === '--file') || '';
+        print(await sendV2('diff.refresh', { file }));
+    },
+    hook: cmdHook,
+    'agent-activity': cmdAgentActivity,
+    // Devcontainer support (issue #19)
+    'raw-v1': cmdRawV1,
+    ...AGENT_STATE_COMMANDS,
+};
+async function main() {
+    let args = process.argv.slice(2);
+    // Global flags (issue #78 remote management) — may appear anywhere in argv.
+    const remoteSpec = getFlag(args, '--remote') ?? process.env.WMUX_REMOTE;
+    const tokenOverride = getFlag(args, '--token') ?? process.env.WMUX_REMOTE_TOKEN;
+    args = stripFlag(stripFlag(args, '--remote'), '--token');
+    if (remoteSpec)
+        remoteTarget = parseRemoteTarget(remoteSpec);
+    if (tokenOverride)
+        PIPE_TOKEN = tokenOverride;
+    const command = args[0];
+    if (!command || command === 'help' || command === '--help' || command === '-h') {
+        cmdHelp(command === 'help' ? args : []);
         process.exit(0);
     }
+    const handler = COMMANDS[command];
+    if (!handler) {
+        console.error(`Unknown command: ${command}`);
+        printUsage();
+        process.exit(1);
+    }
+    // Usage and flag checks both happen before a single byte reaches the pipe, so
+    // probing the CLI can no longer mutate the user's layout (issue #143).
+    const spec = COMMAND_SPECS[command];
+    if (!spec.passthrough && (args.includes('--help') || args.includes('-h'))) {
+        console.log(spec.usage);
+        process.exit(0);
+    }
+    checkFlags(command, args, spec);
     try {
-        switch (command) {
-            // System
-            case 'ping':
-                console.log(await sendV1('ping'));
-                break;
-            case 'identify':
-                console.log(JSON.stringify(await sendV2('system.identify'), null, 2));
-                break;
-            case 'capabilities':
-                console.log(JSON.stringify(await sendV2('system.capabilities'), null, 2));
-                break;
-            case 'list-windows':
-                console.log(JSON.stringify(await sendV2('window.list'), null, 2));
-                break;
-            case 'focus-window':
-                console.log(JSON.stringify(await sendV2('window.focus', { id: args[1] }), null, 2));
-                break;
-            // Workspace
-            case 'new-workspace': {
-                const params = {};
-                for (let i = 1; i < args.length; i += 2) {
-                    if (args[i] === '--title')
-                        params.title = args[i + 1];
-                    if (args[i] === '--shell')
-                        params.shell = args[i + 1];
-                    if (args[i] === '--cwd')
-                        params.cwd = args[i + 1];
-                }
-                console.log(JSON.stringify(await sendV2('workspace.create', params), null, 2));
-                break;
-            }
-            case 'close-workspace':
-                console.log(JSON.stringify(await sendV2('workspace.close', { id: args[1] }), null, 2));
-                break;
-            case 'select-workspace':
-                console.log(JSON.stringify(await sendV2('workspace.select', { id: args[1] }), null, 2));
-                break;
-            case 'rename-workspace':
-                console.log(JSON.stringify(await sendV2('workspace.rename', { id: args[1], title: args[2] }), null, 2));
-                break;
-            case 'list-workspaces':
-                console.log(JSON.stringify(await sendV2('workspace.list'), null, 2));
-                break;
-            // Surface
-            case 'new-surface': {
-                const type = getFlag(args, '--type') || 'terminal';
-                const colorScheme = getFlag(args, '--color-scheme');
-                console.log(JSON.stringify(await sendV2('surface.create', { type, ...(colorScheme ? { colorScheme } : {}) }), null, 2));
-                break;
-            }
-            case 'close-surface':
-                console.log(JSON.stringify(await sendV2('surface.close', { id: args[1] }), null, 2));
-                break;
-            case 'focus-surface':
-                console.log(JSON.stringify(await sendV2('surface.focus', { id: args[1] }), null, 2));
-                break;
-            case 'list-surfaces':
-                console.log(JSON.stringify(await sendV2('surface.list', { paneId: getFlag(args, '--pane') }), null, 2));
-                break;
-            // Surface: per-pane color scheme override (issue #4)
-            case 'set-color-scheme': {
-                // Two forms:
-                //   wmux set-color-scheme <scheme>            → apply to current surface
-                //   wmux set-color-scheme <surfaceId> <scheme> → apply to a specific surface
-                let surfaceId = args[1];
-                let scheme = args[2];
-                if (!scheme) {
-                    scheme = surfaceId;
-                    surfaceId = process.env.WMUX_SURFACE_ID || '';
-                }
-                if (!surfaceId) {
-                    console.error('No surface id. Pass one as argument or run inside a wmux pane.');
-                    process.exit(1);
-                }
-                if (!scheme) {
-                    console.error('Usage: wmux set-color-scheme [surfaceId] <scheme>');
-                    process.exit(1);
-                }
-                console.log(JSON.stringify(await sendV2('surface.set_color_scheme', { surfaceId, colorScheme: scheme }), null, 2));
-                break;
-            }
-            case 'clear-color-scheme': {
-                const surfaceId = args[1] || process.env.WMUX_SURFACE_ID || '';
-                if (!surfaceId) {
-                    console.error('No surface id. Pass one as argument or run inside a wmux pane.');
-                    process.exit(1);
-                }
-                console.log(JSON.stringify(await sendV2('surface.set_color_scheme', { surfaceId, colorScheme: null }), null, 2));
-                break;
-            }
-            case 'list-themes':
-            case 'themes': {
-                // Discovery for users writing scripts: what names are valid for --color-scheme?
-                console.log(JSON.stringify(await sendV2('theme.list'), null, 2));
-                break;
-            }
-            // User config (~/.wmux/config.toml)
-            case 'reload-config': {
-                // Re-read the TOML dotfile and broadcast the new prefs to every window.
-                console.log(JSON.stringify(await sendV2('config.reload'), null, 2));
-                break;
-            }
-            case 'config': {
-                const sub = args[1];
-                if (sub === 'show' || sub === 'get') {
-                    console.log(JSON.stringify(await sendV2('config.get'), null, 2));
-                }
-                else if (sub === 'reload') {
-                    console.log(JSON.stringify(await sendV2('config.reload'), null, 2));
-                }
-                else if (sub === 'path') {
-                    const home = process.env.USERPROFILE || process.env.HOME || '';
-                    console.log(`${home}\\.wmux\\config.toml`);
-                }
-                else {
-                    console.error('Usage: wmux config <show|reload|path>');
-                    process.exit(1);
-                }
-                break;
-            }
-            // Pane
-            case 'split': {
-                const direction = args.includes('--down') ? 'down' : 'right';
-                const type = getFlag(args, '--type') || 'terminal';
-                const colorScheme = getFlag(args, '--color-scheme');
-                console.log(JSON.stringify(await sendV2('pane.split', { direction, type, ...(colorScheme ? { colorScheme } : {}) }), null, 2));
-                break;
-            }
-            // "pane <sub>" verb form — mirrors the syntax from the issue example.
-            case 'pane': {
-                const sub = args[1];
-                if (sub === 'new' || sub === 'split') {
-                    const rest = args.slice(2);
-                    const direction = rest.includes('--down') ? 'down' : 'right';
-                    const type = getFlag(rest, '--type') || 'terminal';
-                    const colorScheme = getFlag(rest, '--color-scheme');
-                    console.log(JSON.stringify(await sendV2('pane.split', { direction, type, ...(colorScheme ? { colorScheme } : {}) }), null, 2));
-                }
-                else if (sub === 'close') {
-                    console.log(JSON.stringify(await sendV2('pane.close', { id: args[2] }), null, 2));
-                }
-                else if (sub === 'focus') {
-                    console.log(JSON.stringify(await sendV2('pane.focus', { id: args[2] }), null, 2));
-                }
-                else if (sub === 'list') {
-                    console.log(JSON.stringify(await sendV2('pane.list', { workspaceId: getFlag(args, '--workspace') }), null, 2));
-                }
-                else {
-                    console.error(`Unknown pane subcommand: ${sub}`);
-                    process.exit(1);
-                }
-                break;
-            }
-            case 'close-pane':
-                console.log(JSON.stringify(await sendV2('pane.close', { id: args[1] }), null, 2));
-                break;
-            case 'focus-pane':
-                console.log(JSON.stringify(await sendV2('pane.focus', { id: args[1] }), null, 2));
-                break;
-            case 'zoom-pane':
-                console.log(JSON.stringify(await sendV2('pane.zoom', { id: args[1] }), null, 2));
-                break;
-            case 'list-panes':
-                console.log(JSON.stringify(await sendV2('pane.list', { workspaceId: getFlag(args, '--workspace') }), null, 2));
-                break;
-            case 'tree':
-                console.log(JSON.stringify(await sendV2('system.tree'), null, 2));
-                break;
-            // Layout
-            case 'layout': {
-                const sub = args[1];
-                if (sub === 'grid') {
-                    const params = {};
-                    for (let i = 2; i < args.length; i += 2) {
-                        if (args[i] === '--count')
-                            params.count = parseInt(args[i + 1], 10);
-                        if (args[i] === '--type')
-                            params.type = args[i + 1];
-                        if (args[i] === '--anchor-surface')
-                            params.anchorSurfaceId = args[i + 1];
-                        if (args[i] === '--anchor-pane')
-                            params.anchorPaneId = args[i + 1];
-                        if (args[i] === '--workspace')
-                            params.workspaceId = args[i + 1];
-                    }
-                    if (!params.count || params.count < 1) {
-                        console.error('--count <N> is required and must be >= 1');
-                        process.exit(1);
-                    }
-                    // If no explicit anchor, fall back to the current shell's surface so the command "just works" from inside a pane.
-                    if (!params.anchorSurfaceId && !params.anchorPaneId && process.env.WMUX_SURFACE_ID) {
-                        params.anchorSurfaceId = process.env.WMUX_SURFACE_ID;
-                    }
-                    console.log(JSON.stringify(await sendV2('layout.grid', params), null, 2));
-                }
-                else {
-                    console.error(`Unknown layout command: ${sub}`);
-                    process.exit(1);
-                }
-                break;
-            }
-            // Terminal interaction
-            case 'send': {
-                // Drop --surface <id> (and its value) from the free-form text args.
-                const surfaceId = getFlag(args, '--surface') || process.env.WMUX_SURFACE_ID;
-                const textArgs = stripFlag(args.slice(1), '--surface');
-                const payload = { text: textArgs.join(' ') };
-                if (surfaceId)
-                    payload.surfaceId = surfaceId;
-                console.log(JSON.stringify(await sendV2('surface.send_text', payload), null, 2));
-                break;
-            }
-            case 'send-key': {
-                const key = args[1];
-                const modifiers = [];
-                if (args.includes('--ctrl'))
-                    modifiers.push('ctrl');
-                if (args.includes('--shift'))
-                    modifiers.push('shift');
-                if (args.includes('--alt'))
-                    modifiers.push('alt');
-                const surfaceId = getFlag(args, '--surface') || process.env.WMUX_SURFACE_ID;
-                const payload = { key, modifiers };
-                if (surfaceId)
-                    payload.surfaceId = surfaceId;
-                console.log(JSON.stringify(await sendV2('surface.send_key', payload), null, 2));
-                break;
-            }
-            case 'read-screen': {
-                const lines = args.find((a, i) => args[i - 1] === '--lines');
-                console.log(JSON.stringify(await sendV2('surface.read_text', { lines: lines ? parseInt(lines) : 50 }), null, 2));
-                break;
-            }
-            case 'trigger-flash':
-                console.log(JSON.stringify(await sendV2('surface.trigger_flash', { id: args[1] }), null, 2));
-                break;
-            // Browser
-            case 'browser': {
-                const sub = args[1];
-                switch (sub) {
-                    case 'open':
-                        console.log(JSON.stringify(await sendV2('browser.navigate', { url: args[2] }), null, 2));
-                        break;
-                    case 'snapshot':
-                        console.log(JSON.stringify(await sendV2('browser.snapshot'), null, 2));
-                        break;
-                    case 'click':
-                        console.log(JSON.stringify(await sendV2('browser.click', { ref: args[2] }), null, 2));
-                        break;
-                    case 'type':
-                        console.log(JSON.stringify(await sendV2('browser.type', { ref: args[2], text: args.slice(3).join(' ') }), null, 2));
-                        break;
-                    case 'fill':
-                        console.log(JSON.stringify(await sendV2('browser.fill', { ref: args[2], value: args.slice(3).join(' ') }), null, 2));
-                        break;
-                    case 'screenshot':
-                        console.log(JSON.stringify(await sendV2('browser.screenshot', { fullPage: args.includes('--full') }), null, 2));
-                        break;
-                    case 'get-text':
-                        console.log(JSON.stringify(await sendV2('browser.get_text', { ref: args[2] }), null, 2));
-                        break;
-                    case 'eval':
-                        console.log(JSON.stringify(await sendV2('browser.eval', { js: args.slice(2).join(' ') }), null, 2));
-                        break;
-                    case 'wait':
-                        console.log(JSON.stringify(await sendV2('browser.wait', { ref: args[2], timeout: parseInt(args[3]) || undefined }), null, 2));
-                        break;
-                    case 'back':
-                        console.log(JSON.stringify(await sendV2('browser.back'), null, 2));
-                        break;
-                    case 'forward':
-                        console.log(JSON.stringify(await sendV2('browser.forward'), null, 2));
-                        break;
-                    case 'reload':
-                        console.log(JSON.stringify(await sendV2('browser.reload'), null, 2));
-                        break;
-                    default:
-                        console.error(`Unknown browser command: ${sub}`);
-                        process.exit(1);
-                }
-                break;
-            }
-            // Agent
-            case 'agent': {
-                const sub = args[1];
-                switch (sub) {
-                    case 'spawn': {
-                        const params = {};
-                        for (let i = 2; i < args.length; i += 2) {
-                            if (args[i] === '--cmd')
-                                params.cmd = args[i + 1];
-                            if (args[i] === '--label')
-                                params.label = args[i + 1];
-                            if (args[i] === '--cwd')
-                                params.cwd = args[i + 1];
-                            if (args[i] === '--pane')
-                                params.paneId = args[i + 1];
-                            if (args[i] === '--workspace')
-                                params.workspaceId = args[i + 1];
-                        }
-                        if (!params.cmd) {
-                            console.error('--cmd is required');
-                            process.exit(1);
-                        }
-                        if (!params.label)
-                            params.label = params.cmd.split(/\s+/)[0];
-                        console.log(JSON.stringify(await sendV2('agent.spawn', params), null, 2));
-                        break;
-                    }
-                    case 'spawn-batch': {
-                        const jsonIdx = args.indexOf('--json');
-                        if (jsonIdx === -1) {
-                            console.error('Usage: wmux agent spawn-batch --json \'[...]\'');
-                            process.exit(1);
-                        }
-                        const json = args[jsonIdx + 1];
-                        const parsed = JSON.parse(json);
-                        const strategy = args.find((a, i) => args[i - 1] === '--strategy') || 'distribute';
-                        console.log(JSON.stringify(await sendV2('agent.spawn_batch', { agents: parsed, strategy }), null, 2));
-                        break;
-                    }
-                    case 'status':
-                        console.log(JSON.stringify(await sendV2('agent.status', { agentId: args[2] }), null, 2));
-                        break;
-                    case 'list':
-                        console.log(JSON.stringify(await sendV2('agent.list', { workspaceId: args.find((a, i) => args[i - 1] === '--workspace') }), null, 2));
-                        break;
-                    case 'kill':
-                        console.log(JSON.stringify(await sendV2('agent.kill', { agentId: args[2] }), null, 2));
-                        break;
-                    default:
-                        console.error(`Unknown agent command: ${sub}`);
-                        process.exit(1);
-                }
-                break;
-            }
-            // Markdown
-            case 'markdown': {
-                const sub = args[1];
-                if (sub === 'set') {
-                    const surfaceId = args[2];
-                    const contentFlag = args.indexOf('--content');
-                    const fileFlag = args.indexOf('--file');
-                    if (contentFlag !== -1) {
-                        console.log(JSON.stringify(await sendV2('markdown.set_content', { surfaceId, markdown: args.slice(contentFlag + 1).join(' ') }), null, 2));
-                    }
-                    else if (fileFlag !== -1) {
-                        console.log(JSON.stringify(await sendV2('markdown.load_file', { surfaceId, filePath: args[fileFlag + 1] }), null, 2));
-                    }
-                }
-                break;
-            }
-            // Notifications
-            case 'notify': {
-                const titleIdx = args.indexOf('--title');
-                const bodyIdx = args.indexOf('--body');
-                const title = titleIdx !== -1 ? args[titleIdx + 1] : undefined;
-                const body = bodyIdx !== -1 ? args[bodyIdx + 1] : undefined;
-                const text = args.filter((_, i) => i > 0 && ![titleIdx, titleIdx + 1, bodyIdx, bodyIdx + 1].includes(i)).join(' ') || body || '';
-                await sendV1(`notify ${process.env.WMUX_SURFACE_ID || ''} ${text}`);
-                console.log('Notification sent');
-                break;
-            }
-            case 'list-notifications':
-                console.log(JSON.stringify(await sendV2('notification.list'), null, 2));
-                break;
-            case 'clear-notifications':
-                console.log(JSON.stringify(await sendV2('notification.clear', { id: args[1] }), null, 2));
-                break;
-            // Sidebar
-            case 'set-status':
-                console.log(JSON.stringify(await sendV2('sidebar.set_status', { key: args[1], value: args[2] }), null, 2));
-                break;
-            case 'set-progress': {
-                const label = args.find((a, i) => args[i - 1] === '--label');
-                console.log(JSON.stringify(await sendV2('sidebar.set_progress', { value: parseFloat(args[1]), label }), null, 2));
-                break;
-            }
-            case 'log':
-                console.log(JSON.stringify(await sendV2('sidebar.log', { level: args[1], message: args.slice(2).join(' ') }), null, 2));
-                break;
-            case 'sidebar-state':
-                console.log(JSON.stringify(await sendV2('sidebar.get_state'), null, 2));
-                break;
-            case 'diff': {
-                const file = args.find((a, i) => args[i - 1] === '--file') || '';
-                console.log(JSON.stringify(await sendV2('diff.refresh', { file }), null, 2));
-                break;
-            }
-            case 'hook': {
-                const params = {};
-                for (let i = 1; i < args.length; i += 2) {
-                    if (args[i] === '--event')
-                        params.event = args[i + 1];
-                    if (args[i] === '--tool')
-                        params.tool = args[i + 1];
-                    if (args[i] === '--agent')
-                        params.agentId = args[i + 1];
-                }
-                await sendV2('hook.event', params);
-                break;
-            }
-            case 'agent-activity': {
-                const surfaceId = getFlag(args, '--surface') || process.env.WMUX_SURFACE_ID;
-                if (!surfaceId) {
-                    console.error('agent-activity: --surface or WMUX_SURFACE_ID required');
-                    process.exit(1);
-                }
-                const params = { surfaceId };
-                const tool = getFlag(args, '--tool');
-                if (tool)
-                    params.tool = tool;
-                const skill = getFlag(args, '--skill');
-                if (skill)
-                    params.skill = skill;
-                if (args.includes('--done'))
-                    params.done = true;
-                if (args.includes('--active'))
-                    params.done = false;
-                await sendV2('agent.activity', params);
-                break;
-            }
-            default:
-                console.error(`Unknown command: ${command}`);
-                printUsage();
-                process.exit(1);
-        }
+        await handler(args);
     }
     catch (err) {
         if (err.code === 'ENOENT' || err.code === 'ECONNREFUSED') {
@@ -533,23 +1451,47 @@ function printUsage() {
 
 Usage: wmux <command> [options]
 
-System:     ping, identify, capabilities, list-windows, focus-window <id>
+System:     ping, identify, capabilities, list-windows, focus-window <id>, new-window
 Workspace:  new-workspace, close-workspace, select-workspace, rename-workspace, list-workspaces
+Remote:     ssh [ssh options] <user@host> [--title T]   (remote terminal in a new workspace)
+            bridge [--port P] [--host H] [--wsl]   (expose this wmux's pipe over TCP, default 127.0.0.1:9787)
+            token                          (print this instance's auth token, for --token)
+Global:     --remote host[:port] --token <T>   (drive a REMOTE wmux through an SSH tunnel;
+            env equivalents: WMUX_REMOTE, WMUX_REMOTE_TOKEN)
 Surface:    new-surface [--type T] [--color-scheme NAME], close-surface, focus-surface, list-surfaces
+            rename-surface [surfaceId] <title>   (renames the current surface when run inside a pane)
             set-color-scheme [surfaceId] <scheme>, clear-color-scheme [surfaceId], list-themes
 Pane:       split [--down] [--type T] [--color-scheme NAME], close-pane, focus-pane, zoom-pane, list-panes, tree
             pane new|close|focus|list   (verb form, mirrors issue #4 example)
 Layout:     layout grid --count <N> [--type terminal] [--anchor-surface <id>]
-Terminal:   send <text>, send-key <key>, read-screen, trigger-flash
+Terminal:   send <text>, send-key <key>, read-screen [--lines N] [--surface <id>], trigger-flash
 Browser:    browser open|snapshot|click|type|fill|screenshot|get-text|eval|wait|back|forward|reload
-Agent:      agent spawn|spawn-batch|status|list|kill
-Markdown:   markdown set <id> --content <text> | --file <path>
+            browser <verb> [--surface <id>]   # which pane's browser to drive
+Agent:      agent spawn [--cmd C] [--label L] [--cwd D] [--pane P] [--replace-tab] | spawn-batch|status|list|kill
+Markdown:   markdown <file>   (open a file in a new markdown view)
+            markdown set <id> --content <text> | --file <path>
 Diff:       diff [--file <path>]
 Notify:     notify <text>, list-notifications, clear-notifications
 Sidebar:    set-status, set-progress, log, sidebar-state
 Hook:       hook --event <type> --tool <name> [--agent <id>]
+Agent state: report-agent --blocked [reason] [--choices <json>] | --unblocked
+            report-agent --run-start | --run-end
+            answer-agent --surface <id> --choice <id>   # reply without leaving your pane
+                          [--run-depth N] [--seq N] [--surface <id>]
+            report-metadata [--model M] [--tokens T] [--context-pct N] [--ttl ms]
+            report-session <id> | release-agent | agent-state [--surface <id>]
+            (surface defaults to $WMUX_SURFACE_ID — an agent in a pane needs no id)
 Config:     config show|reload|path   (edits ~/.wmux/config.toml — see docs)
             reload-config             (shorthand for 'config reload')
+Locales:    locales [list|reload|path] (community UI translations in ~/.wmux/locales)
+
+Help:       wmux help <command>       (per-command usage; works for every command)
+            wmux <command> --help     (same, except for free-form commands such as
+                                       send / notify / log / ssh / browser / markdown,
+                                       where --help is part of the text you are sending)
 `);
 }
-main();
+// Run only when invoked as the CLI. The pure helpers above are exported so the
+// unit tests can import this file without it trying to execute a command.
+if (require.main === module)
+    main();

--- a/resources/cli/wmux.js
+++ b/resources/cli/wmux.js
@@ -506,8 +506,25 @@ async function cmdConfig(args) {
         print(await sendV2('config.reload'));
     }
     else if (sub === 'path') {
-        const home = process.env.USERPROFILE || process.env.HOME || '';
-        console.log(`${home}\\.wmux\\config.toml`);
+        // Ask the instance rather than reconstructing the path here. The config lives
+        // on the Windows host, but this CLI routinely runs somewhere that cannot name
+        // it: inside WSL, or inside a devcontainer reaching wmux over the TCP bridge.
+        // There $HOME is the Linux home and the old `${home}\.wmux\config.toml` form
+        // produced `/home/vscode\.wmux\config.toml` — neither the file wmux reads nor
+        // a well-formed path on either OS. loadUserConfig() already reports the real
+        // one in `path` (user-config.ts), which config.get returns verbatim.
+        try {
+            const cfg = await sendV2('config.get');
+            if (cfg && typeof cfg.path === 'string') {
+                console.log(cfg.path);
+                return;
+            }
+        }
+        catch {
+            // No reachable instance — fall through to a local guess. path.join at least
+            // keeps it self-consistent with whichever filesystem we are actually on.
+        }
+        console.log(path_1.default.join(os_1.default.homedir(), '.wmux', 'config.toml'));
     }
     else {
         console.error('Usage: wmux config <show|reload|path>');

--- a/resources/shell-integration/wmux-bash-integration.sh
+++ b/resources/shell-integration/wmux-bash-integration.sh
@@ -4,9 +4,26 @@
 
 export WMUX=1
 
+# wmux CLI shortcut — Claude Code and users can just type: wmux browser open <url>
+wmux() { node "$WMUX_CLI" "$@"; }
+export -f wmux
+
 _wmux_report() {
     local msg="$1"
-    # Write to temp file for main process to pick up
+    # Devcontainer transport (issue #19): a shell inside a Linux container can
+    # reach neither the Windows named pipe nor the host's Temp dir, so the file
+    # drop below is a no-op there and the pane never reports anything. When
+    # WMUX_REMOTE is set, relay the same V1 line through `wmux raw-v1` instead —
+    # the `wmux` shim resolves to `node "$WMUX_CLI"`, which already speaks TCP to
+    # a `wmux bridge` (issue #78). No protocol is duplicated here.
+    #
+    # Fire-and-forget: backgrounded with output discarded, so a slow or absent
+    # bridge delays no prompt and fails no command.
+    if [ -n "${WMUX_REMOTE}" ] && command -v wmux &>/dev/null; then
+        ( wmux raw-v1 "$msg" >/dev/null 2>&1 & )
+        return
+    fi
+    # Native: write to temp file for the main process to pick up
     local tmpdir="/mnt/c/Users/${USER}/AppData/Local/Temp/wmux"
     mkdir -p "$tmpdir" 2>/dev/null
     echo "$msg" >> "$tmpdir/messages"

--- a/scripts/install-npiperelay.sh
+++ b/scripts/install-npiperelay.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# install-npiperelay.sh — Download npiperelay.exe (SHA-256 pinned) into WSL2 so
+# the wmux CLI / `wmux bridge` can reach the Windows \\.\pipe\wmux named pipe via
+# WSL interop (see src/cli/wmux.ts → connectViaNpiperelay).
+#
+# npiperelay.exe is a small open-source Windows binary that forwards a named pipe
+# to its own stdin/stdout; WSL2 executes it via interop, so no socat/Unix-socket
+# pre-setup is needed. This script only installs the binary — the CLI spawns it.
+#
+# Idempotent: re-running is a no-op when the installed binary's hash matches.
+#
+# Usage:
+#   bash scripts/install-npiperelay.sh
+#
+# Requires: curl, sha256sum (both available via apt).
+
+set -euo pipefail
+
+# ── Pinned release (albertony/npiperelay v1.11.4) ─────────────────────────────
+NPIPERELAY_VERSION="v1.11.4"
+NPIPERELAY_URL="https://github.com/albertony/npiperelay/releases/download/${NPIPERELAY_VERSION}/npiperelay_windows_amd64.exe"
+NPIPERELAY_SHA256="cea82cf5c9c22a28bef8075750acb7958f766393baebff4597cf21442f71c4b3"
+NPIPERELAY_CHECKSUMS_URL="https://github.com/albertony/npiperelay/releases/download/${NPIPERELAY_VERSION}/npiperelay_checksums.txt"
+NPIPERELAY_CHECKSUMS_SHA256="313973839744601ae73eb3597f62c9adb5f9e6985e97b4054ed18701f2cb5df7"
+# ──────────────────────────────────────────────────────────────────────────────
+
+INSTALL_DIR="${HOME}/.local/bin"
+NPIPERELAY_BIN="${INSTALL_DIR}/npiperelay.exe"
+
+echo "wmux npiperelay install"
+echo "======================="
+echo "  version : ${NPIPERELAY_VERSION}"
+echo "  target  : ${NPIPERELAY_BIN}"
+echo ""
+
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+for cmd in curl sha256sum; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "ERROR: '$cmd' not found. Install with: sudo apt-get install $cmd"
+    exit 1
+  fi
+done
+
+# ── Skip when the pinned binary is already present and verified ────────────────
+mkdir -p "${INSTALL_DIR}"
+
+if [[ -f "${NPIPERELAY_BIN}" ]]; then
+  existing_hash="$(sha256sum "${NPIPERELAY_BIN}" | awk '{print $1}')"
+  if [[ "${existing_hash}" == "${NPIPERELAY_SHA256}" ]]; then
+    echo "[OK] npiperelay.exe already present and hash verified."
+    exit 0
+  fi
+  echo "[!] Existing npiperelay.exe hash mismatch (got ${existing_hash}), re-downloading..."
+fi
+
+# ── Verify the checksums file itself before trusting it ────────────────────────
+echo "[+] Downloading checksums file..."
+tmp_checksums="$(mktemp)"
+trap 'rm -f "${tmp_checksums:-}" "${tmp_bin:-}"' EXIT
+curl -fsSL "${NPIPERELAY_CHECKSUMS_URL}" -o "${tmp_checksums}"
+actual_checksums_hash="$(sha256sum "${tmp_checksums}" | awk '{print $1}')"
+if [[ "${actual_checksums_hash}" != "${NPIPERELAY_CHECKSUMS_SHA256}" ]]; then
+  echo "ERROR: Checksums file hash mismatch!"
+  echo "  expected: ${NPIPERELAY_CHECKSUMS_SHA256}"
+  echo "  got:      ${actual_checksums_hash}"
+  exit 1
+fi
+
+# Confirm the pinned binary hash is listed in the (now trusted) checksums file.
+if ! grep -q "${NPIPERELAY_SHA256}" "${tmp_checksums}"; then
+  echo "ERROR: Expected binary hash not found in checksums file — pinned hash outdated?"
+  exit 1
+fi
+
+# ── Download the binary and re-verify its hash ────────────────────────────────
+echo "[+] Downloading npiperelay_windows_amd64.exe..."
+tmp_bin="$(mktemp)"
+curl -fsSL "${NPIPERELAY_URL}" -o "${tmp_bin}"
+actual_hash="$(sha256sum "${tmp_bin}" | awk '{print $1}')"
+if [[ "${actual_hash}" != "${NPIPERELAY_SHA256}" ]]; then
+  echo "ERROR: Downloaded binary hash mismatch!"
+  echo "  expected: ${NPIPERELAY_SHA256}"
+  echo "  got:      ${actual_hash}"
+  exit 1
+fi
+
+mv "${tmp_bin}" "${NPIPERELAY_BIN}"
+chmod +x "${NPIPERELAY_BIN}"
+echo "[OK] npiperelay.exe installed to ${NPIPERELAY_BIN} (sha256 ${actual_hash})"

--- a/src/cli/wmux-hook.ts
+++ b/src/cli/wmux-hook.ts
@@ -37,8 +37,31 @@ if (argv[0] === '--event') {
 const firedAt = Date.now();
 
 const pipePath = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
-const token = process.env.WMUX_PIPE_TOKEN || '';
 const surfaceId = process.env.WMUX_SURFACE_ID || '';
+
+/**
+ * TCP transport for a hook firing where the pipe does not exist (issue #19).
+ *
+ * Inside a devcontainer, Claude Code runs on Linux while wmux runs on the
+ * Windows host: `\\.\pipe\wmux` is unreachable, so every hook failed silently
+ * and the sidebar never left "Running". WMUX_REMOTE points at a `wmux bridge`
+ * (issue #78) instead — same JSON-RPC frame, same auth, different socket. The
+ * env-var form is deliberate: Claude Code owns this process's argv, so there is
+ * nowhere to put a --remote flag.
+ *
+ * The token is the REMOTE instance's, which is not this machine's: on the
+ * container side WMUX_PIPE_TOKEN is either absent or something else entirely.
+ */
+const remote = (() => {
+  const spec = process.env.WMUX_REMOTE?.trim();
+  if (!spec) return null;
+  const idx = spec.lastIndexOf(':');
+  const port = idx === -1 ? NaN : parseInt(spec.slice(idx + 1), 10);
+  return Number.isFinite(port) && port > 0 && port <= 65535
+    ? { host: spec.slice(0, idx) || '127.0.0.1', port }
+    : { host: spec, port: 9787 };
+})();
+const token = (remote ? process.env.WMUX_REMOTE_TOKEN : process.env.WMUX_PIPE_TOKEN) || '';
 
 let stdinData = '';
 let sent = false;
@@ -55,8 +78,13 @@ const MAX_STDIN = 64 * 1024; // 64KB cap
  * tears the connection down rather than half-closing it. The wmux CLI has
  * always armed this same 5s timer before connecting (see sendV1/sendV2); the
  * hook helper was the one client without it, and matching costs nothing.
+ *
+ * The bridge path gets longer: there the frame crosses a TCP hop and then
+ * npiperelay over WSL interop, which measures ~7s worst case on a corporate
+ * host. Firing at 5s there would destroy() the socket mid-flight and drop the
+ * very event this process exists to deliver.
  */
-const PIPE_DEADLINE_MS = 5000;
+const PIPE_DEADLINE_MS = remote ? 30000 : 5000;
 
 /** Cleared once we stop reading, so the happy path is not held open by it. */
 let stdinTimer: NodeJS.Timeout | null = null;
@@ -98,7 +126,7 @@ function sendHook(): void {
   if (message) params.message = message;
   if (surfaceId) params.surfaceId = surfaceId;
 
-  const client = net.connect({ path: pipePath }, () => {
+  const client = net.connect(remote ? { host: remote.host, port: remote.port } : { path: pipePath }, () => {
     const msg = JSON.stringify({ method: 'hook.event', params, id: 1, token });
     client.write(msg + '\n', () => client.end());
     // Drain the reply we do not care about. This is not cosmetic: wmux answers

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -499,8 +499,24 @@ async function cmdConfig(args: string[]): Promise<void> {
   } else if (sub === 'reload') {
     print(await sendV2('config.reload'));
   } else if (sub === 'path') {
-    const home = process.env.USERPROFILE || process.env.HOME || '';
-    console.log(`${home}\\.wmux\\config.toml`);
+    // Ask the instance rather than reconstructing the path here. The config lives
+    // on the Windows host, but this CLI routinely runs somewhere that cannot name
+    // it: inside WSL, or inside a devcontainer reaching wmux over the TCP bridge.
+    // There $HOME is the Linux home and the old `${home}\.wmux\config.toml` form
+    // produced `/home/vscode\.wmux\config.toml` — neither the file wmux reads nor
+    // a well-formed path on either OS. loadUserConfig() already reports the real
+    // one in `path` (user-config.ts), which config.get returns verbatim.
+    try {
+      const cfg = await sendV2('config.get');
+      if (cfg && typeof cfg.path === 'string') {
+        console.log(cfg.path);
+        return;
+      }
+    } catch {
+      // No reachable instance — fall through to a local guess. path.join at least
+      // keeps it self-consistent with whichever filesystem we are actually on.
+    }
+    console.log(path.join(os.homedir(), '.wmux', 'config.toml'));
   } else {
     console.error('Usage: wmux config <show|reload|path>'); process.exit(1);
   }

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -101,10 +101,11 @@ function findNpiperelay(): string | null {
       return false;
     }
   };
-  const fromPath = (process.env.PATH || '')
-    .split(':')
-    .map((d) => path.join(d, 'npiperelay.exe'))
-    .find(readable);
+  const binPaths = (process.env.PATH || process.env.Path || '')
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map((d) => path.join(d, 'npiperelay.exe'));
+  const fromPath = binPaths.find(readable);
   if (fromPath) return fromPath;
   return (
     [
@@ -516,7 +517,11 @@ async function cmdConfig(args: string[]): Promise<void> {
       // No reachable instance — fall through to a local guess. path.join at least
       // keeps it self-consistent with whichever filesystem we are actually on.
     }
-    console.log(path.join(os.homedir(), '.wmux', 'config.toml'));
+    const home = process.env.HOME || process.env.USERPROFILE || os.homedir();
+    const fallbackPath = home.includes('/') && !home.includes('\\')
+      ? path.posix.join(home, '.wmux', 'config.toml')
+      : path.join(home, '.wmux', 'config.toml');
+    console.log(fallbackPath);
   } else {
     console.error('Usage: wmux config <show|reload|path>'); process.exit(1);
   }
@@ -534,8 +539,11 @@ async function cmdLocales(args: string[]): Promise<void> {
   } else if (sub === 'reload') {
     print(await sendV2('config.reload'));
   } else if (sub === 'path') {
-    const home = process.env.USERPROFILE || process.env.HOME || '';
-    console.log(`${home}\\.wmux\\locales`);
+    const home = process.env.HOME || process.env.USERPROFILE || '';
+    const fallbackPath = home.includes('/') && !home.includes('\\')
+      ? path.posix.join(home, '.wmux', 'locales')
+      : path.join(home, '.wmux', 'locales');
+    console.log(fallbackPath);
   } else {
     console.error('Usage: wmux locales [list|reload|path]'); process.exit(1);
   }

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -4,6 +4,8 @@ import net from 'net';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { spawn } from 'child_process';
+import { Duplex } from 'stream';
 
 // Respect WMUX_PIPE when set (e.g. by a parent wmux running with WMUX_INSTANCE),
 // so the CLI talks to the same instance that spawned the shell.
@@ -18,6 +20,26 @@ const PIPE_PATH = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
 const DEFAULT_BRIDGE_PORT = 9787;
 let remoteTarget: { host: string; port: number } | null = null;
 
+// How long `wmux bridge` lets a relay keep draining after its client socket has
+// closed, before forcing teardown. Must exceed the pipe round-trip, or the frame
+// a write-then-close client just sent is discarded mid-flight. Measured worst
+// case inside a devcontainer on a corporate-managed Windows host is ~7s (a fresh
+// npiperelay.exe is spawned per connection over WSL interop, and AV/EDR scans it
+// on every exec), so the default leaves generous headroom. The relay normally
+// exits on its own well before this — the timer is only the backstop.
+const BRIDGE_DRAIN_GRACE_MS = parseInt(process.env.WMUX_BRIDGE_DRAIN_MS || '', 10) || 15000;
+
+// How many npiperelay relays `wmux bridge` keeps spawned and attached to the pipe
+// ahead of demand (see the pool in cmdBridge). 0 disables pre-warming and restores
+// spawn-per-connection. Only ever used on the npiperelay path — the Unix-socket and
+// native-pipe transports connect instantly and have nothing to pre-warm.
+const BRIDGE_WARM_RELAYS = (() => {
+  const raw = process.env.WMUX_BRIDGE_WARM?.trim();
+  if (!raw) return 2;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 2;
+})();
+
 function parseRemoteTarget(spec: string): { host: string; port: number } {
   const idx = spec.lastIndexOf(':');
   if (idx === -1) return { host: spec, port: DEFAULT_BRIDGE_PORT };
@@ -29,10 +51,121 @@ function parseRemoteTarget(spec: string): { host: string; port: number } {
   return { host: spec.slice(0, idx) || '127.0.0.1', port };
 }
 
-function connectTransport(onConnect: () => void): net.Socket {
-  return remoteTarget
-    ? net.connect({ host: remoteTarget.host, port: remoteTarget.port }, onConnect)
-    : net.connect({ path: PIPE_PATH }, onConnect);
+// ─── WSL2 transport: reach the Windows \\.\pipe\wmux from inside WSL2 ─────────
+//
+// A wmux CLI (or `wmux bridge`) running inside WSL2 needs to talk to the wmux
+// process on the Windows host over the \\.\pipe\wmux named pipe. AF_VSOCK,
+// TCP-over-gateway and cross-boundary Unix sockets were all evaluated and
+// rejected (HCS-managed WSL2 UVMs ignore GuestCommunicationServices; gateway
+// IPs/firewall policy are unreliable on corporate networks; 9P does not forward
+// AF_UNIX). The chosen mechanism is npiperelay.exe:
+//
+//   npiperelay.exe is a tiny (~2MB) open-source Windows binary that forwards a
+//   named pipe to its own stdin/stdout. WSL2 executes Windows binaries via
+//   interop, so from inside WSL2 we spawn it and use its stdio as the transport
+//   duplex — zero pre-setup, no socat needed. Install it (SHA-256 pinned) with
+//   scripts/install-npiperelay.sh; see docs/DEVCONTAINER.md for the full setup.
+//   Source: https://github.com/albertony/npiperelay (MIT, fork of jstarks/npiperelay)
+//   Pinned version: v1.11.4  SHA-256: cea82cf5c9c22a28bef8075750acb7958f766393baebff4597cf21442f71c4b3
+//
+//   Transport selection order:
+//     0. remoteTarget set (--remote / WMUX_REMOTE) → TCP (the devcontainer path,
+//        served by a `wmux bridge` reachable at host.docker.internal:9787)
+//     1. WMUX_PIPE starts with '/' → use as a Unix socket path
+//     2. WSL_DISTRO_NAME / WSLENV set → spawn npiperelay.exe automatically
+//     3. native Windows → connect directly to the named pipe
+// ─────────────────────────────────────────────────────────────────────────────
+function connectTransport(onConnect: () => void): net.Socket | Duplex {
+  if (remoteTarget) return net.connect({ host: remoteTarget.host, port: remoteTarget.port }, onConnect);
+  if (PIPE_PATH.startsWith('/')) return net.connect({ path: PIPE_PATH }, onConnect);
+  if (process.env.WSL_DISTRO_NAME || process.env.WSLENV) return connectViaNpiperelay(PIPE_PATH, onConnect);
+  return net.connect({ path: PIPE_PATH }, onConnect);
+}
+
+// Mirrors the selection order above: true when connectTransport() will take the
+// npiperelay branch. That is the only transport whose setup costs anything worth
+// pre-warming — a Unix socket or a native named pipe connects in microseconds.
+function usesNpiperelay(): boolean {
+  return (
+    !remoteTarget && !PIPE_PATH.startsWith('/') && Boolean(process.env.WSL_DISTRO_NAME || process.env.WSLENV)
+  );
+}
+
+// Search common installation locations for npiperelay.exe.
+function findNpiperelay(): string | null {
+  const readable = (p: string): boolean => {
+    try {
+      fs.accessSync(p);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const fromPath = (process.env.PATH || '')
+    .split(':')
+    .map((d) => path.join(d, 'npiperelay.exe'))
+    .find(readable);
+  if (fromPath) return fromPath;
+  return (
+    [
+      path.join(os.homedir(), '.local', 'bin', 'npiperelay.exe'),
+      '/usr/local/bin/npiperelay.exe',
+      '/usr/bin/npiperelay.exe',
+    ].find(readable) ?? null
+  );
+}
+
+// Spawn npiperelay.exe and expose its stdin/stdout as a Duplex stream.
+function connectViaNpiperelay(pipePath: string, onConnect: () => void): Duplex {
+  const bin = findNpiperelay();
+  if (!bin) {
+    console.error('wmux: npiperelay.exe not found.');
+    console.error('  Install it with scripts/install-npiperelay.sh, or fetch it from:');
+    console.error('  https://github.com/albertony/npiperelay/releases/latest');
+    process.exit(1);
+  }
+  // npiperelay names the pipe with forward slashes: \\.\pipe\wmux → //./pipe/wmux
+  const child = spawn(bin, ['-ei', '-s', pipePath.replace(/\\/g, '/')], {
+    stdio: ['pipe', 'pipe', 'inherit'],
+  });
+  const duplex = new Duplex({
+    read() {},
+    write(chunk, enc, cb) {
+      if (!child.stdin?.writable) {
+        cb(new Error('npiperelay stdin closed'));
+        return;
+      }
+      child.stdin.write(chunk, enc, cb);
+    },
+    final(cb) {
+      child.stdin?.end();
+      cb();
+    },
+    // Kills the relay, discarding anything still buffered in its stdin. Callers
+    // must only reach here on error or after the stream has drained — see the
+    // teardown in cmdBridge.
+    destroy(err, cb) {
+      child.kill();
+      cb(err);
+    },
+    allowHalfOpen: true,
+  });
+  child.stdout?.on('data', (chunk: Buffer) => duplex.push(chunk));
+  child.stdout?.on('end', () => duplex.push(null));
+  child.on('error', (err: Error) => duplex.destroy(err));
+  child.on('exit', (code: number | null) => {
+    if (code !== 0 && code !== null) duplex.destroy(new Error(`npiperelay exited with code ${code}`));
+  });
+  // "Ready" here means the relay process exists — NOT that it has attached to the
+  // named pipe, which over WSL interop can take seconds longer. onConnect must
+  // still fire now regardless: callers write their request from inside it, and the
+  // Duplex buffers those bytes until the pipe is live. (Deferring it until the
+  // first byte comes back would deadlock — nothing would ever be written.)
+  //
+  // The cost is that a caller's deadline starts before the pipe is up, so it has
+  // to cover the attach latency too — that is what SLOW_TRANSPORT_FLOOR_MS is for.
+  process.nextTick(onConnect);
+  return duplex;
 }
 
 // Auth token for privileged (V2) pipe requests. wmux injects WMUX_PIPE_TOKEN
@@ -61,7 +194,7 @@ function sendV1(command: string): Promise<string> {
       client.write(line + '\n');
     });
     let data = '';
-    const timer = setTimeout(() => { client.end(); resolve(data.trim()); }, 5000);
+    const timer = setTimeout(() => { client.end(); resolve(data.trim()); }, deadline(5000));
     const finish = () => { clearTimeout(timer); resolve(data.trim()); };
     client.on('data', (chunk) => {
       data += chunk.toString();
@@ -86,6 +219,29 @@ function sendV1(command: string): Promise<string> {
  * Only the browser verbs currently need more than this — see BROWSER_CMDS.
  */
 const DEFAULT_V2_TIMEOUT_MS = 5000;
+
+/**
+ * A floor under every deadline, for transports slower than a local named pipe.
+ *
+ * The budgets above are all sized for a pipe on the same machine, where a
+ * round-trip is sub-millisecond and the whole deadline is the server's own
+ * thinking time. Neither transport this file grew for issue #19 is that: TCP to
+ * a `wmux bridge` from inside a devcontainer, and npiperelay over WSL interop,
+ * both measure ~7s worst case on a corporate-managed host — above the 5s default
+ * on their own, before wmux has done anything. Every request from a container
+ * therefore reported a timeout for a call that had already succeeded.
+ *
+ * A floor rather than a replacement, so a browser verb keeps the longer budget
+ * it asked for, and a local run keeps master's timings unchanged (floor 0).
+ */
+const SLOW_TRANSPORT_FLOOR_MS = 30000;
+
+/** `base`, raised to the slow-transport floor when the transport is a slow one. */
+function deadline(base: number): number {
+  const override = parseInt(process.env.WMUX_RPC_TIMEOUT_MS || '', 10);
+  if (Number.isFinite(override) && override > 0) return Math.max(base, override);
+  return remoteTarget || usesNpiperelay() ? Math.max(base, SLOW_TRANSPORT_FLOOR_MS) : base;
+}
 
 /**
  * What a stalled request says when it gives up.
@@ -118,10 +274,11 @@ function sendV2(
       client.write(request + '\n');
     });
     let data = '';
+    const deadlineMs = deadline(timeoutMs);
     const timer = setTimeout(() => {
       client.end();
-      reject(new Error(timeoutMessage(method, timeoutMs)));
-    }, timeoutMs);
+      reject(new Error(timeoutMessage(method, deadlineMs)));
+    }, deadlineMs);
     client.on('data', (chunk) => {
       data += chunk.toString();
       if (data.includes('\n')) {
@@ -464,27 +621,163 @@ async function cmdSsh(args: string[]): Promise<void> {
 // wmux's pipe server, so the bridge grants nothing by itself.
 async function cmdBridge(args: string[]): Promise<void> {
   const port = parseInt(getFlag(args, '--port') || '', 10) || DEFAULT_BRIDGE_PORT;
-  const host = getFlag(args, '--host') || '127.0.0.1';
+  // --wsl binds 0.0.0.0 so a container on the Windows host can reach a bridge
+  // running inside WSL2 (issue #19). WSL2's NAT gives the distro an address the
+  // container resolves as host.docker.internal, but 127.0.0.1 inside the distro
+  // is not it. The pipe token still authenticates every request end to end.
+  const wslMode = args.includes('--wsl');
+  const host = getFlag(args, '--host') || (wslMode ? '0.0.0.0' : '127.0.0.1');
   if (host !== '127.0.0.1' && host !== 'localhost') {
     console.warn('WARNING: binding beyond localhost exposes the wmux pipe to the network.');
     console.warn(`Prefer the default 127.0.0.1 + an SSH tunnel: ssh -L ${port}:127.0.0.1:${port} user@host`);
   }
+
+  // ── Warm relay pool ─────────────────────────────────────────────────────────
+  // Spawn-per-connection made every request pay the relay's whole startup: a fresh
+  // npiperelay.exe launched over WSL interop (AV/EDR scans the binary on each exec
+  // on a corporate-managed host) and then the pipe dial. Measured worst case from a
+  // devcontainer is ~7s — on every hook. Keeping relays open ahead of demand moves
+  // that cost off the request path: a warm relay has already spawned AND attached
+  // by the time a client arrives, so hand-off is just pipe().
+  //
+  // Deliberately a POOL of exclusive relays, not one shared relay multiplexed
+  // across clients. Multiplexing would force the bridge to parse frames and rewrite
+  // JSON-RPC ids to route replies back to the right socket, which:
+  //   * breaks V1 entirely — `pong` / `ok` / `unauthorized` carry no id to route on;
+  //   * makes every client a casualty when the single relay dies;
+  //   * costs the bridge its one real virtue, being a transparent byte pipe (any
+  //     future streaming or server-pushed method would have to be taught to it).
+  // Pooling buys the same latency win and the bridge stays dumb.
+  //
+  // Only on the npiperelay path — elsewhere this would hold idle sockets open to
+  // buy nothing.
+  const warmSize = usesNpiperelay() ? BRIDGE_WARM_RELAYS : 0;
+  const warm: Array<{ stream: net.Socket | Duplex; claim: () => void }> = [];
+  let warmFailures = 0;
+  let refillTimer: NodeJS.Timeout | null = null;
+
+  const scheduleRefill = (delayMs: number): void => {
+    if (refillTimer || warm.length >= warmSize) return;
+    refillTimer = setTimeout(() => {
+      refillTimer = null;
+      fillWarm();
+    }, delayMs);
+    refillTimer.unref();
+  };
+
+  function fillWarm(): void {
+    while (warm.length < warmSize) {
+      const stream = connectTransport(() => {});
+      const entry = { stream, claim: () => {} };
+      // Dying before being claimed means the upstream isn't there — wmux not
+      // running, or the pipe gone. npiperelay exits immediately in that case, so
+      // without a backoff the bridge would respawn a Windows process in a tight
+      // loop for as long as wmux stays down.
+      const onDead = (): void => {
+        const i = warm.indexOf(entry);
+        if (i === -1) return; // already claimed — the client's teardown owns it now
+        warm.splice(i, 1);
+        warmFailures = Math.min(warmFailures + 1, 6);
+        scheduleRefill(Math.min(30000, 500 * 2 ** warmFailures));
+      };
+      entry.claim = () => {
+        stream.off('error', onDead);
+        stream.off('close', onDead);
+      };
+      stream.on('error', onDead);
+      stream.on('close', onDead);
+      warm.push(entry);
+    }
+  }
+
+  // An idle relay reads nothing, so anything the upstream sent while it waited stays
+  // buffered in the stream and is delivered the moment the client pipes it — no need
+  // to drain before hand-off.
+  const takeWarm = (): net.Socket | Duplex | null => {
+    while (warm.length) {
+      const entry = warm.pop()!;
+      entry.claim();
+      // wmux may have restarted since this relay attached.
+      if (!entry.stream.destroyed && entry.stream.writable) {
+        warmFailures = 0;
+        return entry.stream;
+      }
+      entry.stream.destroy();
+    }
+    return null;
+  };
+
   const server = net.createServer((sock) => {
-    const pipe = net.connect({ path: PIPE_PATH });
+    // Connect to the local wmux through the same selector the CLI uses. In the
+    // bridge process remoteTarget is always null, so this resolves to a Unix
+    // socket, npiperelay (inside WSL2), or the named pipe directly — which is
+    // what lets `wmux bridge` run inside WSL2 and still reach the Windows pipe.
+    // A warm relay is the same thing, already connected.
+    const pipe = takeWarm() ?? connectTransport(() => {});
+    // Replace what we just consumed so the next client is served warm too.
+    scheduleRefill(0);
     sock.pipe(pipe);
     pipe.pipe(sock);
-    const drop = () => { sock.destroy(); pipe.destroy(); };
-    sock.on('error', drop);
-    pipe.on('error', drop);
-    sock.on('close', drop);
-    pipe.on('close', drop);
+
+    // Teardown is half-close-aware on purpose. Destroying BOTH sides on either
+    // 'close' silently ate hook events: wmux-hook.js writes its frame and end()s
+    // immediately, and over npiperelay the Duplex's destroy() is child.kill() —
+    // so the relay died with the frame still buffered in its stdin and never
+    // forwarded it. Clients that write-then-close are the normal case here
+    // (every Claude Code hook is one), not an abort.
+    //
+    // 'end' (peer finished sending) therefore FLUSHES rather than destroys: end()
+    // the other side so its buffered bytes drain and the pipe sees a clean EOF.
+    // destroy() is reserved for 'error', where there is nothing left to save.
+    let done = false;
+    const destroyBoth = (): void => {
+      if (done) return;
+      done = true;
+      sock.destroy();
+      pipe.destroy();
+    };
+    // A closed socket can no longer drain anything, so 'close' still tears down —
+    // but only after a grace period, giving an in-flight relay time to finish
+    // forwarding what it already holds.
+    const closeAfterDrain = (): void => {
+      if (done) return;
+      setTimeout(destroyBoth, BRIDGE_DRAIN_GRACE_MS).unref();
+    };
+
+    sock.on('error', destroyBoth);
+    pipe.on('error', destroyBoth);
+    sock.on('end', () => { pipe.end(); });
+    pipe.on('end', () => { sock.end(); });
+    sock.on('close', closeAfterDrain);
+    pipe.on('close', closeAfterDrain);
   });
   server.on('error', (err) => { console.error(`bridge error: ${err.message}`); process.exit(1); });
+
+  // Warm relays hold a live pipe connection (and an npiperelay.exe) for as long as
+  // the bridge runs, so retire them on the way out rather than orphaning them.
+  const shutdown = (): void => {
+    if (refillTimer) clearTimeout(refillTimer);
+    warm.splice(0).forEach((e) => { e.claim(); e.stream.destroy(); });
+    process.exit(0);
+  };
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+
   server.listen(port, host, () => {
     console.log(`wmux bridge listening on ${host}:${port} ↔ ${PIPE_PATH}`);
-    console.log('From another machine:');
-    console.log(`  ssh -L ${port}:127.0.0.1:${port} <user>@<this-host>`);
-    console.log(`  wmux --remote 127.0.0.1:${port} --token <run 'wmux token' here> list-workspaces`);
+    if (warmSize > 0) {
+      fillWarm();
+      console.log(`Keeping ${warmSize} npiperelay relay(s) warm (WMUX_BRIDGE_WARM=0 to disable).`);
+    }
+    if (wslMode) {
+      console.log('WSL2 mode. From a container on this host:');
+      console.log(`  WMUX_REMOTE=host.docker.internal:${port}`);
+      console.log("  WMUX_REMOTE_TOKEN=<run 'wmux token' here>");
+    } else {
+      console.log('From another machine:');
+      console.log(`  ssh -L ${port}:127.0.0.1:${port} <user>@<this-host>`);
+      console.log(`  wmux --remote 127.0.0.1:${port} --token <run 'wmux token' here> list-workspaces`);
+    }
     console.log('Ctrl+C to stop.');
   });
 }
@@ -563,6 +856,20 @@ async function cmdAgentActivity(args: string[]): Promise<void> {
   if (args.includes('--done')) params.done = true;
   if (args.includes('--active')) params.done = false;
   await sendV2('agent.activity', params);
+}
+
+// Generic V1 passthrough (issue #19: devcontainer support). Lets a caller send
+// any raw V1 command line (report_pwd, report_git_branch, report_shell_state,
+// report_startup_command, …) without the CLI growing a near-identical wrapper
+// for each. wmux-bash-integration.sh writes those lines straight to the local
+// pipe when it can reach one; inside a devcontainer it can't, so it calls
+// `wmux raw-v1` instead and gets the CLI's transport — including TCP via
+// --remote / WMUX_REMOTE to a `wmux bridge` (issue #78) — for free. Auth is
+// unchanged: sendV1 still prefixes `auth <token>`.
+async function cmdRawV1(args: string[]): Promise<void> {
+  const line = args.slice(1).join(' ');
+  if (!line) { console.error('Usage: wmux raw-v1 <command> [surfaceId] [args...]'); process.exit(1); }
+  console.log(await sendV1(line));
 }
 
 // ─── Declared agent state (issue #128) ───────────────────────────────────────
@@ -712,8 +1019,12 @@ const COMMAND_SPECS = {
 
   // Remote management (issue #78)
   bridge: {
-    usage: 'wmux bridge [--port P] [--host H]   (expose this wmux\'s pipe over TCP, default 127.0.0.1:9787)',
+    usage: [
+      'wmux bridge [--port P] [--host H] [--wsl]   (expose this wmux\'s pipe over TCP, default 127.0.0.1:9787)',
+      '  --wsl   bind 0.0.0.0 so a container on this host can reach a bridge running in WSL2',
+    ].join('\n'),
     value: ['--port', '--host'],
+    bool: ['--wsl'],
   },
   token: { usage: 'wmux token   (print this instance\'s pipe auth token)' },
 
@@ -851,6 +1162,10 @@ const COMMAND_SPECS = {
     usage: `wmux agent-activity [--tool T] [--skill S] [--done|--active] [--surface <id>]   ${SURFACE_NOTE}`,
     value: ['--tool', '--skill', '--surface'],
     bool: ['--done', '--active'],
+  },
+  'raw-v1': {
+    usage: 'wmux raw-v1 <command> [surfaceId] [args...]   (send a raw V1 line; used by shell integration)',
+    passthrough: true,
   },
 
   // Declared agent state (issue #128)
@@ -1084,6 +1399,8 @@ const COMMANDS: Record<CommandName, (args: string[]) => Promise<void> | void> = 
   },
   hook: cmdHook,
   'agent-activity': cmdAgentActivity,
+  // Devcontainer support (issue #19)
+  'raw-v1': cmdRawV1,
   ...AGENT_STATE_COMMANDS,
 };
 
@@ -1140,7 +1457,7 @@ Usage: wmux <command> [options]
 System:     ping, identify, capabilities, list-windows, focus-window <id>, new-window
 Workspace:  new-workspace, close-workspace, select-workspace, rename-workspace, list-workspaces
 Remote:     ssh [ssh options] <user@host> [--title T]   (remote terminal in a new workspace)
-            bridge [--port P] [--host H]   (expose this wmux's pipe over TCP, default 127.0.0.1:9787)
+            bridge [--port P] [--host H] [--wsl]   (expose this wmux's pipe over TCP, default 127.0.0.1:9787)
             token                          (print this instance's auth token, for --token)
 Global:     --remote host[:port] --token <T>   (drive a REMOTE wmux through an SSH tunnel;
             env equivalents: WMUX_REMOTE, WMUX_REMOTE_TOKEN)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -716,8 +716,12 @@ app.whenReady().then(() => {
         // Re-read ~/.wmux/config.toml and live-apply to every open window.
         (async () => {
           try {
-            const { loadUserConfig } = await import('./user-config');
+            const { loadUserConfig, resetConfigWarnings } = await import('./user-config');
             const { loadUserLocales } = await import('./user-locales');
+            // A reload is the user saying "I have edited it" — so re-report the
+            // problems the file still has rather than staying quiet because the
+            // pre-edit version already warned about them.
+            resetConfigWarnings();
             // Same contract as the IPC path: one reload covers all of ~/.wmux,
             // including community translations (issue #147).
             const cfg = { ...loadUserConfig(), locales: loadUserLocales() };

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -14,7 +14,7 @@ import { listSystemFonts } from './font-detector';
 import { isContextMenuInstalled, installContextMenu, uninstallContextMenu } from './shell-context-menu';
 import { getDefaultTheme, getThemeByName, loadBundledThemes } from './theme-loader';
 import { parseWindowsTerminalConfig, parseGhosttyConfig, loadProjectProfiles, importWindowsTerminalProfiles } from './config-loader';
-import { loadUserConfig, getConfigPath } from './user-config';
+import { loadUserConfig, getConfigPath, resetConfigWarnings } from './user-config';
 import { loadUserLocales } from './user-locales';
 import { WindowManager } from './window-manager';
 import { CDPBridge } from './cdp-bridge';
@@ -199,6 +199,9 @@ export function registerIpcHandlers(windowManager: WindowManager, cdpProxyInstan
   });
 
   ipcMain.handle(IPC_CHANNELS.CONFIG_RELOAD_USER_CONFIG, async () => {
+    // See the config.reload pipe handler in index.ts: a reload re-reports the
+    // file's remaining problems instead of staying quiet about pre-edit ones.
+    resetConfigWarnings();
     // A reload covers everything under ~/.wmux, so edited community
     // translations (issue #147) apply without a restart too.
     const cfg = { ...loadUserConfig(), locales: loadUserLocales() };

--- a/src/main/pipe-server.ts
+++ b/src/main/pipe-server.ts
@@ -132,6 +132,7 @@ export class PipeServer extends EventEmitter {
     let args: string[];
     switch (command) {
       case 'report_pwd':
+      case 'report_startup_command':
       case 'notify':
         // Single free-text argument — may contain spaces (issue #53).
         args = argsRaw ? [argsRaw] : [];

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -214,8 +214,12 @@ function buildShellArgs(
     // strips every Windows env var, so the notification framework, sidebar and
     // `wmux` CLI inside WSL can't reach the host. /u = pass through, /up = pass
     // through AND translate the Windows path to a WSL mount (/mnt/c/...).
+    // WMUX_REMOTE / WMUX_REMOTE_TOKEN ride along so a devcontainer launched from
+    // this WSL shell inherits them and its CLI can reach wmux over the bridge
+    // (issue #19). Harmless when unset — WSLENV skips a variable with no value.
     const wmuxWslEnv =
-      'WMUX/u:WMUX_SURFACE_ID/u:WMUX_CLI/up:WMUX_PIPE/u:WMUX_PIPE_TOKEN/u:WMUX_INTEGRATION/u';
+      'WMUX/u:WMUX_SURFACE_ID/u:WMUX_CLI/up:WMUX_PIPE/u:WMUX_PIPE_TOKEN/u:WMUX_INTEGRATION/u'
+      + ':WMUX_REMOTE/u:WMUX_REMOTE_TOKEN/u';
     env.WSLENV = env.WSLENV ? `${env.WSLENV}:${wmuxWslEnv}` : wmuxWslEnv;
     // A restored WSL/POSIX cwd (issue #60) can't be a Win32 process cwd (error
     // 267). Open it INSIDE the distro via --cd instead; the Win32-side cwd is

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -5,6 +5,7 @@ import { execFileSync, spawn } from 'child_process';
 import { v4 as uuidv4 } from 'uuid';
 import { SurfaceId } from '../shared/types';
 import { getPipePath, readPipeToken } from '../shared/instance';
+import { isPosixPath } from '../shared/paths';
 import { PtyLedger } from './pty-ledger';
 import { attachErrorSink, installPtyCrashGuard } from './pty-crash-guard';
 import { powerShellShimDir } from './powershell-shim';
@@ -129,12 +130,37 @@ function getShellType(shell: string): 'powershell' | 'cmd' | 'wsl' | 'unknown' {
   return 'unknown';
 }
 
-// A POSIX/WSL path (e.g. /home/user/project restored from session.json — issue
-// #60). Such a path is NOT a valid working dir for a Win32 process and makes
-// pty.spawn fail with error 267 (ERROR_DIRECTORY). Win32 paths are drive-rooted
-// (C:\...) or UNC (\\server\...); a leading forward slash means POSIX.
-function isPosixPath(p: string): boolean {
-  return p.startsWith('/') && !p.startsWith('//');
+// The two environment facts resolveShellForCwd depends on, behind an object so
+// a test can substitute them without pretending to be Windows. `hasWsl` is
+// cached because it shells out to `where`, and this runs on every pane create.
+let cachedWsl: boolean | null = null;
+export const shellEnv = {
+  isWindows: (): boolean => process.platform === 'win32',
+  hasWsl: (): boolean => {
+    if (cachedWsl === null) cachedWsl = isShellAvailable('wsl.exe');
+    return cachedWsl;
+  },
+};
+
+// A pane whose cwd is a POSIX/WSL path (the common case once a WSL or
+// devcontainer shell has reported its directory via report_pwd) cannot be
+// served by a Win32 shell: resolveSpawnCwd() below has no choice but to hand
+// pwsh/cmd %USERPROFILE%, so a new tab or split silently lands in the Windows
+// home folder instead of the project. Translating to \\wsl.localhost\... is not
+// an option either — CreateProcess rejects a UNC working directory.
+//
+// wsl.exe is the one shell that CAN open that path (buildShellArgs passes it as
+// --cd), so substitute it. Only the two shells that are physically incapable of
+// the directory are replaced: an 'unknown' spec is left alone because it may be
+// a deliberate remote command line such as `ssh user@host` (issue #78).
+export function resolveShellForCwd(shell: string, cwd: string | undefined): string {
+  if (!shellEnv.isWindows()) return shell;
+  if (!cwd || !isPosixPath(cwd)) return shell;
+  const shellType = getShellType(shell);
+  if (shellType !== 'powershell' && shellType !== 'cmd') return shell;
+  if (!shellEnv.hasWsl()) return shell;
+  console.warn(`[wmux] cwd is a POSIX path, using wsl.exe instead of ${shell}: ${cwd}`);
+  return 'wsl.exe';
 }
 
 // Resolve the working dir handed to pty.spawn, guaranteeing it is a directory
@@ -194,6 +220,10 @@ function buildShellArgs(
     // A restored WSL/POSIX cwd (issue #60) can't be a Win32 process cwd (error
     // 267). Open it INSIDE the distro via --cd instead; the Win32-side cwd is
     // sanitized to a valid Windows dir by the caller.
+    //
+    // --cd is BEST-EFFORT: WSL applies it before the interactive login shell
+    // reads its rc, so a distro whose /etc/profile or ~/.profile cds to $HOME
+    // discards it and the pane opens at home. See docs/config.md.
     const posixCwd = cwd && isPosixPath(cwd) ? cwd : null;
     return ['--cd', posixCwd ?? '~'];
   }
@@ -301,7 +331,9 @@ export class PtyManager {
     // Extra args only apply when the REQUESTED executable resolved — if we fell
     // back to the default shell, its command line must not inherit ssh's args.
     const spec = parseShellSpec(options.shell);
-    const shell = resolveShell(spec.command);
+    // A POSIX cwd forces wsl.exe — pwsh/cmd cannot open that directory at all
+    // and would silently start in %USERPROFILE% instead of the project.
+    const shell = resolveShellForCwd(resolveShell(spec.command), options.cwd);
     const shellExtraArgs = shell === spec.command ? spec.args : [];
     const shellType = getShellType(shell);
     const integrationDir = getShellIntegrationPath();

--- a/src/main/session-persistence.ts
+++ b/src/main/session-persistence.ts
@@ -23,6 +23,10 @@ export interface SessionData {
       pinned: boolean;
       shell: string;
       cwd?: string; // last reported working dir — restored so new terminals reopen here (issue #20)
+      // The POSIX/WSL directory. `cwd` is last-writer-wins across both
+      // filesystems, so a pwsh pane leaves a Win32 path there and restored WSL
+      // panes get `--cd ~`; this one is only ever written by a POSIX report.
+      posixCwd?: string;
       splitTree: any; // SplitNode serialized
       // The renderer has always written these two; the interface omitting them
       // is what let backupAutoSession drop them without tsc noticing (#145).
@@ -115,6 +119,7 @@ function backupAutoSession(previousVersion: string): void {
         pinned: !!w.pinned,
         shell: w.shell,
         cwd: w.cwd || '',
+        posixCwd: w.posixCwd || '',
         splitTree: w.splitTree,
         browserUrl: w.browserUrl || '',
         browserWidth: w.browserWidth,

--- a/src/main/user-config.ts
+++ b/src/main/user-config.ts
@@ -95,6 +95,30 @@ export function getConfigPath(): string {
   return path.join(home, '.wmux', 'config.toml');
 }
 
+/**
+ * Complaints already made, so the log is not spammed. loadUserConfig() is called
+ * on every WSL pane spawn (pty-manager.ts) as well as at startup and on reload —
+ * without this a single bad file would warn once per pane for the life of the app.
+ */
+const warnedConfigProblems = new Set<string>();
+
+/** Forget past complaints, so `wmux reload-config` reports the file's state afresh. */
+export function resetConfigWarnings(): void {
+  warnedConfigProblems.clear();
+}
+
+// A read or parse failure discards the WHOLE file: every [terminal], [keys],
+// [browser] and [appearance] section silently reverts to its default. The errors
+// were always returned to the caller and printed by `wmux config show`, but
+// nothing ever told you to go and look — so a typo presented as "my setting has
+// no effect", with no way to tell a mis-set value from an unread file.
+function warnConfig(filePath: string, problem: string): void {
+  const key = `${filePath}\0${problem}`;
+  if (warnedConfigProblems.has(key)) return;
+  warnedConfigProblems.add(key);
+  console.warn(`[wmux] ${filePath}: ${problem} — see \`wmux config show\``);
+}
+
 export function loadUserConfig(filePath: string = getConfigPath()): UserConfig {
   const errors: string[] = [];
   if (!fs.existsSync(filePath)) {
@@ -105,17 +129,26 @@ export function loadUserConfig(filePath: string = getConfigPath()): UserConfig {
   try {
     text = fs.readFileSync(filePath, 'utf-8');
   } catch (e: any) {
-    return { path: filePath, errors: [`read failed: ${e?.message || e}`] };
+    const problem = `read failed: ${e?.message || e}`;
+    warnConfig(filePath, `${problem} — the entire config was ignored`);
+    return { path: filePath, errors: [problem] };
   }
 
   let parsed: TomlTable;
   try {
     parsed = parseToml(text);
   } catch (e: any) {
-    return { path: filePath, errors: [`parse failed: ${e?.message || e}`] };
+    const problem = `parse failed: ${e?.message || e}`;
+    warnConfig(filePath, `${problem} — the entire config was ignored`);
+    return { path: filePath, errors: [problem] };
   }
 
-  return { ...mapToConfig(parsed, errors), path: filePath, errors };
+  // Per-key mapping errors are survivable: the rest of the file still applies.
+  // Still worth one line, or a skipped key looks like a wmux bug.
+  const mapped = mapToConfig(parsed, errors);
+  for (const err of errors) warnConfig(filePath, err);
+
+  return { ...mapped, path: filePath, errors };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { v4 as uuid } from 'uuid';
 import { useStore } from './store';
 import { PaneId, SurfaceId, WorkspaceId, WorkspaceInfo, SplitNode } from '../shared/types';
+import { cwdReportPatch } from '../shared/paths';
 import SplitContainer from './components/SplitPane/SplitContainer';
 import { updateRatio, getAllPaneIds, findLeaf, replaceSoleTerminalSurface, freezeSurfaceCwds } from './store/split-utils';
 import { DEFAULT_DEV_PORTS, mergeDevPorts, matchDevPorts, firstNewDevPort } from './dev-ports';
@@ -288,7 +289,10 @@ function handleSurfaceMetadata(cmd: any, ws: WorkspaceInfo, deps: MetaDeps): voi
   switch (cmd.command) {
     case 'report_pwd': {
       const pwd = cmd.args?.[0];
-      deps.updateWorkspaceMetadata(ws.id, { cwd: pwd });
+      // Records the POSIX path separately so a pwsh report cannot erase the
+      // WSL fallback its neighbours depend on — without this, the next WSL
+      // pane in the workspace gets `--cd ~`.
+      deps.updateWorkspaceMetadata(ws.id, cwdReportPatch(pwd));
       // Also store cwd at the surface level so the tab label can show the project folder.
       if (pwd && cmd.surfaceId) {
         const { updateSurface } = useStore.getState();
@@ -768,6 +772,10 @@ export default function App() {
             pinned: ws.pinned,
             shell: ws.shell,
             cwd: ws.cwd, // issue #20 — restore so new terminals reopen in the workspace folder
+            // The WSL half of that: ws.cwd is whichever pane reported last, so a
+            // pwsh pane leaves a Win32 path behind and every restored WSL pane
+            // falls through to `--cd ~`. Persist the POSIX one alongside it.
+            posixCwd: ws.posixCwd,
             // Per-tab directories, frozen at save time (issue #134): ws.cwd above
             // is a single value for the whole workspace, so on its own it sends
             // every restored terminal to the same place.
@@ -835,6 +843,7 @@ export default function App() {
         pinned: ws.pinned,
         shell: ws.shell,
         cwd: ws.cwd || '',
+        posixCwd: ws.posixCwd || '',
         // See the auto-save path below — a named session is the case #134
         // reported, where losing a worktree's drive makes the session
         // unidentifiable after a restore.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { v4 as uuid } from 'uuid';
 import { useStore } from './store';
-import { PaneId, SurfaceId, WorkspaceId, WorkspaceInfo, SplitNode } from '../shared/types';
+import { PaneId, SurfaceId, SurfaceRef, WorkspaceId, WorkspaceInfo, SplitNode } from '../shared/types';
 import { cwdReportPatch } from '../shared/paths';
 import SplitContainer from './components/SplitPane/SplitContainer';
 import { updateRatio, getAllPaneIds, findLeaf, replaceSoleTerminalSurface, freezeSurfaceCwds } from './store/split-utils';
@@ -284,6 +284,18 @@ function applyShellState(cmd: any, ws: WorkspaceInfo, deps: MetaDeps): void {
   fireNotification(cmd.surfaceId, ws.id, msg, deps.addNotification);
 }
 
+/** Apply a patch to one surface of `ws`, wherever in the split tree it lives. */
+function patchSurface(ws: WorkspaceInfo, surfaceId: SurfaceId, patch: Partial<SurfaceRef>): void {
+  const { updateSurface } = useStore.getState();
+  for (const paneId of getAllPaneIds(ws.splitTree)) {
+    const leaf = findLeaf(ws.splitTree, paneId);
+    if (leaf?.surfaces.some((s) => s.id === surfaceId)) {
+      updateSurface(ws.id, paneId, surfaceId, patch);
+      return;
+    }
+  }
+}
+
 /** Dispatch a surface-scoped metadata command to the owning workspace. */
 function handleSurfaceMetadata(cmd: any, ws: WorkspaceInfo, deps: MetaDeps): void {
   switch (cmd.command) {
@@ -294,16 +306,22 @@ function handleSurfaceMetadata(cmd: any, ws: WorkspaceInfo, deps: MetaDeps): voi
       // pane in the workspace gets `--cd ~`.
       deps.updateWorkspaceMetadata(ws.id, cwdReportPatch(pwd));
       // Also store cwd at the surface level so the tab label can show the project folder.
-      if (pwd && cmd.surfaceId) {
-        const { updateSurface } = useStore.getState();
-        for (const paneId of getAllPaneIds(ws.splitTree)) {
-          const leaf = findLeaf(ws.splitTree, paneId);
-          if (leaf?.surfaces.some((s) => s.id === cmd.surfaceId)) {
-            updateSurface(ws.id, paneId, cmd.surfaceId, { currentCwd: pwd });
-            break;
-          }
-        }
-      }
+      if (pwd && cmd.surfaceId) patchSurface(ws, cmd.surfaceId, { currentCwd: pwd });
+      break;
+    }
+    case 'report_startup_command': {
+      // A shell declares how to bring its own surface back after a restart —
+      // a devcontainer shell reports the launcher that re-enters the container,
+      // so a restored pane starts in WSL and runs it (issue #19). Reported per
+      // surface, stored per surface: two containers in one pane restore to two
+      // different containers. No argument clears it.
+      //
+      // The command must be cwd-independent (`cd '<path>' && …`): the restored
+      // pane's shell is a fresh login shell whose rc files have had their say,
+      // so nothing guarantees it starts where the reporting shell was.
+      if (!cmd.surfaceId) break;
+      const command = cmd.args?.[0];
+      patchSurface(ws, cmd.surfaceId, { startupCommands: command ? [command] : undefined });
       break;
     }
     case 'report_git_branch':

--- a/src/renderer/components/SplitPane/PaneWrapper.tsx
+++ b/src/renderer/components/SplitPane/PaneWrapper.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { PaneId, SplitNode, SurfaceId, WorkspaceId, QuickLaunchProfile, ShellInfo } from '../../../shared/types';
+import { workspaceFallbackCwd } from '../../../shared/paths';
 import { findLeaf, splitNode } from '../../store/split-utils';
 import TerminalPane from '../Terminal/TerminalPane';
 import BrowserPane from '../Browser/BrowserPane';
@@ -214,7 +215,7 @@ export default function PaneWrapper({
             <TerminalPane
               surfaceId={surface.id}
               shell={surface.shell || workspace?.shell}
-              cwd={surface.cwd || workspace?.cwd}
+              cwd={surface.cwd || workspaceFallbackCwd(surface.shell || workspace?.shell, workspace)}
               colorScheme={surface.colorScheme}
               startupCommands={surface.startupCommands}
               focused={isFocused && isActive}

--- a/src/renderer/store/workspace-slice.ts
+++ b/src/renderer/store/workspace-slice.ts
@@ -1,6 +1,7 @@
 import { StateCreator } from 'zustand';
 import { v4 as uuid } from 'uuid';
 import { WorkspaceId, WorkspaceInfo, SplitNode } from '../../shared/types';
+import { isPosixPath } from '../../shared/paths';
 import { createLeaf } from './split-utils';
 import { killTreeTerminalPtys } from './pty-teardown';
 import type { TranslationKey } from '../i18n/core';
@@ -64,6 +65,12 @@ export const createWorkspaceSlice: StateCreator<WorkspaceSlice> = (set, get) => 
       gitBranch: options.gitBranch,
       gitDirty: options.gitDirty,
       cwd: options.cwd,
+      // Seed the WSL fallback from the folder the workspace was opened on
+      // ("Open in wmux" on a \\wsl.localhost path, `wmux new-workspace --cwd`,
+      // a restored session). Without this seed a workspace whose only reporting
+      // pane is pwsh would have no POSIX path at all, and its WSL panes would
+      // stay on `--cd ~` for the rest of the session.
+      posixCwd: options.posixCwd ?? (options.cwd && isPosixPath(options.cwd) ? options.cwd : undefined),
       prNumber: options.prNumber,
       prStatus: options.prStatus,
       prLabel: options.prLabel,
@@ -181,6 +188,11 @@ export const createWorkspaceSlice: StateCreator<WorkspaceSlice> = (set, get) => 
       unreadCount: 0,
       customColor: config.customColor,
       cwd: config.cwd,
+      // Same seed as createWorkspace, which is what repairs a session saved
+      // before this field existed: its workspaces come back with `cwd` already
+      // rewritten to C:\Users\<user> by a pwsh pane, so falling back to `cwd`
+      // when it is POSIX is the only place the project path can still be found.
+      posixCwd: config.posixCwd ?? (config.cwd && isPosixPath(config.cwd) ? config.cwd : undefined),
       browserUrl: config.browserUrl,
       browserWidth: config.browserWidth,
     }));

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -1,0 +1,71 @@
+// Path- and shell-namespace helpers shared by main and renderer.
+//
+// A wmux workspace can hold panes living in two different filesystems at once:
+// Win32 (pwsh/cmd) and POSIX (wsl, and devcontainer shells reached through it).
+// Both report their directory over the same `report_pwd`, so anything that
+// stores or consumes a workspace-level cwd has to know which namespace a path
+// belongs to. Keeping the predicate here rather than in pty-manager.ts lets the
+// renderer apply the same rule the PTY layer does, instead of re-deriving it.
+
+/**
+ * A POSIX/WSL path (e.g. /home/user/project restored from session.json — issue
+ * #60). Such a path is NOT a valid working dir for a Win32 process and makes
+ * pty.spawn fail with error 267 (ERROR_DIRECTORY). Win32 paths are drive-rooted
+ * (C:\...) or UNC (\\server\...); a leading forward slash means POSIX.
+ */
+export function isPosixPath(p: string): boolean {
+  return p.startsWith('/') && !p.startsWith('//');
+}
+
+/**
+ * Whether a shell command line opens a POSIX filesystem rather than a Win32 one.
+ *
+ * Deliberately the same substring test `getShellType` in pty-manager.ts uses, so
+ * the renderer's idea of "this pane lives in WSL" cannot drift from the one the
+ * spawn path acts on. An 'unknown' spec (a remote command line such as
+ * `ssh user@host`, issue #78) is not treated as WSL — wmux does not know where
+ * that lands, and guessing POSIX would send it a path it cannot open.
+ */
+export function isWslShell(shell: string | undefined): boolean {
+  return !!shell && shell.toLowerCase().includes('wsl');
+}
+
+/**
+ * The workspace-metadata patch for a `report_pwd` from some pane.
+ *
+ * `cwd` stays last-writer-wins — it is what the sidebar shows, and the most
+ * recent prompt is the honest answer there. `posixCwd` is additive and only
+ * ever written by a POSIX report, so a pwsh pane reporting C:\Users\<user>
+ * cannot erase the WSL fallback its neighbours depend on. Omitting the key
+ * (rather than writing undefined) is the whole point: updateWorkspaceMetadata
+ * spreads the patch, so a present-but-undefined key would clear it.
+ */
+export function cwdReportPatch(pwd: string | undefined): { cwd?: string; posixCwd?: string } {
+  return { cwd: pwd, ...(pwd && isPosixPath(pwd) ? { posixCwd: pwd } : {}) };
+}
+
+/**
+ * The workspace-level cwd a surface should spawn in when it has none of its own
+ * — picked to match the surface's filesystem namespace.
+ *
+ * A surface only carries its own `cwd` once shell integration has reported a
+ * prompt (frozen into the tree by freezeSurfaceCwds at save time). Plain WSL
+ * panes never report — wmux exports WMUX_INTEGRATION=1 into the distro but
+ * installs no rc hook there — so in practice they live on this fallback for
+ * their whole life, which is why handing them the wrong namespace is not a
+ * corner case.
+ *
+ * For a WSL surface, deliberately returns undefined rather than a Win32 path
+ * when no POSIX directory is known: `--cd C:\Users\<user>` is not something
+ * wsl.exe can honour, so there is nothing to gain by passing it, and undefined
+ * keeps the intent ("we do not know") legible downstream.
+ */
+export function workspaceFallbackCwd(
+  shell: string | undefined,
+  workspace: { cwd?: string; posixCwd?: string } | null | undefined,
+): string | undefined {
+  if (!workspace) return undefined;
+  if (!isWslShell(shell)) return workspace.cwd;
+  if (workspace.posixCwd) return workspace.posixCwd;
+  return workspace.cwd && isPosixPath(workspace.cwd) ? workspace.cwd : undefined;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -89,6 +89,15 @@ export interface WorkspaceInfo {
   gitBranch?: string;
   gitDirty?: boolean;
   cwd?: string;
+  // The last POSIX/WSL directory known for this workspace, kept apart from
+  // `cwd` because one workspace can hold panes in two filesystems at once.
+  // `cwd` is whichever pane reported last, so a single pwsh/cmd pane rewrites
+  // it to a Win32 path — and a WSL pane with no cwd of its own then falls back
+  // to a path wsl.exe cannot open, so `--cd` degrades to `~` and the pane
+  // silently lands in the WSL home instead of the project. Only POSIX reports
+  // (and a POSIX folder at creation) write here, so the WSL fallback survives
+  // a Win32 pane living in the same workspace.
+  posixCwd?: string;
   prNumber?: number;
   prStatus?: 'open' | 'merged' | 'closed';
   prLabel?: string;
@@ -224,6 +233,11 @@ export interface SavedSession {
     customColor?: string;
     shell: string;
     cwd: string;
+    // The POSIX/WSL directory, kept apart from `cwd` because a pwsh pane's
+    // report overwrites the latter with a Win32 path and strands every WSL pane
+    // in the workspace on `--cd ~`. Optional: sessions saved before this field
+    // existed recover via the isPosixPath(cwd) seed in replaceAllWorkspaces.
+    posixCwd?: string;
     splitTree: SplitNode;
     browserUrl?: string;
     // Both written since 0.4x; declared here as of #145, which was caused by a

--- a/src/shell-integration/wmux-bash-integration.sh
+++ b/src/shell-integration/wmux-bash-integration.sh
@@ -10,7 +10,20 @@ export -f wmux
 
 _wmux_report() {
     local msg="$1"
-    # Write to temp file for main process to pick up
+    # Devcontainer transport (issue #19): a shell inside a Linux container can
+    # reach neither the Windows named pipe nor the host's Temp dir, so the file
+    # drop below is a no-op there and the pane never reports anything. When
+    # WMUX_REMOTE is set, relay the same V1 line through `wmux raw-v1` instead —
+    # the `wmux` shim resolves to `node "$WMUX_CLI"`, which already speaks TCP to
+    # a `wmux bridge` (issue #78). No protocol is duplicated here.
+    #
+    # Fire-and-forget: backgrounded with output discarded, so a slow or absent
+    # bridge delays no prompt and fails no command.
+    if [ -n "${WMUX_REMOTE}" ] && command -v wmux &>/dev/null; then
+        ( wmux raw-v1 "$msg" >/dev/null 2>&1 & )
+        return
+    fi
+    # Native: write to temp file for the main process to pick up
     local tmpdir="/mnt/c/Users/${USER}/AppData/Local/Temp/wmux"
     mkdir -p "$tmpdir" 2>/dev/null
     echo "$msg" >> "$tmpdir/messages"

--- a/tests/helpers/bash-path.ts
+++ b/tests/helpers/bash-path.ts
@@ -20,7 +20,12 @@ export function bashPathCandidates(p: string): string[] {
   if (!drive) return [slashed];
   const letter = drive[1].toLowerCase();
   const rest = drive[2];
-  return [`/${letter}/${rest}`, `/mnt/${letter}/${rest}`, `/cygdrive/${letter}/${rest}`];
+  // Git Bash usually sees `C:` as `/c`, WSL sees `/mnt/c`, and Cygwin exposes
+  // `/cygdrive/c`. The actual bash on PATH decides which spelling exists, so
+  // keep the likely order but let `toBashPath()` probe and select the real one.
+  return process.platform === 'win32'
+    ? [`/${letter}/${rest}`, `/mnt/${letter}/${rest}`, `/cygdrive/${letter}/${rest}`]
+    : [`/mnt/${letter}/${rest}`, `/${letter}/${rest}`, `/cygdrive/${letter}/${rest}`];
 }
 
 /**
@@ -38,7 +43,7 @@ export function toBashPath(p: string, exists: (candidate: string) => boolean): s
 
 /** True when `candidate` names an existing path to the bash on PATH. */
 export function bashExists(candidate: string): boolean {
-  const probe = spawnSync('bash', ['-c', 'test -e "$1"', 'bash', candidate], { stdio: 'ignore' });
+  const probe = spawnSync('bash', ['-lc', 'test -e "$1"', '_', candidate], { stdio: 'ignore' });
   return !probe.error && probe.status === 0;
 }
 

--- a/tests/helpers/bash-path.ts
+++ b/tests/helpers/bash-path.ts
@@ -31,9 +31,11 @@ export function bashPathCandidates(p: string): string[] {
 /**
  * First candidate spelling `exists` accepts, else the first candidate.
  *
- * Order matters beyond mere likelihood: Git Bash (`/c`) is preferred because it
- * runs in the Windows process tree and can execute the `node` the scripts call,
- * whereas WSL bash would need a second toolchain installed inside the distro.
+ * Order matters beyond mere likelihood: on Windows, Git Bash (`/c`) is preferred
+ * because it runs in the Windows process tree and can execute the `node` the
+ * scripts call, whereas WSL bash would need a second toolchain installed inside
+ * the distro. Off Windows there is no Git Bash to prefer, so `bashPathCandidates`
+ * leads with the WSL mount instead.
  */
 export function toBashPath(p: string, exists: (candidate: string) => boolean): string {
   const candidates = bashPathCandidates(p);

--- a/tests/unit/bash-path.test.ts
+++ b/tests/unit/bash-path.test.ts
@@ -1,17 +1,38 @@
 import { describe, it, expect } from 'vitest';
 import { bashPathCandidates, toBashPath } from '../helpers/bash-path';
 
+/**
+ * Which spelling `bashPathCandidates` leads with depends on the bash the suite
+ * can actually reach, so it is the one thing here that is platform-conditional.
+ * On Windows that bash is Git Bash, which mounts `C:` at `/c`; anywhere else
+ * the runner is already inside a Linux bash, where a Windows drive — if it is
+ * visible at all — is a WSL2 mount at `/mnt/c`. Every flavour is always
+ * offered either way; only the order moves. Asserting the fixed Git Bash order
+ * would pass on Windows and fail on every Linux and macOS checkout.
+ */
+const likeliestMount = process.platform === 'win32' ? '/c' : '/mnt/c';
+
 describe('bashPathCandidates', () => {
   it('offers the Git Bash, WSL and Cygwin spellings of a Windows drive path', () => {
-    expect(bashPathCandidates('C:\\dev\\wmux\\scripts')).toEqual([
-      '/c/dev/wmux/scripts',
-      '/mnt/c/dev/wmux/scripts',
-      '/cygdrive/c/dev/wmux/scripts',
-    ]);
+    const candidates = bashPathCandidates('C:\\dev\\wmux\\scripts');
+    expect(candidates).toEqual(
+      expect.arrayContaining([
+        '/c/dev/wmux/scripts',
+        '/mnt/c/dev/wmux/scripts',
+        '/cygdrive/c/dev/wmux/scripts',
+      ]),
+    );
+    expect(candidates).toHaveLength(3);
+  });
+
+  it('leads with the spelling the bash on this platform is likeliest to mount', () => {
+    expect(bashPathCandidates('C:\\dev\\wmux\\scripts')[0]).toBe(`${likeliestMount}/dev/wmux/scripts`);
   });
 
   it('lower-cases the drive letter, the way every bash flavour mounts it', () => {
-    expect(bashPathCandidates('D:/Temp/x')[0]).toBe('/d/Temp/x');
+    expect(bashPathCandidates('D:/Temp/x')).toEqual(
+      expect.arrayContaining(['/d/Temp/x', '/mnt/d/Temp/x', '/cygdrive/d/Temp/x']),
+    );
   });
 
   it('leaves a POSIX path alone', () => {
@@ -29,12 +50,17 @@ describe('toBashPath', () => {
     expect(toBashPath('C:\\dev\\wmux', wslOnly)).toBe('/mnt/c/dev/wmux');
   });
 
-  it('prefers Git Bash when both spellings resolve — it inherits the Windows env', () => {
-    expect(toBashPath('C:\\dev\\wmux', () => true)).toBe('/c/dev/wmux');
+  it('picks the spelling the probe says the bash on PATH can see, Git Bash flavour', () => {
+    const gitBashOnly = (p: string) => !p.startsWith('/mnt/') && !p.startsWith('/cygdrive/');
+    expect(toBashPath('C:\\dev\\wmux', gitBashOnly)).toBe('/c/dev/wmux');
+  });
+
+  it('prefers the platform mount when every spelling resolves', () => {
+    expect(toBashPath('C:\\dev\\wmux', () => true)).toBe(`${likeliestMount}/dev/wmux`);
   });
 
   it('falls back to the first candidate when nothing probes true', () => {
-    expect(toBashPath('C:\\dev\\wmux', () => false)).toBe('/c/dev/wmux');
+    expect(toBashPath('C:\\dev\\wmux', () => false)).toBe(`${likeliestMount}/dev/wmux`);
   });
 
   it('never probes a path that has no drive letter to translate', () => {

--- a/tests/unit/cli-config-path.test.ts
+++ b/tests/unit/cli-config-path.test.ts
@@ -110,7 +110,8 @@ describe('wmux config path', () => {
       WMUX_REMOTE: '127.0.0.1:1',
       WMUX_REMOTE_TOKEN: 'tok',
     });
-    expect(out).toBe(path.join('/home/vscode', '.wmux', 'config.toml'));
+    const expected = path.posix.join('/home/vscode', '.wmux', 'config.toml');
+    expect(out).toBe(expected);
     expect(out).not.toContain('\\');
   });
 });

--- a/tests/unit/cli-config-path.test.ts
+++ b/tests/unit/cli-config-path.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import path from 'node:path';
+
+/**
+ * `wmux config path` used to build the path client-side:
+ *
+ *   console.log(`${os.homedir()}\\.wmux\\config.toml`)
+ *
+ * Run from inside WSL or a devcontainer — where this CLI spends most of its
+ * life, reaching wmux over the TCP bridge — that prints
+ * `/home/vscode\.wmux\config.toml`: neither the file wmux reads (it lives on the
+ * Windows host) nor a well-formed path on either OS. Someone editing "the config
+ * file" at that path is editing nothing, which is a long way to walk before
+ * finding out why a setting had no effect.
+ *
+ * The instance already knows: loadUserConfig() records the real path and
+ * `config.get` returns it. Exercised against the shipped resources/cli/wmux.js,
+ * because that is the file a released wmux actually runs.
+ */
+
+const CLI = path.resolve(__dirname, '../../resources/cli/wmux.js');
+const WINDOWS_PATH = 'C:\\Users\\lsi2abt\\.wmux\\config.toml';
+
+let server: net.Server | null = null;
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((r) => server!.close(() => r()));
+    server = null;
+  }
+});
+
+/**
+ * A wmux instance that answers `config.get` and nothing else, over the same
+ * newline-delimited JSON-RPC the real pipe server speaks.
+ */
+function startFakeInstance(token: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server = net.createServer((sock) => {
+      let buf = '';
+      sock.on('data', (chunk) => {
+        buf += chunk.toString();
+        let nl: number;
+        while ((nl = buf.indexOf('\n')) >= 0) {
+          const line = buf.slice(0, nl).trim();
+          buf = buf.slice(nl + 1);
+          if (!line) continue;
+          let req: { id?: unknown; method?: string; token?: string };
+          try { req = JSON.parse(line); } catch { continue; }
+          if (req.token !== token) {
+            sock.write(JSON.stringify({ id: req.id, error: 'unauthorized' }) + '\n');
+            continue;
+          }
+          const result = req.method === 'config.get'
+            ? { path: WINDOWS_PATH, errors: [], terminal: { fontSize: 13 } }
+            : {};
+          sock.write(JSON.stringify({ id: req.id, result }) + '\n');
+        }
+      });
+      sock.on('error', () => { /* client hangs up after its one call */ });
+    });
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server!.address();
+      resolve(typeof addr === 'object' && addr ? addr.port : 0);
+    });
+  });
+}
+
+// Async, not spawnSync: the fake instance lives in this process, and a blocking
+// spawn would stop its event loop from ever accepting the CLI's connection —
+// every call would "fail to reach an instance" and take the fallback.
+function runCli(args: string[], env: Record<string, string>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [CLI, ...args], {
+      env: { ...process.env, HOME: '/home/vscode', ...env },
+    });
+    let out = '';
+    child.stdout.on('data', (c: Buffer) => { out += c.toString(); });
+    child.on('error', reject);
+    child.on('close', () => resolve(out.trim()));
+  });
+}
+
+describe('wmux config path', () => {
+  it("prints the instance's own path, not one rebuilt from the local $HOME", async () => {
+    const port = await startFakeInstance('tok');
+    const out = await runCli(['config', 'path'], {
+      WMUX_REMOTE: `127.0.0.1:${port}`,
+      WMUX_REMOTE_TOKEN: 'tok',
+    });
+    expect(out).toBe(WINDOWS_PATH);
+  });
+
+  it('agrees with what `config show` reports', async () => {
+    // The two disagreeing is exactly the failure: `show` was right all along,
+    // so a user comparing them had one true answer and one plausible fiction.
+    const port = await startFakeInstance('tok');
+    const env = { WMUX_REMOTE: `127.0.0.1:${port}`, WMUX_REMOTE_TOKEN: 'tok' };
+    const shown = JSON.parse(await runCli(['config', 'show'], env)) as { path: string };
+    expect(await runCli(['config', 'path'], env)).toBe(shown.path);
+  });
+
+  it('falls back to a well-formed local path when no instance answers', async () => {
+    // Still a guess, but a self-consistent one: path.join on POSIX cannot emit
+    // the `/home/vscode\.wmux\config.toml` hybrid the old string template did.
+    const out = await runCli(['config', 'path'], {
+      WMUX_REMOTE: '127.0.0.1:1',
+      WMUX_REMOTE_TOKEN: 'tok',
+    });
+    expect(out).toBe(path.join('/home/vscode', '.wmux', 'config.toml'));
+    expect(out).not.toContain('\\');
+  });
+});

--- a/tests/unit/orchestration-status-vocab.test.ts
+++ b/tests/unit/orchestration-status-vocab.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { forBash, hasBash } from '../helpers/bash-path';
+import { bashExists, forBash, hasBash } from '../helpers/bash-path';
 import type { OrchAgentStatus, OrchWaveStatus, OrchRunStatus } from '../../src/shared/types';
 
 const SCRIPTS = path.resolve(__dirname, '../../resources/wmux-orchestrator/scripts');
@@ -20,6 +20,9 @@ let tmp: string;
 let orchDir: string;
 
 const readState = () => JSON.parse(fs.readFileSync(path.join(orchDir, 'state.json'), 'utf8'));
+
+const hookPath = forBash(HOOK);
+const canRunHookSuite = hasBash() && bashExists(hookPath);
 
 function writeState(overrides: Record<string, unknown> = {}): void {
   fs.writeFileSync(
@@ -79,7 +82,7 @@ afterEach(() => {
 
 // A Windows box without Git for Windows has no bash at all — nothing to convert
 // a path FOR. Skipping is explicit and loud rather than a silent green.
-describe.skipIf(!hasBash())('on-agent-stop.sh status vocabulary (#99)', () => {
+describe.skipIf(!canRunHookSuite)('on-agent-stop.sh status vocabulary (#99)', () => {
   it('marks a successful agent "exited" — the word the sidebar counts, not "completed"', () => {
     writeState();
     runHook();

--- a/tests/unit/pipe-server.test.ts
+++ b/tests/unit/pipe-server.test.ts
@@ -59,6 +59,26 @@ describe('PipeServer', () => {
     expect(commands[0].args).toEqual(['C:\\Users\\test']);
   });
 
+  // A restore command is a whole shell line — `cd '/some/path' && ./relaunch.sh`
+  // (issue #19). Splitting it on whitespace like the default V1 case would turn
+  // it into eight useless args, so it joins report_pwd/notify in the
+  // single-free-text-argument group.
+  it('keeps a report_startup_command line intact, spaces and all', async () => {
+    const pipe = uniquePipe();
+    server = new PipeServer(pipe, 'test-token');
+    const commands: any[] = [];
+    server.on('v1', (cmd) => commands.push(cmd));
+    server.start();
+    await new Promise(r => setTimeout(r, 200));
+
+    const line = "cd '/workspaces/my project' && ./relaunch.sh --attach";
+    const response = await connectAndSend(pipe, `auth test-token report_startup_command surf-123 ${line}`);
+    expect(response).toBe('ok');
+    expect(commands[0].command).toBe('report_startup_command');
+    expect(commands[0].surfaceId).toBe('surf-123');
+    expect(commands[0].args).toEqual([line]);
+  });
+
   it('rejects V1 state updates without a token', async () => {
     const pipe = uniquePipe();
     server = new PipeServer(pipe, 'secret');

--- a/tests/unit/pty-manager.test.ts
+++ b/tests/unit/pty-manager.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { PtyManager, parseShellSpec, resolveSpawnCwd } from '../../src/main/pty-manager';
+import { PtyManager, parseShellSpec, resolveSpawnCwd, resolveShellForCwd, shellEnv } from '../../src/main/pty-manager';
 import type { SurfaceId } from '../../src/shared/types';
 
 const TEST_SHELL = 'cmd.exe';
@@ -268,3 +268,53 @@ describe('resolveSpawnCwd', () => {
     expect(resolveSpawnCwd(undefined)).toBeUndefined();
   });
 });
+/**
+ * resolveSpawnCwd above is the honest Win32 answer — %USERPROFILE% — but it is
+ * also why a new tab in a WSL/devcontainer workspace silently opened in the
+ * Windows home folder instead of the project. A UNC working directory is not an
+ * option (CreateProcess rejects it), so the fix is to pick the one shell that
+ * can actually reach the path.
+ */
+describe('resolveShellForCwd (POSIX cwd → WSL shell)', () => {
+  const POSIX = '/home/user/agent/project';
+
+  beforeEach(() => {
+    vi.spyOn(shellEnv, 'isWindows').mockReturnValue(true);
+    vi.spyOn(shellEnv, 'hasWsl').mockReturnValue(true);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('swaps a Win32 shell for wsl.exe when the cwd is POSIX', () => {
+    expect(resolveShellForCwd('pwsh.exe', POSIX)).toBe('wsl.exe');
+    expect(resolveShellForCwd('powershell.exe', POSIX)).toBe('wsl.exe');
+    expect(resolveShellForCwd('cmd.exe', POSIX)).toBe('wsl.exe');
+  });
+
+  it('leaves a Win32 cwd alone', () => {
+    expect(resolveShellForCwd('pwsh.exe', 'C:\\work\\project')).toBe('pwsh.exe');
+    expect(resolveShellForCwd('pwsh.exe', undefined)).toBe('pwsh.exe');
+  });
+
+  it('leaves a shell that is already WSL alone', () => {
+    expect(resolveShellForCwd('wsl.exe', POSIX)).toBe('wsl.exe');
+  });
+
+  it('does not hijack a deliberate remote command line (issue #78)', () => {
+    // `wmux ssh user@host` resolves to a shell wmux cannot classify. Replacing
+    // it with wsl.exe would drop the user somewhere else entirely, which is a
+    // worse failure than opening in the wrong directory.
+    expect(resolveShellForCwd('ssh', POSIX)).toBe('ssh');
+  });
+
+  it('keeps today\'s behaviour when WSL is not installed', () => {
+    vi.spyOn(shellEnv, 'hasWsl').mockReturnValue(false);
+    expect(resolveShellForCwd('pwsh.exe', POSIX)).toBe('pwsh.exe');
+  });
+
+  it('is a no-op off Windows', () => {
+    vi.spyOn(shellEnv, 'isWindows').mockReturnValue(false);
+    expect(resolveShellForCwd('/bin/bash', POSIX)).toBe('/bin/bash');
+  });
+});
+

--- a/tests/unit/user-config.test.ts
+++ b/tests/unit/user-config.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { loadUserConfig } from '../../src/main/user-config';
+import { loadUserConfig, resetConfigWarnings } from '../../src/main/user-config';
 
 function writeTmp(contents: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-cfg-'));
@@ -180,5 +180,72 @@ describe('loadUserConfig', () => {
     `);
     const out = loadUserConfig(tmpPath);
     expect(out.terminal?.userColorSchemes?.big?.palette?.length).toBe(16);
+  });
+});
+
+/**
+ * A read or parse failure discards the WHOLE file — every [terminal], [keys],
+ * [browser] and [appearance] section reverts to its default. That used to happen
+ * in silence: one stray character and the user's entire config stopped applying,
+ * with nothing in any log to say so.
+ */
+describe('loadUserConfig diagnostics', () => {
+  let tmpPath: string | null = null;
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetConfigWarnings();
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (tmpPath) {
+      try { fs.rmSync(path.dirname(tmpPath), { recursive: true, force: true }); } catch { /* noop */ }
+      tmpPath = null;
+    }
+  });
+
+  it('warns, naming the file, when a syntax error discards the config', () => {
+    tmpPath = writeTmp('[terminal\nfont-size = 13\n');
+    const out = loadUserConfig(tmpPath);
+    expect(out.errors.length).toBeGreaterThan(0);
+    expect(out.terminal).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0].join(' ')).toContain(tmpPath);
+  });
+
+  it('warns once per problem, however often the file is read', () => {
+    // loadUserConfig runs on every startup and every `reload-config`; without
+    // dedupe one bad file would fill the log.
+    tmpPath = writeTmp('[terminal\n');
+    for (let i = 0; i < 10; i++) loadUserConfig(tmpPath);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the file afresh after resetConfigWarnings', () => {
+    // What `wmux reload-config` calls: the user is iterating on the file and
+    // needs to see whether their edit fixed it.
+    tmpPath = writeTmp('[terminal\n');
+    loadUserConfig(tmpPath);
+    resetConfigWarnings();
+    loadUserConfig(tmpPath);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('says nothing about a config that parses', () => {
+    tmpPath = writeTmp('[terminal]\nfont-size = 13\n');
+    expect(loadUserConfig(tmpPath).errors).toEqual([]);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns about a section-level mistake without discarding the rest', () => {
+    // A mapping error is not fatal — the good sections still apply — but it is
+    // still the reason a setting "did nothing", so it has to be said out loud.
+    tmpPath = writeTmp('[appearance]\nui-theme = "purple"\n\n[terminal]\nfont-size = 13\n');
+    const out = loadUserConfig(tmpPath);
+    expect(out.terminal?.fontSize).toBe(13);
+    expect(out.errors.length).toBe(1);
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/wmux-bridge-transport.test.ts
+++ b/tests/unit/wmux-bridge-transport.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawn, ChildProcess } from 'child_process';
+import net from 'net';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Exercises the real compiled wmux.js (resources/cli/wmux.js) `bridge` command
+// end-to-end. `wmux bridge` is a pure byte relay: it accepts TCP connections and
+// forwards them to the local wmux via connectTransport(). This verifies the two
+// non-TCP transport branches the bridge must pick between:
+//   * WMUX_PIPE=/path        → Unix-socket upstream
+//   * inside WSL2            → spawn npiperelay.exe and use its stdio
+// so a `wmux bridge` running inside WSL2 reaches the Windows-host named pipe.
+
+const BRIDGE_SCRIPT = path.resolve(__dirname, '../../resources/cli/wmux.js');
+
+// Bind to :0 to discover a free port, then release it for the bridge to reuse.
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+// Spawn `node wmux.js bridge --wsl --port <port>` and resolve once it logs that
+// it is listening. Returns the child so the test can kill it in afterEach.
+function startBridge(port: number, env: Record<string, string>): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [BRIDGE_SCRIPT, 'bridge', '--wsl', '--port', String(port)], { env });
+    const timer = setTimeout(() => reject(new Error('bridge did not start listening in time')), 5000);
+    child.stdout.on('data', (chunk: Buffer) => {
+      if (chunk.toString().includes('listening')) {
+        clearTimeout(timer);
+        resolve(child);
+      }
+    });
+    child.on('error', (err) => { clearTimeout(timer); reject(err); });
+    child.on('exit', (code) => { clearTimeout(timer); reject(new Error(`bridge exited early (code ${code})`)); });
+  });
+}
+
+// Round-trip a payload through the bridge: connect over TCP, send, and collect
+// whatever the (echoing) upstream sends back.
+function roundTrip(port: number, payload: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const sock = net.connect({ host: '127.0.0.1', port }, () => sock.write(payload));
+    let received = '';
+    sock.on('data', (chunk) => { received += chunk.toString(); });
+    sock.on('end', () => resolve(received));
+    sock.on('close', () => resolve(received));
+    sock.on('error', reject);
+    setTimeout(() => { sock.destroy(); resolve(received); }, 2000);
+  });
+}
+
+describe('wmux bridge transport selection (WSL2 devcontainer path)', () => {
+  const cleanups: Array<() => void> = [];
+
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()!();
+  });
+
+  it('relays TCP ↔ a Unix-socket upstream when WMUX_PIPE is a /path', async () => {
+    // Stand-in for the local pipe: a Unix-socket echo server.
+    const sockPath = path.join(os.tmpdir(), `wmux-bridge-test-${process.pid}.sock`);
+    try { fs.unlinkSync(sockPath); } catch { /* not present */ }
+    const upstream = net.createServer((c) => c.pipe(c)); // echo
+    await new Promise<void>((r) => upstream.listen(sockPath, r));
+    cleanups.push(() => { upstream.close(); try { fs.unlinkSync(sockPath); } catch { /* gone */ } });
+
+    const port = await freePort();
+    // WMUX_PIPE starting with '/' selects the Unix-socket branch regardless of
+    // WSL detection, so this branch needs no fake npiperelay. WMUX_REMOTE must
+    // be cleared: it takes precedence (TCP) and is set when this suite itself
+    // runs inside a wmux devcontainer.
+    const child = await startBridge(port, {
+      ...process.env,
+      WMUX_REMOTE: '',
+      WMUX_REMOTE_TOKEN: '',
+      WMUX_PIPE: sockPath,
+    } as Record<string, string>);
+    cleanups.push(() => child.kill());
+
+    const echoed = await roundTrip(port, 'ping-unix\n');
+    expect(echoed).toContain('ping-unix');
+  });
+
+  it('relays TCP ↔ npiperelay.exe stdio when running inside WSL2', async () => {
+    // Fake npiperelay.exe: ignores its args (-ei -s //./pipe/wmux) and echoes
+    // stdin→stdout, standing in for the Windows named pipe over interop.
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-npiperelay-'));
+    const fakeBin = path.join(binDir, 'npiperelay.exe');
+    fs.writeFileSync(fakeBin, '#!/usr/bin/env node\nprocess.stdin.pipe(process.stdout);\n');
+    fs.chmodSync(fakeBin, 0o755);
+    cleanups.push(() => fs.rmSync(binDir, { recursive: true, force: true }));
+
+    const port = await freePort();
+    // WSL_DISTRO_NAME set + WMUX_PIPE cleared (falls back to the \\.\pipe\wmux
+    // default, which is not a '/path') selects the npiperelay branch;
+    // findNpiperelay() picks up our fake via PATH.
+    const child = await startBridge(port, {
+      ...process.env,
+      WMUX_PIPE: '',
+      WMUX_REMOTE: '',
+      WSL_DISTRO_NAME: 'test-distro',
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+    } as Record<string, string>);
+    cleanups.push(() => child.kill());
+
+    const echoed = await roundTrip(port, 'ping-npiperelay\n');
+    expect(echoed).toContain('ping-npiperelay');
+  });
+
+  // Regression: the bridge used to destroy BOTH sides on either 'close', so a
+  // client that wrote a frame and closed immediately — which is exactly what
+  // wmux-hook.js does for every Claude Code hook — had its frame killed inside a
+  // still-draining npiperelay relay (the Duplex's destroy() is child.kill()). The
+  // hook exited 0, the sidebar never updated, and nothing logged an error.
+  //
+  // Measured against a live bridge before the fix, delivery depended purely on how
+  // long the client held the socket open relative to the ~7s pipe round-trip:
+  //     end() after 0ms ✗   2000ms ✗   6000ms ~   9000ms ✓
+  // 0ms is what the hook actually does, hence the bug.
+  it('delivers a frame from a client that closes immediately, even to a slow relay', async () => {
+    // Fake npiperelay that takes its time, standing in for a real one that needs
+    // seconds to attach to the Windows pipe over WSL interop. It records what it
+    // received to a file, so the assertion is "the upstream actually got the
+    // bytes" rather than "a reply came back" — pre-fix the relay is killed before
+    // either could happen.
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-slowrelay-'));
+    const fakeBin = path.join(binDir, 'npiperelay.exe');
+    const received = path.join(binDir, 'received.txt');
+    const RELAY_DELAY_MS = 1500;
+    fs.writeFileSync(
+      fakeBin,
+      '#!/usr/bin/env node\n' +
+        "const fs = require('fs');\n" +
+        "let buf = '';\n" +
+        "process.stdin.on('data', (d) => { buf += d; });\n" +
+        // Forward only once stdin has been ENDED and the delay has elapsed. A
+        // bridge that kills us on client close never gets here.
+        "process.stdin.on('end', () => {\n" +
+        `  setTimeout(() => { fs.writeFileSync(${JSON.stringify(received)}, buf); process.stdout.write(buf); }, ${RELAY_DELAY_MS});\n` +
+        '});\n'
+    );
+    fs.chmodSync(fakeBin, 0o755);
+    cleanups.push(() => fs.rmSync(binDir, { recursive: true, force: true }));
+
+    const port = await freePort();
+    const child = await startBridge(port, {
+      ...process.env,
+      WMUX_PIPE: '',
+      WMUX_REMOTE: '',
+      WSL_DISTRO_NAME: 'test-distro',
+      // Comfortably longer than RELAY_DELAY_MS, short enough to keep the suite
+      // quick. Pinned rather than inherited so the test does not depend on the
+      // shipped default.
+      WMUX_BRIDGE_DRAIN_MS: '8000',
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+    } as Record<string, string>);
+    cleanups.push(() => child.kill());
+
+    // The bug trigger: write one frame, then close at once without awaiting a reply.
+    const frame = JSON.stringify({ method: 'hook.event', params: { event: 'Notification' }, id: 1 });
+    await new Promise<void>((resolve, reject) => {
+      const sock = net.connect({ host: '127.0.0.1', port }, () => {
+        sock.write(frame + '\n', () => sock.end());
+      });
+      sock.on('close', () => resolve());
+      sock.on('error', reject);
+    });
+
+    // Poll rather than sleep a fixed span, so a fast machine finishes early and a
+    // slow one still gets its full window.
+    const deadline = Date.now() + RELAY_DELAY_MS + 6000;
+    let got = '';
+    while (Date.now() < deadline) {
+      if (fs.existsSync(received)) {
+        got = fs.readFileSync(received, 'utf-8');
+        if (got.includes('hook.event')) break;
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    expect(got).toContain('hook.event');
+  }, 20000);
+
+  // The other half of the devcontainer latency problem: the bridge used to spawn a
+  // fresh npiperelay.exe per connection, so every hook paid the exec (AV/EDR-scanned
+  // on a corporate host) plus the pipe dial — ~7s measured. The pool spawns relays
+  // ahead of demand so a client gets one already attached.
+  describe('warm relay pool', () => {
+    // Fake npiperelay that records each spawn to a log file, then echoes. Counting
+    // the log is how the test distinguishes "pre-warmed" from "spawned on demand".
+    function makeCountingRelay(): { binDir: string; spawnLog: string } {
+      const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-warm-'));
+      const spawnLog = path.join(binDir, 'spawns.log');
+      fs.writeFileSync(
+        path.join(binDir, 'npiperelay.exe'),
+        '#!/usr/bin/env node\n' +
+          `require('fs').appendFileSync(${JSON.stringify(spawnLog)}, 'x');\n` +
+          'process.stdin.pipe(process.stdout);\n'
+      );
+      fs.chmodSync(path.join(binDir, 'npiperelay.exe'), 0o755);
+      return { binDir, spawnLog };
+    }
+
+    const spawnCount = (logPath: string): number =>
+      (fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf-8').length : 0);
+
+    async function waitFor(fn: () => boolean, timeoutMs = 5000): Promise<void> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline && !fn()) await new Promise((r) => setTimeout(r, 50));
+    }
+
+    it('spawns relays before any client connects, and refills after one is claimed', async () => {
+      const { binDir, spawnLog } = makeCountingRelay();
+      cleanups.push(() => fs.rmSync(binDir, { recursive: true, force: true }));
+
+      const port = await freePort();
+      const child = await startBridge(port, {
+        ...process.env,
+        WMUX_PIPE: '',
+        WMUX_REMOTE: '',
+        WSL_DISTRO_NAME: 'test-distro',
+        WMUX_BRIDGE_WARM: '2',
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      } as Record<string, string>);
+      cleanups.push(() => child.kill());
+
+      // Pre-warm happens in the listen callback — no client has connected yet.
+      await waitFor(() => spawnCount(spawnLog) >= 2);
+      expect(spawnCount(spawnLog)).toBe(2);
+
+      // The warm relay must be a working transport, not just a spawned process.
+      expect(await roundTrip(port, 'ping-warm\n')).toContain('ping-warm');
+
+      // Claiming one triggers a replacement, so the next client is served warm too.
+      await waitFor(() => spawnCount(spawnLog) >= 3);
+      expect(spawnCount(spawnLog)).toBe(3);
+    }, 20000);
+
+    it('spawns nothing ahead of time when WMUX_BRIDGE_WARM=0', async () => {
+      const { binDir, spawnLog } = makeCountingRelay();
+      cleanups.push(() => fs.rmSync(binDir, { recursive: true, force: true }));
+
+      const port = await freePort();
+      const child = await startBridge(port, {
+        ...process.env,
+        WMUX_PIPE: '',
+        WMUX_REMOTE: '',
+        WSL_DISTRO_NAME: 'test-distro',
+        WMUX_BRIDGE_WARM: '0',
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      } as Record<string, string>);
+      cleanups.push(() => child.kill());
+
+      await new Promise((r) => setTimeout(r, 500));
+      expect(spawnCount(spawnLog)).toBe(0);
+
+      // Opting out restores spawn-per-connection, which must still work.
+      expect(await roundTrip(port, 'ping-cold\n')).toContain('ping-cold');
+      expect(spawnCount(spawnLog)).toBe(1);
+    }, 20000);
+  });
+});

--- a/tests/unit/wmux-bridge-transport.test.ts
+++ b/tests/unit/wmux-bridge-transport.test.ts
@@ -61,12 +61,13 @@ function roundTrip(port: number, payload: string): Promise<string> {
 
 describe('wmux bridge transport selection (WSL2 devcontainer path)', () => {
   const cleanups: Array<() => void> = [];
+  const isWslRuntime = Boolean(process.env.WSL_DISTRO_NAME || process.env.WSLENV);
 
   afterEach(() => {
     while (cleanups.length) cleanups.pop()!();
   });
 
-  it('relays TCP ↔ a Unix-socket upstream when WMUX_PIPE is a /path', async () => {
+  it.skipIf(process.platform === 'win32')('relays TCP ↔ a Unix-socket upstream when WMUX_PIPE is a /path', async () => {
     // Stand-in for the local pipe: a Unix-socket echo server.
     const sockPath = path.join(os.tmpdir(), `wmux-bridge-test-${process.pid}.sock`);
     try { fs.unlinkSync(sockPath); } catch { /* not present */ }
@@ -91,7 +92,7 @@ describe('wmux bridge transport selection (WSL2 devcontainer path)', () => {
     expect(echoed).toContain('ping-unix');
   });
 
-  it('relays TCP ↔ npiperelay.exe stdio when running inside WSL2', async () => {
+  it.skipIf(!isWslRuntime)('relays TCP ↔ npiperelay.exe stdio when running inside WSL2', async () => {
     // Fake npiperelay.exe: ignores its args (-ei -s //./pipe/wmux) and echoes
     // stdin→stdout, standing in for the Windows named pipe over interop.
     const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-npiperelay-'));
@@ -127,7 +128,7 @@ describe('wmux bridge transport selection (WSL2 devcontainer path)', () => {
   // long the client held the socket open relative to the ~7s pipe round-trip:
   //     end() after 0ms ✗   2000ms ✗   6000ms ~   9000ms ✓
   // 0ms is what the hook actually does, hence the bug.
-  it('delivers a frame from a client that closes immediately, even to a slow relay', async () => {
+  it.skipIf(!isWslRuntime)('delivers a frame from a client that closes immediately, even to a slow relay', async () => {
     // Fake npiperelay that takes its time, standing in for a real one that needs
     // seconds to attach to the Windows pipe over WSL interop. It records what it
     // received to a file, so the assertion is "the upstream actually got the
@@ -219,7 +220,7 @@ describe('wmux bridge transport selection (WSL2 devcontainer path)', () => {
       while (Date.now() < deadline && !fn()) await new Promise((r) => setTimeout(r, 50));
     }
 
-    it('spawns relays before any client connects, and refills after one is claimed', async () => {
+    it.skipIf(!isWslRuntime)('spawns relays before any client connects, and refills after one is claimed', async () => {
       const { binDir, spawnLog } = makeCountingRelay();
       cleanups.push(() => fs.rmSync(binDir, { recursive: true, force: true }));
 
@@ -246,7 +247,7 @@ describe('wmux bridge transport selection (WSL2 devcontainer path)', () => {
       expect(spawnCount(spawnLog)).toBe(3);
     }, 20000);
 
-    it('spawns nothing ahead of time when WMUX_BRIDGE_WARM=0', async () => {
+    it.skipIf(!isWslRuntime)('spawns nothing ahead of time when WMUX_BRIDGE_WARM=0', async () => {
       const { binDir, spawnLog } = makeCountingRelay();
       cleanups.push(() => fs.rmSync(binDir, { recursive: true, force: true }));
 

--- a/tests/unit/wmux-hook-remote-transport.test.ts
+++ b/tests/unit/wmux-hook-remote-transport.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFile } from 'child_process';
+import net from 'net';
+import path from 'path';
+
+// Exercises the real compiled wmux-hook.js (resources/cli/wmux-hook.js) over
+// its TCP remote-mode transport (WMUX_REMOTE, issue #19/#78) against a raw
+// TCP server standing in for `wmux bridge`. Unlike the named-pipe path, this
+// script has no exported functions to unit test directly (it's a
+// fire-and-forget CLI leaf), so we verify its actual process behavior
+// end-to-end instead.
+
+const HOOK_SCRIPT = path.resolve(__dirname, '../../resources/cli/wmux-hook.js');
+
+function runHook(args: string[], env: Record<string, string>, stdin = ''): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = execFile('node', [HOOK_SCRIPT, ...args], { env, timeout: 5000 }, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+    child.stdin?.end(stdin);
+  });
+}
+
+function startCapturingServer(): Promise<{ port: number; requests: Promise<any>; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    let resolveRequest: (v: any) => void;
+    const requests = new Promise<any>((r) => { resolveRequest = r; });
+
+    const server = net.createServer((socket) => {
+      let data = '';
+      socket.on('data', (chunk) => {
+        data += chunk.toString();
+        if (data.includes('\n')) {
+          resolveRequest(JSON.parse(data.trim()));
+          socket.end();
+        }
+      });
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({ port, requests, close: () => new Promise((r) => server.close(() => r())) });
+    });
+  });
+}
+
+describe('wmux-hook.js TCP remote-mode transport (issue #19)', () => {
+  let close: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (close) await close();
+    close = undefined;
+  });
+
+  it('sends hook.event over TCP with the token when WMUX_REMOTE is set', async () => {
+    const server = await startCapturingServer();
+    close = server.close;
+
+    await runHook(['Bash'], {
+      ...process.env,
+      WMUX_REMOTE: `127.0.0.1:${server.port}`,
+      WMUX_REMOTE_TOKEN: 'secret-token',
+      WMUX_SURFACE_ID: 'pane-1',
+    } as Record<string, string>);
+
+    const req = await server.requests;
+    expect(req.method).toBe('hook.event');
+    expect(req.token).toBe('secret-token');
+    // Same frame the pipe path sends, including the `at` fire stamp wmux orders
+    // racing hook processes by (issue #151) — the transport is all that differs.
+    expect(req.params).toEqual({ tool: 'Bash', surfaceId: 'pane-1', at: expect.any(Number) });
+    expect(req.params.at).toBeGreaterThan(0);
+  });
+
+  it('includes file_path from PostToolUse Edit/Write stdin payloads', async () => {
+    const server = await startCapturingServer();
+    close = server.close;
+
+    await runHook(
+      ['Edit'],
+      { ...process.env, WMUX_REMOTE: `127.0.0.1:${server.port}`, WMUX_REMOTE_TOKEN: 't', WMUX_SURFACE_ID: 'pane-2' } as Record<string, string>,
+      JSON.stringify({ tool_input: { file_path: '/workspaces/repo/foo.ts' } }),
+    );
+
+    const req = await server.requests;
+    expect(req.params).toEqual({ tool: 'Edit', file: '/workspaces/repo/foo.ts', surfaceId: 'pane-2', at: expect.any(Number) });
+  });
+
+  it('sends the --event flag as the event field for Notification/Stop', async () => {
+    const server = await startCapturingServer();
+    close = server.close;
+
+    await runHook(
+      ['--event', 'Notification'],
+      { ...process.env, WMUX_REMOTE: `127.0.0.1:${server.port}`, WMUX_REMOTE_TOKEN: 't', WMUX_SURFACE_ID: '' } as Record<string, string>,
+      JSON.stringify({ message: 'Permission needed' }),
+    );
+
+    const req = await server.requests;
+    expect(req.params).toEqual({ event: 'Notification', message: 'Permission needed', at: expect.any(Number) });
+  });
+
+  it('defaults to port 9787 when WMUX_REMOTE has no explicit port', async () => {
+    // Can't bind 9787 in a shared test env reliably, so just assert it doesn't
+    // fall back to the named pipe (would hang/error differently) — connection
+    // refused on the default port is the expected, quick failure mode here.
+    await expect(
+      runHook(['Bash'], {
+        ...process.env,
+        WMUX_REMOTE: '127.0.0.1',
+        WMUX_REMOTE_TOKEN: 't',
+      } as Record<string, string>),
+    ).resolves.toBeUndefined();
+  });
+
+  it('exits cleanly (does not hang or throw) when the remote target is unreachable', async () => {
+    await expect(
+      runHook(['Bash'], {
+        ...process.env,
+        WMUX_REMOTE: '127.0.0.1:1', // nothing listens on port 1
+        WMUX_REMOTE_TOKEN: 't',
+      } as Record<string, string>),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/workspace-posix-cwd.test.ts
+++ b/tests/unit/workspace-posix-cwd.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import { create } from 'zustand';
+import { createWorkspaceSlice, WorkspaceSlice } from '../../src/renderer/store/workspace-slice';
+import { cwdReportPatch, isPosixPath, isWslShell, workspaceFallbackCwd } from '../../src/shared/paths';
+import { WorkspaceId } from '../../src/shared/types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// One workspace, two filesystems.
+//
+// A workspace can hold a pwsh pane and a WSL pane side by side, and both report
+// their directory over the same `report_pwd`. `workspace.cwd` was a single
+// last-writer-wins field, so the pwsh pane's C:\Users\<user> overwrote the
+// POSIX path — and since a plain WSL pane never reports its own cwd (wmux sets
+// WMUX_INTEGRATION=1 in the distro but installs no rc hook there), the next WSL
+// pane fell back to that Win32 path, failed isPosixPath, and got `--cd ~`.
+// Users saw every new WSL pane open in /home/<user> instead of the project.
+//
+// `posixCwd` is the same medicine issue #134 applied per-terminal: stop making
+// one field answer for two namespaces.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeStore() {
+  return create<WorkspaceSlice>()((...args) => ({ ...createWorkspaceSlice(...args) }));
+}
+
+function wsById(store: ReturnType<typeof makeStore>, id: WorkspaceId) {
+  return store.getState().workspaces.find((w) => w.id === id)!;
+}
+
+describe('isPosixPath', () => {
+  it('accepts a WSL/devcontainer path', () => {
+    expect(isPosixPath('/home/lsi2abt/agent/ms-container-feature-agent1')).toBe(true);
+  });
+
+  it('rejects a drive-rooted Win32 path', () => {
+    expect(isPosixPath('C:\\Users\\lsi2abt')).toBe(false);
+  });
+
+  it('rejects a UNC path — a leading // is a server, not a POSIX root', () => {
+    expect(isPosixPath('//server/share')).toBe(false);
+  });
+});
+
+describe('isWslShell', () => {
+  it('recognises the shell spec wmux spawns WSL panes with', () => {
+    expect(isWslShell('wsl.exe')).toBe(true);
+    expect(isWslShell('C:\\Windows\\System32\\wsl.exe -d Ubuntu')).toBe(true);
+  });
+
+  it('does not claim a Win32 shell', () => {
+    expect(isWslShell('powershell.exe')).toBe(false);
+    expect(isWslShell(undefined)).toBe(false);
+  });
+
+  it('does not guess POSIX for a remote command line (issue #78)', () => {
+    // wmux has no idea where `ssh user@host` lands; handing it a POSIX path
+    // would be a guess, and a wrong one whenever the far end is Windows.
+    expect(isWslShell('ssh user@host')).toBe(false);
+  });
+});
+
+describe('cwdReportPatch', () => {
+  it('records a POSIX report in both fields', () => {
+    expect(cwdReportPatch('/home/u/proj')).toEqual({ cwd: '/home/u/proj', posixCwd: '/home/u/proj' });
+  });
+
+  it('omits posixCwd entirely for a Win32 report', () => {
+    const patch = cwdReportPatch('C:\\Users\\lsi2abt');
+    expect(patch).toEqual({ cwd: 'C:\\Users\\lsi2abt' });
+    // Present-but-undefined would still clear the field when the patch is
+    // spread into the workspace, so absence of the key is the contract.
+    expect('posixCwd' in patch).toBe(false);
+  });
+
+  it('omits posixCwd for an empty report rather than blanking it', () => {
+    expect('posixCwd' in cwdReportPatch(undefined)).toBe(false);
+    expect('posixCwd' in cwdReportPatch('')).toBe(false);
+  });
+});
+
+describe('a powershell report_pwd does not clear a recorded posixCwd', () => {
+  it('leaves posixCwd intact while cwd follows the latest prompt', () => {
+    const store = makeStore();
+    const id = store.getState().createWorkspace({ title: 'ms-playbook-agent2', shell: 'wsl.exe' });
+
+    // The WSL pane reports first…
+    store.getState().updateWorkspaceMetadata(id, cwdReportPatch('/home/lsi2abt/agent/ms-playbook-agent2'));
+    expect(wsById(store, id).posixCwd).toBe('/home/lsi2abt/agent/ms-playbook-agent2');
+
+    // …then the pwsh pane in the same workspace reports. This is the exact
+    // sequence that produced `cwd: "C:\\Users\\lsi2abt"` in a real session.json.
+    store.getState().updateWorkspaceMetadata(id, cwdReportPatch('C:\\Users\\lsi2abt'));
+
+    expect(wsById(store, id).cwd).toBe('C:\\Users\\lsi2abt');
+    expect(wsById(store, id).posixCwd).toBe('/home/lsi2abt/agent/ms-playbook-agent2');
+  });
+});
+
+describe('workspaceFallbackCwd', () => {
+  const polluted = { cwd: 'C:\\Users\\lsi2abt', posixCwd: '/home/lsi2abt/agent/ms-playbook-agent2' };
+
+  it('gives a WSL surface the POSIX path even when cwd holds a Win32 one', () => {
+    expect(workspaceFallbackCwd('wsl.exe', polluted)).toBe('/home/lsi2abt/agent/ms-playbook-agent2');
+  });
+
+  it('still gives a Win32 surface the Win32 path', () => {
+    expect(workspaceFallbackCwd('powershell.exe', polluted)).toBe('C:\\Users\\lsi2abt');
+  });
+
+  it('falls back to a POSIX cwd for a WSL surface when posixCwd was never set', () => {
+    // Sessions written before posixCwd existed, and workspaces whose panes are
+    // all POSIX, have the right answer sitting in `cwd`.
+    expect(workspaceFallbackCwd('wsl.exe', { cwd: '/home/u/proj' })).toBe('/home/u/proj');
+  });
+
+  it('returns undefined rather than handing wsl.exe a path it cannot open', () => {
+    // `--cd C:\Users\lsi2abt` is not something wsl.exe can honour, so there is
+    // nothing to gain by passing it; undefined keeps "we do not know" legible.
+    expect(workspaceFallbackCwd('wsl.exe', { cwd: 'C:\\Users\\lsi2abt' })).toBeUndefined();
+  });
+
+  it('returns undefined for a surface with no workspace', () => {
+    expect(workspaceFallbackCwd('wsl.exe', null)).toBeUndefined();
+    expect(workspaceFallbackCwd('wsl.exe', undefined)).toBeUndefined();
+  });
+});
+
+describe('createWorkspace seeds posixCwd', () => {
+  it('derives it from a POSIX cwd, so a folder-opened workspace is correct from birth', () => {
+    const store = makeStore();
+    const id = store.getState().createWorkspace({ title: 'p', shell: 'wsl.exe', cwd: '/home/u/proj' });
+    expect(wsById(store, id).posixCwd).toBe('/home/u/proj');
+  });
+
+  it('leaves it unset for a Win32 cwd', () => {
+    const store = makeStore();
+    const id = store.getState().createWorkspace({ title: 'p', shell: 'powershell.exe', cwd: 'C:\\dev\\proj' });
+    expect(wsById(store, id).posixCwd).toBeUndefined();
+  });
+
+  it('prefers an explicit posixCwd over the derived one', () => {
+    const store = makeStore();
+    const id = store.getState().createWorkspace({
+      title: 'p',
+      shell: 'wsl.exe',
+      cwd: 'C:\\dev\\proj',
+      posixCwd: '/home/u/proj',
+    });
+    expect(wsById(store, id).posixCwd).toBe('/home/u/proj');
+  });
+});
+
+describe('posixCwd round-trips through save → replaceAllWorkspaces', () => {
+  it('restores a saved posixCwd verbatim', () => {
+    const store = makeStore();
+    store.getState().replaceAllWorkspaces([
+      {
+        title: 'ms-playbook-agent2',
+        shell: 'wsl.exe',
+        cwd: 'C:\\Users\\lsi2abt',
+        posixCwd: '/home/lsi2abt/agent/ms-playbook-agent2',
+      },
+    ]);
+    const ws = store.getState().workspaces[0];
+    expect(ws.posixCwd).toBe('/home/lsi2abt/agent/ms-playbook-agent2');
+    expect(workspaceFallbackCwd('wsl.exe', ws)).toBe('/home/lsi2abt/agent/ms-playbook-agent2');
+  });
+
+  it('repairs a session written before posixCwd existed, when cwd is POSIX', () => {
+    // This is what rescues the user's already-saved workspaces without asking
+    // them to recreate a tab: the seed runs on every restore, not just on create.
+    const store = makeStore();
+    store.getState().replaceAllWorkspaces([
+      { title: 'p', shell: 'wsl.exe', cwd: '/home/u/proj' },
+    ]);
+    expect(store.getState().workspaces[0].posixCwd).toBe('/home/u/proj');
+  });
+
+  it('cannot invent a POSIX path when the saved cwd is Win32', () => {
+    // A workspace whose cwd was already clobbered before the fix shipped has no
+    // POSIX path recorded anywhere; it recovers on the next WSL report, not here.
+    const store = makeStore();
+    store.getState().replaceAllWorkspaces([
+      { title: 'p', shell: 'wsl.exe', cwd: 'C:\\Users\\lsi2abt' },
+    ]);
+    expect(store.getState().workspaces[0].posixCwd).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Seven commits on top of `master` (v0.50.0). The headline one lets the `wmux` CLI, the Claude Code hooks and the shell integration reach `\\.\pipe\wmux` from inside a Linux devcontainer; the rest are standalone fixes found along the way.

Each commit stands alone and explains its own reasoning in the message — reviewing commit by commit will be a lot easier than reading the combined diff. Happy to split this into separate PRs if you'd prefer; opened as a draft so you can say so before I do.

## What's in it

- **`feat(devcontainer)`** (`9fd08ed`) — `wmux bridge --wsl` runs the byte relay *inside* WSL2 and reaches the Windows pipe via [`npiperelay.exe`](https://github.com/albertony/npiperelay) over interop. `0.0.0.0` there is the WSL2 network namespace: reachable from containers through the Docker host gateway, not from the LAN, and no firewall rule needed. Builds on the remote transport from #78. Adds `wmux raw-v1` so the bash integration can send V1 lines through the CLI's transport instead of a Windows temp file it cannot write, plus `report_startup_command` so a restored pane re-enters its container instead of coming up as a bare WSL prompt. AF_VSOCK, a Windows-side listener and cross-boundary Unix sockets were all tried first and are documented as rejected in the code. Setup guide: `docs/DEVCONTAINER.md`.
- **`fix(cwd)`** (`f5f782c`) — a workspace tracks `posixCwd` separately from `cwd`, so a pwsh pane no longer rewrites the directory a neighbouring WSL pane falls back to. Extends what #134 did per-terminal to the workspace, and is additive: sessions saved before the field existed recover via an `isPosixPath(cwd)` seed.
- **`feat(config)`** (`0fa84ab`) — warn when `~/.wmux/config.toml` fails to read or parse. The whole file is discarded on failure, so one stray character presents as "my setting has no effect" with nothing pointing at the file. Deduped, because `loadUserConfig` runs on every WSL pane spawn.
- **`fix(cli)`** (`16b0d4c`) — `wmux config path` built the path from `os.homedir()` instead of asking the instance, so from WSL or a container it printed `/home/vscode\.wmux\config.toml` — not the file wmux reads, and not a well-formed path on either OS.
- **`fix(shell-integration)`** (`d1c1b58`) — `resources/shell-integration/wmux-bash-integration.sh` had not moved since v0.5.2 while the copy under `src/` had. Consumers that read it out of a repo checkout got the pre-bridge `_wmux_report` and an error on every prompt. Plain copy of the `src/` file, no hand-edits. The `.cmd` and `.ps1` copies have drifted the same way and are deliberately left for a separate change.
- **`fix(cli)`** (`c693c06`) — three places in the CLI that assumed one OS's path conventions. `findNpiperelay()` split `$PATH` on a hard-coded `:`, so on native Windows the whole search collapsed to one nonsense entry; it now splits on `path.delimiter`, drops empties, and reads `Path` as well as `PATH`. The `config path` and `locales path` fallbacks — the branch taken when no instance answers — chose their separator from the *host* rather than from the home directory actually in hand, producing `/home/vscode\.wmux\config.toml`; they now pick `path.posix.join` for a POSIX home and `path.join` otherwise.
- **`test(bash-path)`** (`64fb8d8`) — repairs the test fallout of the commit above. `c693c06` also made the `bashPathCandidates()` test helper platform-conditional (Git Bash's `/c` first on Windows, WSL's `/mnt/c` elsewhere) so the orchestrator suites can resolve a drive path under a Linux bash, but `tests/unit/bash-path.test.ts` still asserted the fixed Git-Bash-first order it was written against in #130 — green on Windows, four failures on Linux and macOS. The set of spellings offered is invariant and is now asserted order-independently; the order is not, and is asserted once against the same `process.platform` condition the helper uses. No behaviour change.

`resources/cli/wmux.js` and `resources/cli/wmux-hook.js` are the `tsc -p tsconfig.node.json` output of their sources — re-checked at this head, and byte-identical to a fresh `npm run build:main`, so there are no hand-edits in the artifacts.

## Testing

Measured on Linux (a devcontainer), which is not where most of this code lives, so the honest form is a comparison against `master` on the same machine. Baseline: `8122b69` checked out in a detached worktree, same `node_modules`, same commands.

|  | `master` `8122b69` | this branch `64fb8d8` |
|---|---|---|
| `npm run typecheck` | clean | clean |
| `npm run lint` | 32 problems (17 errors, 15 warnings) | identical — 32 (17 / 15) |
| `npx vitest run` | 6 failed, 865 passed, 2 skipped (873) | 6 failed, 909 passed, 6 skipped (921) |

The failing set is **identical to `master`, one for one** — same files, same test names:

```
tests/unit/orchestration-watcher.test.ts          (suite-level)
tests/unit/pty-ledger.test.ts        × 2          (live Win32_Process probe)
tests/unit/pty-manager.test.ts       × 1          (resolveSpawnCwd)
tests/unit/shell-context-menu.test.ts × 3         (directoryFromArgv)
```

All of them are Windows-path or live-Win32-probe cases that cannot pass off Windows; none of them are new. Nothing this branch adds breaks anything that worked before it.

The four new suites pass: `workspace-posix-cwd` 21/21, `wmux-hook-remote-transport` 5/5, `cli-config-path` 3/3, and `wmux-bridge-transport` 1/1 — including the case that relays TCP to a Unix-socket upstream, which is the transport shape the container path depends on. That suite's other four cases (npiperelay stdio, warm relay pool) are gated to WSL2 and skip here, which is where the +4 skipped comes from.

A run on Windows is still worth having before merge, and matters a little more now: `c693c06` and `64fb8d8` both branch on `process.platform`, so each has a side no Linux run exercises.

The devcontainer path itself is in daily use in the setup `docs/DEVCONTAINER.md` describes (Windows 11 + WSL2 + Docker devcontainer, Claude Code inside the container).

## Notes

- `wmux locales path` still cannot be resolved the way `wmux config path` now is — `config.get` carries no locales directory, so there is nothing to ask the instance for. `c693c06` only makes its local fallback produce a well-formed path for the OS it runs on; it can still be the wrong path when the CLI and wmux are on opposite sides of the WSL boundary.
- Deadlines gained a floor on the slow transports: the 5s default sat below the container→WSL2→pipe round-trip, so calls that had already succeeded were reported as timeouts.

---

🤖 This PR and the code in it were written with the help of [Claude Code](https://claude.com/claude-code); every commit but `c693c06`, where the trailer was dropped by accident, carries a `Co-Authored-By: Claude` trailer.
