### PR TITLE
fix(cli): cross-platform config and locales paths, and a bash-path test repair

### DIFF
--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -359,7 +359,11 @@ async function cmdConfig(args: string[]): Promise<void> {
       // No reachable instance — fall through to a local guess. path.join at least
       // keeps it self-consistent with whichever filesystem we are actually on.
     }
-    console.log(path.join(os.homedir(), '.wmux', 'config.toml'));
+    const home = process.env.HOME || process.env.USERPROFILE || os.homedir();
+    const fallbackPath = home.includes('/') && !home.includes('\\')
+      ? path.posix.join(home, '.wmux', 'config.toml')
+      : path.join(home, '.wmux', 'config.toml');
+    console.log(fallbackPath);
   } else {
     console.error('Usage: wmux config <show|reload|path>'); process.exit(1);
   }
@@ -377,8 +381,14 @@ async function cmdLocales(args: string[]): Promise<void> {
   } else if (sub === 'reload') {
     print(await sendV2('config.reload'));
   } else if (sub === 'path') {
-    const home = process.env.USERPROFILE || process.env.HOME || '';
-    console.log(`${home}\\.wmux\\locales`);
+    // No locales equivalent of config.get to ask, so this stays a guess — but a
+    // guess spelled for the filesystem the CLI is on. $HOME first: under WSL both
+    // are set, and USERPROFILE is the Windows one leaking in over interop.
+    const home = process.env.HOME || process.env.USERPROFILE || '';
+    const fallbackPath = home.includes('/') && !home.includes('\\')
+      ? path.posix.join(home, '.wmux', 'locales')
+      : path.join(home, '.wmux', 'locales');
+    console.log(fallbackPath);
   } else {
     console.error('Usage: wmux locales [list|reload|path]'); process.exit(1);
   }

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -342,8 +342,24 @@ async function cmdConfig(args: string[]): Promise<void> {
   } else if (sub === 'reload') {
     print(await sendV2('config.reload'));
   } else if (sub === 'path') {
-    const home = process.env.USERPROFILE || process.env.HOME || '';
-    console.log(`${home}\\.wmux\\config.toml`);
+    // Ask the instance rather than reconstructing the path here. The config lives
+    // on the Windows host, but this CLI routinely runs somewhere that cannot name
+    // it: inside WSL, or inside a devcontainer reaching wmux over the TCP bridge.
+    // There $HOME is the Linux home and the old `${home}\.wmux\config.toml` form
+    // produced `/home/vscode\.wmux\config.toml` — neither the file wmux reads nor
+    // a well-formed path on either OS. loadUserConfig() already reports the real
+    // one in `path` (user-config.ts), which config.get returns verbatim.
+    try {
+      const cfg = await sendV2('config.get');
+      if (cfg && typeof cfg.path === 'string') {
+        console.log(cfg.path);
+        return;
+      }
+    } catch {
+      // No reachable instance — fall through to a local guess. path.join at least
+      // keeps it self-consistent with whichever filesystem we are actually on.
+    }
+    console.log(path.join(os.homedir(), '.wmux', 'config.toml'));
   } else {
     console.error('Usage: wmux config <show|reload|path>'); process.exit(1);
   }

--- a/tests/helpers/bash-path.ts
+++ b/tests/helpers/bash-path.ts
@@ -20,15 +20,22 @@ export function bashPathCandidates(p: string): string[] {
   if (!drive) return [slashed];
   const letter = drive[1].toLowerCase();
   const rest = drive[2];
-  return [`/${letter}/${rest}`, `/mnt/${letter}/${rest}`, `/cygdrive/${letter}/${rest}`];
+  // Git Bash usually sees `C:` as `/c`, WSL sees `/mnt/c`, and Cygwin exposes
+  // `/cygdrive/c`. The actual bash on PATH decides which spelling exists, so
+  // keep the likely order but let `toBashPath()` probe and select the real one.
+  return process.platform === 'win32'
+    ? [`/${letter}/${rest}`, `/mnt/${letter}/${rest}`, `/cygdrive/${letter}/${rest}`]
+    : [`/mnt/${letter}/${rest}`, `/${letter}/${rest}`, `/cygdrive/${letter}/${rest}`];
 }
 
 /**
  * First candidate spelling `exists` accepts, else the first candidate.
  *
- * Order matters beyond mere likelihood: Git Bash (`/c`) is preferred because it
- * runs in the Windows process tree and can execute the `node` the scripts call,
- * whereas WSL bash would need a second toolchain installed inside the distro.
+ * Order matters beyond mere likelihood: on Windows, Git Bash (`/c`) is preferred
+ * because it runs in the Windows process tree and can execute the `node` the
+ * scripts call, whereas WSL bash would need a second toolchain installed inside
+ * the distro. Off Windows there is no Git Bash to prefer, so `bashPathCandidates`
+ * leads with the WSL mount instead.
  */
 export function toBashPath(p: string, exists: (candidate: string) => boolean): string {
   const candidates = bashPathCandidates(p);
@@ -38,7 +45,7 @@ export function toBashPath(p: string, exists: (candidate: string) => boolean): s
 
 /** True when `candidate` names an existing path to the bash on PATH. */
 export function bashExists(candidate: string): boolean {
-  const probe = spawnSync('bash', ['-c', 'test -e "$1"', 'bash', candidate], { stdio: 'ignore' });
+  const probe = spawnSync('bash', ['-lc', 'test -e "$1"', '_', candidate], { stdio: 'ignore' });
   return !probe.error && probe.status === 0;
 }
 

--- a/tests/unit/bash-path.test.ts
+++ b/tests/unit/bash-path.test.ts
@@ -1,17 +1,38 @@
 import { describe, it, expect } from 'vitest';
 import { bashPathCandidates, toBashPath } from '../helpers/bash-path';
 
+/**
+ * Which spelling `bashPathCandidates` leads with depends on the bash the suite
+ * can actually reach, so it is the one thing here that is platform-conditional.
+ * On Windows that bash is Git Bash, which mounts `C:` at `/c`; anywhere else
+ * the runner is already inside a Linux bash, where a Windows drive — if it is
+ * visible at all — is a WSL2 mount at `/mnt/c`. Every flavour is always
+ * offered either way; only the order moves. Asserting the fixed Git Bash order
+ * would pass on Windows and fail on every Linux and macOS checkout.
+ */
+const likeliestMount = process.platform === 'win32' ? '/c' : '/mnt/c';
+
 describe('bashPathCandidates', () => {
   it('offers the Git Bash, WSL and Cygwin spellings of a Windows drive path', () => {
-    expect(bashPathCandidates('C:\\dev\\wmux\\scripts')).toEqual([
-      '/c/dev/wmux/scripts',
-      '/mnt/c/dev/wmux/scripts',
-      '/cygdrive/c/dev/wmux/scripts',
-    ]);
+    const candidates = bashPathCandidates('C:\\dev\\wmux\\scripts');
+    expect(candidates).toEqual(
+      expect.arrayContaining([
+        '/c/dev/wmux/scripts',
+        '/mnt/c/dev/wmux/scripts',
+        '/cygdrive/c/dev/wmux/scripts',
+      ]),
+    );
+    expect(candidates).toHaveLength(3);
+  });
+
+  it('leads with the spelling the bash on this platform is likeliest to mount', () => {
+    expect(bashPathCandidates('C:\\dev\\wmux\\scripts')[0]).toBe(`${likeliestMount}/dev/wmux/scripts`);
   });
 
   it('lower-cases the drive letter, the way every bash flavour mounts it', () => {
-    expect(bashPathCandidates('D:/Temp/x')[0]).toBe('/d/Temp/x');
+    expect(bashPathCandidates('D:/Temp/x')).toEqual(
+      expect.arrayContaining(['/d/Temp/x', '/mnt/d/Temp/x', '/cygdrive/d/Temp/x']),
+    );
   });
 
   it('leaves a POSIX path alone', () => {
@@ -29,12 +50,17 @@ describe('toBashPath', () => {
     expect(toBashPath('C:\\dev\\wmux', wslOnly)).toBe('/mnt/c/dev/wmux');
   });
 
-  it('prefers Git Bash when both spellings resolve — it inherits the Windows env', () => {
-    expect(toBashPath('C:\\dev\\wmux', () => true)).toBe('/c/dev/wmux');
+  it('picks the spelling the probe says the bash on PATH can see, Git Bash flavour', () => {
+    const gitBashOnly = (p: string) => !p.startsWith('/mnt/') && !p.startsWith('/cygdrive/');
+    expect(toBashPath('C:\\dev\\wmux', gitBashOnly)).toBe('/c/dev/wmux');
+  });
+
+  it('prefers the platform mount when every spelling resolves', () => {
+    expect(toBashPath('C:\\dev\\wmux', () => true)).toBe(`${likeliestMount}/dev/wmux`);
   });
 
   it('falls back to the first candidate when nothing probes true', () => {
-    expect(toBashPath('C:\\dev\\wmux', () => false)).toBe('/c/dev/wmux');
+    expect(toBashPath('C:\\dev\\wmux', () => false)).toBe(`${likeliestMount}/dev/wmux`);
   });
 
   it('never probes a path that has no drive letter to translate', () => {

--- a/tests/unit/cli-config-path.test.ts
+++ b/tests/unit/cli-config-path.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, afterEach, beforeAll } from 'vitest';
+import { spawn, execFileSync } from 'node:child_process';
+import net from 'node:net';
+import path from 'node:path';
+
+/**
+ * `wmux config path` used to build the path client-side:
+ *
+ *   console.log(`${os.homedir()}\\.wmux\\config.toml`)
+ *
+ * Run from inside WSL or a devcontainer — where this CLI spends most of its
+ * life, reaching wmux over the TCP bridge — that prints
+ * `/home/vscode\.wmux\config.toml`: neither the file wmux reads (it lives on the
+ * Windows host) nor a well-formed path on either OS. Someone editing "the config
+ * file" at that path is editing nothing, which is a long way to walk before
+ * finding out why a setting had no effect.
+ *
+ * The instance already knows: loadUserConfig() records the real path and
+ * `config.get` returns it.
+ *
+ * Spawned from dist/, not from resources/cli/wmux.js. dist/cli/wmux.js is the
+ * file a released wmux runs — package.json's `bin` points at it, electron-builder
+ * copies it into the package, and the release staging step copies it into the zip.
+ * resources/cli/wmux.js is a checked-in copy of that build with nothing enforcing
+ * the copy, so it drifts from src/; a test spawning it asserts against whatever
+ * was committed last rather than against this branch's source.
+ */
+
+const ROOT = path.resolve(__dirname, '../..');
+const CLI = path.join(ROOT, 'dist', 'cli', 'wmux.js');
+const WINDOWS_PATH = 'C:\\Users\\lsi2abt\\.wmux\\config.toml';
+
+// dist/ is gitignored and `npm test` runs ahead of `npm run build:main`, so the
+// file these tests spawn has to be produced here. ~3s, and building unconditionally
+// is what makes the spawned CLI this working tree's rather than a leftover from
+// whatever was last compiled. Invoked through node + typescript's own bin so it
+// works the same on Windows, where node_modules/.bin/tsc is a .cmd shim.
+beforeAll(() => {
+  execFileSync(process.execPath, [path.join(ROOT, 'node_modules', 'typescript', 'bin', 'tsc'), '-p', 'tsconfig.node.json'], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+}, 120_000);
+
+let server: net.Server | null = null;
+
+afterEach(async () => {
+  if (server) {
+    await new Promise<void>((r) => server!.close(() => r()));
+    server = null;
+  }
+});
+
+/**
+ * A wmux instance that answers `config.get` and nothing else, over the same
+ * newline-delimited JSON-RPC the real pipe server speaks.
+ */
+function startFakeInstance(token: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server = net.createServer((sock) => {
+      let buf = '';
+      sock.on('data', (chunk) => {
+        buf += chunk.toString();
+        let nl: number;
+        while ((nl = buf.indexOf('\n')) >= 0) {
+          const line = buf.slice(0, nl).trim();
+          buf = buf.slice(nl + 1);
+          if (!line) continue;
+          let req: { id?: unknown; method?: string; token?: string };
+          try { req = JSON.parse(line); } catch { continue; }
+          if (req.token !== token) {
+            sock.write(JSON.stringify({ id: req.id, error: 'unauthorized' }) + '\n');
+            continue;
+          }
+          const result = req.method === 'config.get'
+            ? { path: WINDOWS_PATH, errors: [], terminal: { fontSize: 13 } }
+            : {};
+          sock.write(JSON.stringify({ id: req.id, result }) + '\n');
+        }
+      });
+      sock.on('error', () => { /* client hangs up after its one call */ });
+    });
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server!.address();
+      resolve(typeof addr === 'object' && addr ? addr.port : 0);
+    });
+  });
+}
+
+// Async, not spawnSync: the fake instance lives in this process, and a blocking
+// spawn would stop its event loop from ever accepting the CLI's connection —
+// every call would "fail to reach an instance" and take the fallback.
+function runCli(args: string[], env: Record<string, string>): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [CLI, ...args], {
+      env: { ...process.env, HOME: '/home/vscode', ...env },
+    });
+    let out = '';
+    child.stdout.on('data', (c: Buffer) => { out += c.toString(); });
+    child.on('error', reject);
+    child.on('close', () => resolve(out.trim()));
+  });
+}
+
+describe('wmux config path', () => {
+  it("prints the instance's own path, not one rebuilt from the local $HOME", async () => {
+    const port = await startFakeInstance('tok');
+    const out = await runCli(['config', 'path'], {
+      WMUX_REMOTE: `127.0.0.1:${port}`,
+      WMUX_REMOTE_TOKEN: 'tok',
+    });
+    expect(out).toBe(WINDOWS_PATH);
+  });
+
+  it('agrees with what `config show` reports', async () => {
+    // The two disagreeing is exactly the failure: `show` was right all along,
+    // so a user comparing them had one true answer and one plausible fiction.
+    const port = await startFakeInstance('tok');
+    const env = { WMUX_REMOTE: `127.0.0.1:${port}`, WMUX_REMOTE_TOKEN: 'tok' };
+    const shown = JSON.parse(await runCli(['config', 'show'], env)) as { path: string };
+    expect(await runCli(['config', 'path'], env)).toBe(shown.path);
+  });
+
+  it('falls back to a well-formed local path when no instance answers', async () => {
+    // Still a guess, but a self-consistent one: path.join on POSIX cannot emit
+    // the `/home/vscode\.wmux\config.toml` hybrid the old string template did.
+    const out = await runCli(['config', 'path'], {
+      WMUX_REMOTE: '127.0.0.1:1',
+      WMUX_REMOTE_TOKEN: 'tok',
+    });
+    expect(out).toBe(path.join('/home/vscode', '.wmux', 'config.toml'));
+    expect(out).not.toContain('\\');
+  });
+});

--- a/tests/unit/cli-config-path.test.ts
+++ b/tests/unit/cli-config-path.test.ts
@@ -129,7 +129,10 @@ describe('wmux config path', () => {
       WMUX_REMOTE: '127.0.0.1:1',
       WMUX_REMOTE_TOKEN: 'tok',
     });
-    expect(out).toBe(path.join('/home/vscode', '.wmux', 'config.toml'));
+    // path.posix, not path.join: $HOME is a POSIX path, and on a Windows runner
+    // path.join would spell the expectation with backslashes the CLI no longer emits.
+    const expected = path.posix.join('/home/vscode', '.wmux', 'config.toml');
+    expect(out).toBe(expected);
     expect(out).not.toContain('\\');
   });
 });

--- a/tests/unit/orchestration-status-vocab.test.ts
+++ b/tests/unit/orchestration-status-vocab.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { forBash, hasBash } from '../helpers/bash-path';
+import { bashExists, forBash, hasBash } from '../helpers/bash-path';
 import type { OrchAgentStatus, OrchWaveStatus, OrchRunStatus } from '../../src/shared/types';
 
 const SCRIPTS = path.resolve(__dirname, '../../resources/wmux-orchestrator/scripts');
@@ -20,6 +20,9 @@ let tmp: string;
 let orchDir: string;
 
 const readState = () => JSON.parse(fs.readFileSync(path.join(orchDir, 'state.json'), 'utf8'));
+
+const hookPath = forBash(HOOK);
+const canRunHookSuite = hasBash() && bashExists(hookPath);
 
 function writeState(overrides: Record<string, unknown> = {}): void {
   fs.writeFileSync(
@@ -79,7 +82,7 @@ afterEach(() => {
 
 // A Windows box without Git for Windows has no bash at all — nothing to convert
 // a path FOR. Skipping is explicit and loud rather than a silent green.
-describe.skipIf(!hasBash())('on-agent-stop.sh status vocabulary (#99)', () => {
+describe.skipIf(!canRunHookSuite)('on-agent-stop.sh status vocabulary (#99)', () => {
   it('marks a successful agent "exited" — the word the sidebar counts, not "completed"', () => {
     writeState();
     runHook();


### PR DESCRIPTION
First of the three splits of #166, in the order you asked for.

Three commits, `src/cli/wmux.ts` and `tests/` only. No `resources/` artifact is touched — see the note at the bottom, that turned out to be its own story.

## What is here

**`wmux config path` asks the instance.** It built the path from the caller's own home directory, which only holds when the CLI runs on the same Windows box as wmux. From WSL or a container over the bridge it printed `/home/vscode\.wmux\config.toml` — not the file wmux reads, and not a well-formed path on either OS. `loadUserConfig()` already records the real path and `config.get` returns it, so ask; the local guess stays as the no-instance answer.

**Both no-instance fallbacks are spelled for the OS in hand.** `config path`'s remaining guess and `locales path`, which has no instance-side answer to ask for at all, both hardcoded backslashes. The separator now comes from the home directory that was found rather than from `process.platform`, because the interesting case is exactly where those two disagree: a POSIX `$HOME` gets `path.posix.join`, everything else gets `path.join`. `$HOME` is now preferred over `USERPROFILE` — under WSL both are set and `USERPROFILE` is the Windows one arriving over interop.

`locales path` can still name the wrong directory across the WSL boundary. Fixing that properly needs a `locales.get` reporting the loaded directory the way `config.get` reports `path`; out of scope here.

**The bash-path helper and its test.** `bashPathCandidates()` offered `/c`, `/mnt/c`, `/cygdrive/c` in a fixed order; in a Linux checkout the bash on PATH mounts a Windows drive at `/mnt/c` if it sees one at all, so leading with `/c` put the fallback branch in charge. The order is now conditional on `process.platform`, the set is unchanged, and the probe still decides. `orchestration-status-vocab.test.ts` gains a `bashExists(hookPath)` term in its skip condition — `hasBash()` only says a bash exists, not that it can see the hook script.

`bash-path.test.ts` is in the same commit and not a separate one because it cannot survive the helper change alone: it pinned the Git-Bash-first order literally, and four assertions go red on Linux and macOS the moment the order becomes conditional. Splitting them would leave a commit that fails `npm test` for anyone not on Windows.

## What is not here, and why

You asked for this "minus the npiperelay-specific parts if they're separable". They are not: `findNpiperelay()` does not exist on master — `git grep npiperelay master -- src/cli/wmux.ts` is empty. It arrives with the bridge, so its `path.delimiter` / `Path`-vs-`PATH` fix has to ride with PR 3. Flagging rather than silently omitting.

## The `resources/cli/wmux.js` conflict you expected

It is not there. Nothing in `8122b69..master` touches `src/cli/` or `resources/cli/` — #153's timeout work (`18940c0`) is *below* the PR base, and #158 (`1dd0d9e`) is in `claude-context.ts` and friends. So this PR had no artifact conflict to resolve.

But while checking that, something else turned up, and it changes one test in this PR:

**`resources/cli/wmux.js` is 1519 diff lines behind a build of master's own `src/`** (`wmux-hook.js` is 64). It is missing `timeoutMessage` and `browserDeadline` from #153, `subcommandError` from #156, and `rename-surface` from #104. Nothing shipped is broken by this — `package.json`'s `bin`, `electron-builder.json`'s `extraResources` and step 7 of the release process all use `dist/cli/*.js`, so releases and installs get a fresh build. The stale copies are read by dev-mode Claude hooks (`claude-context.ts:394`) and by anything consuming the CLI out of a repo checkout.

`cli-config-path.test.ts` as originally written spawned `resources/cli/wmux.js`, on the stated grounds that it is "the file a released wmux actually runs" — which is the belief above, and it is wrong. It now spawns `dist/cli/wmux.js` and compiles it in `beforeAll` (~3s; `dist/` is gitignored and `npm test` runs ahead of `npm run build:main`). Building unconditionally is what makes the spawned CLI the working tree's rather than a leftover.

I have deliberately **not** regenerated the artifact here. Doing so would put 1519 lines of unrelated catch-up into a three-file fix and bury the actual change. Same class of bug as the shell-integration drift in PR 2 — happy to send a fourth PR that regenerates both `resources/cli/*.js`, or a CI check that `resources/` matches a fresh build, whichever you prefer. Tell me which and I will open it.

## Verification

- `npm run typecheck` clean (both tsconfigs).
- Full suite on this branch: **6 failed, 993 passed, 2 skipped**. Same suite on a detached `master` worktree with the same `node_modules`: **6 failed, 988 passed, 2 skipped**. The failing set is identical one-for-one — the Windows-path and live-Win32-probe cases (`shell-context-menu` ×3, `pty-ledger` ×2, `pty-manager > resolveSpawnCwd`). This PR adds 5 passing tests and takes nothing green to red.
- Linux only. `bashPathCandidates()` still has a Windows branch a Linux run cannot exercise, and `wmux config path` / `wmux locales path` want a check from a native Windows shell — that half is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)