### PR TITLE
feat(devcontainer): drive wmux from a container over the TCP bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,8 @@ rm -rf ../wmux-release-staging/resources/themes && cp -r resources/themes ../wmu
 rm -rf ../wmux-release-staging/resources/sounds && cp -r resources/sounds ../wmux-release-staging/resources/sounds
 mkdir -p ../wmux-release-staging/resources/cli && cp dist/cli/wmux.js ../wmux-release-staging/resources/cli/wmux.js
 cp dist/cli/wmux-hook.js ../wmux-release-staging/resources/cli/wmux-hook.js   # Claude hooks exec this via bare node — MUST ship outside the asar (missing until 0.29.1 → sidebar stuck on "Running", issue #81)
+cp dist/cli/transport-deadline.js ../wmux-release-staging/resources/cli/transport-deadline.js   # required by BOTH files above; omitting it is MODULE_NOT_FOUND on the first line, not a degraded feature
+cp dist/cli/wsl-network.js ../wmux-release-staging/resources/cli/wsl-network.js                 # required by wmux.js (bridge bind selection)
 rm -rf ../wmux-release-staging/resources/shell-integration && mkdir -p ../wmux-release-staging/resources/shell-integration
 cp -r src/shell-integration/* ../wmux-release-staging/resources/shell-integration/
 rm -rf ../wmux-release-staging/resources/wmux-orchestrator && cp -r resources/wmux-orchestrator ../wmux-release-staging/resources/wmux-orchestrator
@@ -296,6 +298,7 @@ rm -rf .asar-staging build-out /tmp/asar-verify ../wmux-release-staging
 - [ ] wmux-orchestrator plugin copied to release staging
 - [ ] cli-bin + cli-bin-ps copied to release staging (issue #154)
 - [ ] opencode-plugin copied to release staging (issue #149) — `npm test` now derives this from `process.resourcesPath` usage in `src/main/`, so a new runtime resource that isn't in `extraResources` fails the release build
+- [ ] `resources/cli/` holds all four files — `wmux.js`, `wmux-hook.js`, `transport-deadline.js`, `wsl-network.js`. The CLI is packaged file-by-file, so a shared module has to be listed on its own; `npm test` derives this from the relative imports in `src/cli/`
 - [ ] rcedit applied (icon + version metadata) — `{ rcedit }` destructured
 - [ ] `latest.yml` generated (sha512 + size of the final zip) and uploaded as a release asset — electron-updater 404s without it (issue #68)
 - [ ] Zip created and uploaded to GitHub release

--- a/README.md
+++ b/README.md
@@ -326,6 +326,12 @@ wmux --remote 127.0.0.1:9787 --token <TOKEN> list-workspaces
 wmux --remote 127.0.0.1:9787 --token <TOKEN> new-workspace --title "api"
 # Or set once: WMUX_REMOTE=127.0.0.1:9787 and WMUX_REMOTE_TOKEN=<TOKEN>
 
+# From a devcontainer — same transport, no SSH tunnel. Run the bridge in WSL2
+# (--wsl binds 0.0.0.0 there, reachable from the container, not from the LAN):
+wmux bridge --wsl                  # relays to \\.\pipe\wmux via npiperelay.exe
+# Then in the container: WMUX_REMOTE=host.docker.internal:9787 + WMUX_REMOTE_TOKEN
+# Full setup: docs/DEVCONTAINER.md
+
 # Agents
 wmux agent spawn --cmd "claude --resume abc" --label "Research"
 wmux agent spawn-batch --json '[{"cmd":"claude","label":"Agent 1"},{"cmd":"claude","label":"Agent 2"}]'
@@ -345,9 +351,14 @@ Connect to `\\.\pipe\wmux` for programmatic control. Two protocols supported:
 report_pwd <surface_id> <path>
 report_git_branch <surface_id> <branch> [dirty]
 report_shell_state <surface_id> idle|running|interrupted
+report_startup_command <surface_id> <command>   # how to restore this surface; must be cwd-independent
 notify <surface_id> <text>
 ping
 ```
+
+`wmux raw-v1 "<line>"` sends any of these through the CLI's transport, which is
+what lets a shell with no reachable pipe — inside a devcontainer — still report.
+See [docs/DEVCONTAINER.md](docs/DEVCONTAINER.md).
 
 **V2** (JSON-RPC, used by CLI and automation):
 ```json

--- a/docs/DEVCONTAINER.md
+++ b/docs/DEVCONTAINER.md
@@ -29,10 +29,17 @@ line (V1) protocol it would speak to a local pipe; only the socket underneath
 changes. Auth is unchanged end to end — every request still carries the wmux
 instance's pipe token, which `wmux bridge` forwards without inspecting.
 
-The bridge deliberately runs **inside WSL2**, not on Windows. From there,
-`0.0.0.0` is the WSL2 network namespace, which the container reaches through
-the Docker host gateway and the LAN does not. A Windows-side bind would expose
-the pipe to the corporate network and need a firewall rule; this needs neither.
+The bridge deliberately runs **inside WSL2**, not on Windows. Under WSL2's
+default **NAT** networking, `0.0.0.0` there is the distro's own network
+namespace, which the container reaches through the Docker host gateway and the
+LAN does not. A Windows-side bind would expose the pipe to the corporate network
+and need a firewall rule; this needs neither.
+
+That holds for NAT and not for **mirrored** networking, where the distro shares
+the Windows host's interfaces rather than having a namespace of its own — see
+[Mirrored networking](#mirrored-networking) below. `wmux bridge --wsl` reads the
+mode with `wslinfo --networking-mode` and only picks `0.0.0.0` once it has
+confirmed NAT.
 
 The WSL2 → Windows hop is [npiperelay.exe](https://github.com/albertony/npiperelay),
 a ~2 MB MIT-licensed binary that forwards a named pipe to its own stdin/stdout.
@@ -65,13 +72,48 @@ running on Windows. It stays in the foreground:
 wmux bridge --wsl --port 9787
 ```
 
-`--wsl` binds `0.0.0.0` instead of `127.0.0.1`. If `wmux` is not on your
-`PATH` inside WSL2, invoke the shipped CLI directly — any wmux pane exports
-`WMUX_CLI` for exactly this:
+`--wsl` binds `0.0.0.0` instead of `127.0.0.1`, after checking that this really
+is a WSL distro and that it runs NAT networking. If it refuses, read
+[Mirrored networking](#mirrored-networking). If `wmux` is not on your `PATH`
+inside WSL2, invoke the shipped CLI directly — any wmux pane exports `WMUX_CLI`
+for exactly this:
 
 ```bash
 node "$WMUX_CLI" bridge --wsl --port 9787
 ```
+
+#### Mirrored networking
+
+WSL 2.0+ on Windows 11 can run `networkingMode=mirrored` in `.wslconfig`. A
+mirrored distro has **no network namespace of its own** — it shares the Windows
+host's interfaces, including the physical LAN adapter and any VPN adapter. So
+`0.0.0.0` inside it is not the private 172.x this guide describes; it is the
+corporate network. Inbound traffic is filtered by the **Hyper-V firewall**
+rather than the ordinary Windows Firewall profile, and the widely-copied "make
+WSL reachable" recipe turns that filter off:
+
+```powershell
+Set-NetFirewallHyperVVMSetting -Name '{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}' -DefaultInboundAction Allow
+```
+
+Mirrored mode **plus** that setting puts wmux's control pipe on the LAN. The
+pipe token still authenticates every request, so this is exposure rather than an
+open door — but it is not a default anything should pick for you, so `--wsl`
+refuses under mirrored mode and tells you to name an address:
+
+```bash
+wmux bridge --host <addr-the-container-reaches> --port 9787
+```
+
+`--host 0.0.0.0` is still honoured — with the warning upgraded to say the bind
+is on the host's real interfaces. Check which mode you are in with:
+
+```bash
+wslinfo --networking-mode      # nat | mirrored; needs WSL 2.0.5+
+```
+
+On WSL too old to answer, `--wsl` also refuses rather than assuming NAT, and
+`--host` is required.
 
 ### 3. Read the instance token
 
@@ -241,10 +283,14 @@ workspace path instead.
 
 ## Security
 
-- The bridge binds inside the WSL2 network namespace. It is reachable from
-  containers on that host and not from the LAN, and it needs no Windows
-  firewall rule. `--host` overrides this; the CLI warns when you do, because a
-  Windows-side bind really does expose the pipe to the network.
+- Under NAT networking the bridge binds inside the WSL2 network namespace: it is
+  reachable from containers on that host and not from the LAN, and it needs no
+  Windows firewall rule. **Under mirrored networking none of that is true** — the
+  distro shares the Windows host's adapters, so `0.0.0.0` is the LAN and any VPN,
+  gated only by the Hyper-V firewall's inbound policy. `wmux bridge --wsl` reads
+  the mode and refuses to choose `0.0.0.0` unless it is NAT; see
+  [Mirrored networking](#mirrored-networking). `--host` overrides the choice
+  either way, and the CLI warns when the address is beyond loopback.
 - The bridge authenticates nothing and parses nothing — it copies bytes. wmux's
   own pipe server verifies the per-instance token on every request, V1
   (`auth <token> …`) and V2 (`token` field) alike, so the bridge grants no

--- a/docs/DEVCONTAINER.md
+++ b/docs/DEVCONTAINER.md
@@ -1,0 +1,256 @@
+# Driving wmux from a devcontainer
+
+wmux runs on Windows, but a Claude Code session often does not: it runs in a
+Linux devcontainer on top of WSL2 + Docker. Nothing in that container can open
+`\\.\pipe\wmux`, so the `wmux` CLI, the Claude Code hooks and the shell
+integration all fail silently — panes show no cwd or git branch, the sidebar
+never leaves "Running", and `wmux agent spawn` cannot reach the app at all.
+
+This guide sets up a path from the container to that pipe. It needs no Bosch
+feature, no vendor tooling and no code you have to write: one binary, one
+long-running command, and two environment variables.
+
+## How it fits together
+
+```
+  Devcontainer (Linux)                WSL2 distro                     Windows
+ ┌──────────────────────┐   TCP    ┌────────────────────┐  interop  ┌─────────┐
+ │ claude               │ ───────► │ wmux bridge --wsl  │ ────────► │ wmux    │
+ │  wmux CLI            │  :9787   │  listens 0.0.0.0   │           │         │
+ │  wmux-hook.js        │          │  npiperelay.exe ×N │ ═════════ │ \\.\pipe│
+ │  bash integration    │ ◄─────── │  (warm pool)       │ ◄──────── │  \wmux  │
+ └──────────────────────┘          └────────────────────┘           └─────────┘
+   WMUX_REMOTE=                      wmux bridge is a byte relay:
+   host.docker.internal:9787         no parsing, no auth of its own
+```
+
+Three hops, one protocol. The container speaks the same JSON-RPC (V2) and
+line (V1) protocol it would speak to a local pipe; only the socket underneath
+changes. Auth is unchanged end to end — every request still carries the wmux
+instance's pipe token, which `wmux bridge` forwards without inspecting.
+
+The bridge deliberately runs **inside WSL2**, not on Windows. From there,
+`0.0.0.0` is the WSL2 network namespace, which the container reaches through
+the Docker host gateway and the LAN does not. A Windows-side bind would expose
+the pipe to the corporate network and need a firewall rule; this needs neither.
+
+The WSL2 → Windows hop is [npiperelay.exe](https://github.com/albertony/npiperelay),
+a ~2 MB MIT-licensed binary that forwards a named pipe to its own stdin/stdout.
+WSL2 runs Windows executables via interop, so the bridge spawns it and treats
+its stdio as the socket. AF_VSOCK, a TCP listener on the Windows side and
+cross-boundary Unix sockets were all tried first: HCS-managed WSL2 VMs ignore
+`GuestCommunicationServices`, gateway IPs and firewall policy are unreliable on
+managed networks, and 9P does not forward `AF_UNIX`.
+
+## Setup
+
+### 1. Install npiperelay in the WSL2 distro
+
+Once per distro. The download is SHA-256 pinned against the release's own
+checksums file, and re-running is a no-op:
+
+```bash
+bash scripts/install-npiperelay.sh     # → ~/.local/bin/npiperelay.exe
+```
+
+The CLI also finds it on `PATH`, in `/usr/local/bin` or in `/usr/bin`, if you
+prefer to install it yourself.
+
+### 2. Start the bridge in WSL2
+
+Run this in the WSL2 distro that hosts your Docker daemon, with wmux already
+running on Windows. It stays in the foreground:
+
+```bash
+wmux bridge --wsl --port 9787
+```
+
+`--wsl` binds `0.0.0.0` instead of `127.0.0.1`. If `wmux` is not on your
+`PATH` inside WSL2, invoke the shipped CLI directly — any wmux pane exports
+`WMUX_CLI` for exactly this:
+
+```bash
+node "$WMUX_CLI" bridge --wsl --port 9787
+```
+
+### 3. Read the instance token
+
+On Windows, or in any WSL2 shell that can reach the pipe:
+
+```bash
+wmux token
+```
+
+This is the running instance's pipe token. It changes when wmux restarts.
+
+### 4. Point the container at the bridge
+
+Two variables. Add them to your `devcontainer.json`:
+
+```jsonc
+{
+  "containerEnv": {
+    "WMUX_REMOTE": "host.docker.internal:9787",
+    "WMUX_REMOTE_TOKEN": "${localEnv:WMUX_REMOTE_TOKEN}"
+  },
+  // Docker Desktop resolves host.docker.internal already; plain Docker on
+  // Linux/WSL2 does not, so map it to the gateway explicitly.
+  "runArgs": ["--add-host=host.docker.internal:host-gateway"]
+}
+```
+
+Export `WMUX_REMOTE_TOKEN` on the host before launching, so the token is not
+committed to the repo. The equivalent for a hand-rolled `docker run`:
+
+```bash
+docker run --add-host=host.docker.internal:host-gateway \
+  -e WMUX_REMOTE=host.docker.internal:9787 \
+  -e WMUX_REMOTE_TOKEN="$(wmux token)" \
+  …
+```
+
+### 5. Get the CLI and the plugin into the container
+
+Outside a container wmux installs both for you. Inside one it cannot: wmux is
+not running there, so `ensureOrchestratorPlugin()` never executes. This is the
+one step the native case gets for free.
+
+Mount them read-only from the wmux install directory (`resources/` next to
+`wmux.exe`, or the repo checkout):
+
+```jsonc
+"mounts": [
+  "source=${localEnv:WMUX_RESOURCES}/cli,target=/opt/wmux/cli,type=bind,readonly",
+  "source=${localEnv:WMUX_RESOURCES}/wmux-orchestrator,target=/home/vscode/.claude/plugins/wmux-orchestrator,type=bind,readonly"
+],
+"containerEnv": {
+  "WMUX_CLI": "/opt/wmux/cli/wmux.js"
+}
+```
+
+Then give the container a `wmux` command and let the shell integration report
+to it, in the image or in `postCreateCommand`:
+
+```bash
+printf 'wmux() { node "$WMUX_CLI" "$@"; }\nexport -f wmux\n' >> ~/.bashrc
+```
+
+Copying instead of mounting works equally well and survives the host path
+moving; mounting keeps the container in step when wmux updates.
+
+### 6. Verify
+
+```bash
+wmux ping           # → pong
+wmux list-workspaces
+```
+
+`pong` means all three hops are up. A hang or `ECONNREFUSED` means the bridge
+is not listening or `host.docker.internal` does not resolve; `unauthorized`
+means the token is stale — wmux was restarted, so re-read `wmux token`.
+
+## What now works
+
+Everything routes through the same transport, with no per-tool configuration:
+
+| In the container | Reaches wmux via |
+|---|---|
+| `wmux <any command>` | the CLI's `--remote` / `WMUX_REMOTE` support (issue #78) |
+| `wmux-hook.js` (Claude Code hooks) | its own TCP branch on `WMUX_REMOTE` — this is what unsticks the sidebar |
+| `wmux-bash-integration.sh` | `wmux raw-v1 <line>`, instead of the WSL temp-file drop it cannot write to |
+| wmux-orchestrator | the `wmux` shim above; the plugin itself is unaware of any of this |
+
+With `WMUX_REMOTE` unset, every one of these falls back to the local named
+pipe exactly as before. The transport is additive.
+
+## Latency and the warm relay pool
+
+Spawning `npiperelay.exe` is not free. On a corporate-managed host where AV/EDR
+scans the binary on every exec, spawn + pipe attach measures up to ~7 seconds —
+and a hook fires on every tool call, in every pane.
+
+So `wmux bridge` keeps relays spawned and attached ahead of demand. A client
+arriving gets one that is already live, and the bridge immediately starts
+another to replace it. Tune with:
+
+| Variable | Default | Effect |
+|---|---|---|
+| `WMUX_BRIDGE_WARM` | `2` | Relays kept warm. `0` restores spawn-per-connection. |
+| `WMUX_BRIDGE_DRAIN_MS` | `15000` | How long a relay may keep draining after its client hangs up. |
+| `WMUX_RPC_TIMEOUT_MS` | `30000` | CLI deadline floor on a remote/npiperelay transport. |
+
+The pool is deliberately N exclusive relays rather than one multiplexed relay:
+multiplexing would force the bridge to parse frames and rewrite JSON-RPC ids,
+which V1 lines (`pong`, `ok`, `unauthorized`) carry no id to be rewritten by —
+and would make every client a casualty of one relay dying.
+
+The 30-second floor exists because the CLI's normal 5-second deadline sits
+*below* that 7-second worst case: without it, a container reported `timed out`
+for calls that had already succeeded.
+
+## Session restore: `report_startup_command`
+
+A restored pane is a fresh WSL shell on the Windows host. It has no idea it
+used to be inside a container, so by default it comes back as a plain WSL
+prompt and the container session is gone.
+
+`report_startup_command` is how a shell says how to bring itself back. Report
+it once, from inside the container, and wmux stores it on that surface and
+replays it into the pane it restores:
+
+```bash
+_wmux_report "report_startup_command ${WMUX_SURFACE_ID} cd '/home/me/project' && ./relaunch.sh"
+```
+
+Or from anywhere with a CLI:
+
+```bash
+wmux raw-v1 "report_startup_command $WMUX_SURFACE_ID cd '/home/me/project' && ./relaunch.sh"
+```
+
+It is stored per surface, so two containers sharing one pane restore to two
+different containers. Sending it with no command clears it.
+
+> **The command must be cwd-independent.** This is a hard requirement, not a
+> precaution.
+
+wmux replays the command into a freshly spawned login shell, and makes no
+promise about where that shell starts. `wsl.exe --cd <dir>` is applied *before*
+the shell reads its rc files, so a distro whose `/etc/profile` or `~/.profile`
+ends in `$HOME` — common on managed images — silently discards it:
+
+```console
+$ wsl --cd /tmp -- pwd     # non-interactive → /tmp   (--cd holds)
+$ wsl --cd /tmp            # interactive login → ~    (the rc wins)
+```
+
+A relative `./relaunch.sh` therefore dies with "No such file or directory" and
+the container is never re-entered. Lead with an absolute `cd`, as above.
+
+Two details that bite:
+
+- **Expand the path where you send the report**, not where it runs. The stored
+  string must hold a literal host-side path; a `$WORKSPACE` in it would be
+  expanded by the restored shell, which has never heard of it.
+- **Single-quote the path.** It is replayed as a shell line, so an unquoted
+  space splits it and an unquoted `$` expands.
+
+The same asymmetry applies to `report_pwd`: `$(pwd)` inside a container is a
+container path that means nothing to Windows or WSL. Report the host-side
+workspace path instead.
+
+## Security
+
+- The bridge binds inside the WSL2 network namespace. It is reachable from
+  containers on that host and not from the LAN, and it needs no Windows
+  firewall rule. `--host` overrides this; the CLI warns when you do, because a
+  Windows-side bind really does expose the pipe to the network.
+- The bridge authenticates nothing and parses nothing — it copies bytes. wmux's
+  own pipe server verifies the per-instance token on every request, V1
+  (`auth <token> …`) and V2 (`token` field) alike, so the bridge grants no
+  access that the token does not already grant.
+- The token is per-instance and rotates on restart. Pass it through the
+  environment; do not commit it.
+- `npiperelay.exe` is fetched over HTTPS from a pinned release tag, and its
+  SHA-256 is checked against a checksums file whose own hash is pinned in the
+  install script.

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -50,6 +50,8 @@
     { "from": "src/shell-integration", "to": "shell-integration" },
     { "from": "dist/cli/wmux.js", "to": "cli/wmux.js" },
     { "from": "dist/cli/wmux-hook.js", "to": "cli/wmux-hook.js" },
+    { "from": "dist/cli/transport-deadline.js", "to": "cli/transport-deadline.js" },
+    { "from": "dist/cli/wsl-network.js", "to": "cli/wsl-network.js" },
     { "from": "src/cli-bin", "to": "cli-bin" },
     { "from": "src/cli-bin-ps", "to": "cli-bin-ps" },
     { "from": "resources/wmux-orchestrator", "to": "wmux-orchestrator" },

--- a/resources/cli/transport-deadline.js
+++ b/resources/cli/transport-deadline.js
@@ -1,0 +1,72 @@
+"use strict";
+/**
+ * How long a wmux client waits for the pipe, derived from the transport rather
+ * than written down per client.
+ *
+ * Two processes talk to wmux over the same socket: the CLI (`wmux.ts`) and the
+ * Claude Code hook helper (`wmux-hook.ts`). Both had their own copy of the same
+ * pair of numbers and their own idea of when to use which — the CLI derived it
+ * from `remoteTarget || usesNpiperelay()`, the hook hardcoded
+ * `remote ? 30000 : 5000`. Same intent, two spellings, and only one of them
+ * knew about npiperelay. A third client, or a change to either number, would
+ * have had to find both.
+ *
+ * So the transport describes itself and the deadline follows. Nothing here does
+ * I/O; the caller supplies what it already knows about its own connection.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SLOW_TRANSPORT_FLOOR_MS = exports.DEFAULT_V2_TIMEOUT_MS = void 0;
+exports.usesNpiperelay = usesNpiperelay;
+exports.isSlowTransport = isSlowTransport;
+exports.transportDeadline = transportDeadline;
+/**
+ * What a local named pipe on the same machine is worth waiting.
+ *
+ * Sized for a round-trip that is sub-millisecond, so the whole budget is the
+ * server's own thinking time. This deadline has to stay LARGER than whatever
+ * the main process spends serving the same request, or the client loses a race
+ * it should never have been in: a command that succeeds late is reported as a
+ * failure and the server's own diagnosis is discarded unread.
+ */
+exports.DEFAULT_V2_TIMEOUT_MS = 5000;
+/**
+ * A floor under every deadline, for transports slower than a local pipe.
+ *
+ * Neither transport added for issue #19 is a local pipe: TCP to a `wmux bridge`
+ * from inside a devcontainer, and npiperelay over WSL interop. Both measure ~7s
+ * worst case on a corporate-managed host — above the 5s default on their own,
+ * before wmux has done anything — so every request from a container reported a
+ * timeout for a call that had already succeeded.
+ *
+ * A floor rather than a replacement, so a browser verb keeps the longer budget
+ * it asked for and a local run keeps its original timings exactly.
+ */
+exports.SLOW_TRANSPORT_FLOOR_MS = 30000;
+/**
+ * Whether the local hop goes through npiperelay.exe over WSL interop.
+ *
+ * A Windows pipe path (`\\.\pipe\wmux`, not something rooted at `/`) reached
+ * from inside a WSL distro cannot be dialled directly — npiperelay is what
+ * bridges it, and spawning a Windows executable over interop is the slow part,
+ * especially where AV scans the binary on each exec.
+ */
+function usesNpiperelay(t) {
+    return !t.remote && !t.pipePath.startsWith('/') && Boolean(t.env.WSL_DISTRO_NAME || t.env.WSLENV);
+}
+/** Whether this transport needs the floor at all. */
+function isSlowTransport(t) {
+    return t.remote || usesNpiperelay(t);
+}
+/**
+ * `base`, raised to the slow-transport floor when the transport is a slow one.
+ *
+ * `WMUX_RPC_TIMEOUT_MS` overrides the floor for anyone whose link is slower
+ * still, and is itself a floor rather than a cap — it can only ever lengthen a
+ * deadline, so setting it can never cause the truncation this exists to avoid.
+ */
+function transportDeadline(base, t) {
+    const override = parseInt(t.env.WMUX_RPC_TIMEOUT_MS || '', 10);
+    if (Number.isFinite(override) && override > 0)
+        return Math.max(base, override);
+    return isSlowTransport(t) ? Math.max(base, exports.SLOW_TRANSPORT_FLOOR_MS) : base;
+}

--- a/resources/cli/wmux-hook.js
+++ b/resources/cli/wmux-hook.js
@@ -20,6 +20,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
  * WMUX_SURFACE_ID (set by wmux in each pane's shell) ties the event to its pane.
  */
 const net_1 = __importDefault(require("net"));
+const transport_deadline_1 = require("./transport-deadline");
 const argv = process.argv.slice(2);
 let tool = '';
 let event = '';
@@ -40,8 +41,31 @@ else {
  */
 const firedAt = Date.now();
 const pipePath = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
-const token = process.env.WMUX_PIPE_TOKEN || '';
 const surfaceId = process.env.WMUX_SURFACE_ID || '';
+/**
+ * TCP transport for a hook firing where the pipe does not exist (issue #19).
+ *
+ * Inside a devcontainer, Claude Code runs on Linux while wmux runs on the
+ * Windows host: `\\.\pipe\wmux` is unreachable, so every hook failed silently
+ * and the sidebar never left "Running". WMUX_REMOTE points at a `wmux bridge`
+ * (issue #78) instead — same JSON-RPC frame, same auth, different socket. The
+ * env-var form is deliberate: Claude Code owns this process's argv, so there is
+ * nowhere to put a --remote flag.
+ *
+ * The token is the REMOTE instance's, which is not this machine's: on the
+ * container side WMUX_PIPE_TOKEN is either absent or something else entirely.
+ */
+const remote = (() => {
+    const spec = process.env.WMUX_REMOTE?.trim();
+    if (!spec)
+        return null;
+    const idx = spec.lastIndexOf(':');
+    const port = idx === -1 ? NaN : parseInt(spec.slice(idx + 1), 10);
+    return Number.isFinite(port) && port > 0 && port <= 65535
+        ? { host: spec.slice(0, idx) || '127.0.0.1', port }
+        : { host: spec, port: 9787 };
+})();
+const token = (remote ? process.env.WMUX_REMOTE_TOKEN : process.env.WMUX_PIPE_TOKEN) || '';
 let stdinData = '';
 let sent = false;
 const MAX_STDIN = 64 * 1024; // 64KB cap
@@ -54,10 +78,20 @@ const MAX_STDIN = 64 * 1024; // 64KB cap
  * an absent, a responsive and a wedged (accepts, never answers) server, the
  * hook exits on its own in every case, because on Windows named pipes `end()`
  * tears the connection down rather than half-closing it. The wmux CLI has
- * always armed this same 5s timer before connecting (see sendV1/sendV2); the
- * hook helper was the one client without it, and matching costs nothing.
+ * always armed this same timer before connecting (see sendV1/sendV2); the hook
+ * helper was the one client without it, and matching costs nothing.
+ *
+ * Derived rather than written down. This used to be `remote ? 30000 : 5000` —
+ * the same intent as the CLI's `deadline()` in a second spelling that did not
+ * know about npiperelay, so the two could drift and only one would be found by
+ * anyone changing a number. Both now ask transport-deadline.ts, describing the
+ * same connection the same way.
  */
-const PIPE_DEADLINE_MS = 5000;
+const PIPE_DEADLINE_MS = (0, transport_deadline_1.transportDeadline)(transport_deadline_1.DEFAULT_V2_TIMEOUT_MS, {
+    remote: !!remote,
+    pipePath,
+    env: process.env,
+});
 /** Cleared once we stop reading, so the happy path is not held open by it. */
 let stdinTimer = null;
 function sendHook() {
@@ -105,7 +139,7 @@ function sendHook() {
         params.message = message;
     if (surfaceId)
         params.surfaceId = surfaceId;
-    const client = net_1.default.connect({ path: pipePath }, () => {
+    const client = net_1.default.connect(remote ? { host: remote.host, port: remote.port } : { path: pipePath }, () => {
         const msg = JSON.stringify({ method: 'hook.event', params, id: 1, token });
         client.write(msg + '\n', () => client.end());
         // Drain the reply we do not care about. This is not cosmetic: wmux answers

--- a/resources/cli/wmux.js
+++ b/resources/cli/wmux.js
@@ -4,13 +4,49 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.RAW_V1_VERBS = void 0;
 exports.timeoutMessage = timeoutMessage;
 exports.browserRequest = browserRequest;
 exports.subcommandError = subcommandError;
+exports.rawV1Error = rawV1Error;
 const net_1 = __importDefault(require("net"));
 const fs_1 = __importDefault(require("fs"));
 const os_1 = __importDefault(require("os"));
 const path_1 = __importDefault(require("path"));
+const child_process_1 = require("child_process");
+const stream_1 = require("stream");
+const wsl_network_1 = require("./wsl-network");
+const transport_deadline_1 = require("./transport-deadline");
+/** The two signals wsl-network.ts uses to decide we are inside a WSL distro. */
+function readWslEnvironment() {
+    let osRelease = null;
+    try {
+        osRelease = fs_1.default.readFileSync('/proc/sys/kernel/osrelease', 'utf-8');
+    }
+    catch {
+        // Not Linux, or a kernel that does not expose it — either way, not WSL.
+    }
+    return {
+        osRelease,
+        hasInteropEnv: !!(process.env.WSL_INTEROP || process.env.WSL_DISTRO_NAME),
+    };
+}
+/**
+ * `wslinfo --networking-mode`, or null if it cannot answer. Absent before WSL
+ * 2.0.5, so a null here is ordinary rather than exceptional; parseNetworkingMode
+ * turns it into `unknown` and the caller refuses to guess from there.
+ */
+function readWslNetworkingMode() {
+    try {
+        const probe = (0, child_process_1.spawnSync)('wslinfo', ['--networking-mode'], { encoding: 'utf-8', timeout: 5000 });
+        if (probe.error || probe.status !== 0)
+            return null;
+        return probe.stdout;
+    }
+    catch {
+        return null;
+    }
+}
 // Respect WMUX_PIPE when set (e.g. by a parent wmux running with WMUX_INSTANCE),
 // so the CLI talks to the same instance that spawned the shell.
 const PIPE_PATH = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
@@ -22,6 +58,25 @@ const PIPE_PATH = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
 // supplied via --token or WMUX_REMOTE_TOKEN (print it there with `wmux token`).
 const DEFAULT_BRIDGE_PORT = 9787;
 let remoteTarget = null;
+// How long `wmux bridge` lets a relay keep draining after its client socket has
+// closed, before forcing teardown. Must exceed the pipe round-trip, or the frame
+// a write-then-close client just sent is discarded mid-flight. Measured worst
+// case inside a devcontainer on a corporate-managed Windows host is ~7s (a fresh
+// npiperelay.exe is spawned per connection over WSL interop, and AV/EDR scans it
+// on every exec), so the default leaves generous headroom. The relay normally
+// exits on its own well before this — the timer is only the backstop.
+const BRIDGE_DRAIN_GRACE_MS = parseInt(process.env.WMUX_BRIDGE_DRAIN_MS || '', 10) || 15000;
+// How many npiperelay relays `wmux bridge` keeps spawned and attached to the pipe
+// ahead of demand (see the pool in cmdBridge). 0 disables pre-warming and restores
+// spawn-per-connection. Only ever used on the npiperelay path — the Unix-socket and
+// native-pipe transports connect instantly and have nothing to pre-warm.
+const BRIDGE_WARM_RELAYS = (() => {
+    const raw = process.env.WMUX_BRIDGE_WARM?.trim();
+    if (!raw)
+        return 2;
+    const n = parseInt(raw, 10);
+    return Number.isFinite(n) && n >= 0 ? n : 2;
+})();
 function parseRemoteTarget(spec) {
     const idx = spec.lastIndexOf(':');
     if (idx === -1)
@@ -33,10 +88,130 @@ function parseRemoteTarget(spec) {
     }
     return { host: spec.slice(0, idx) || '127.0.0.1', port };
 }
+// ─── WSL2 transport: reach the Windows \\.\pipe\wmux from inside WSL2 ─────────
+//
+// A wmux CLI (or `wmux bridge`) running inside WSL2 needs to talk to the wmux
+// process on the Windows host over the \\.\pipe\wmux named pipe. AF_VSOCK,
+// TCP-over-gateway and cross-boundary Unix sockets were all evaluated and
+// rejected (HCS-managed WSL2 UVMs ignore GuestCommunicationServices; gateway
+// IPs/firewall policy are unreliable on corporate networks; 9P does not forward
+// AF_UNIX). The chosen mechanism is npiperelay.exe:
+//
+//   npiperelay.exe is a tiny (~2MB) open-source Windows binary that forwards a
+//   named pipe to its own stdin/stdout. WSL2 executes Windows binaries via
+//   interop, so from inside WSL2 we spawn it and use its stdio as the transport
+//   duplex — zero pre-setup, no socat needed. Install it (SHA-256 pinned) with
+//   scripts/install-npiperelay.sh; see docs/DEVCONTAINER.md for the full setup.
+//   Source: https://github.com/albertony/npiperelay (MIT, fork of jstarks/npiperelay)
+//   Pinned version: v1.11.4  SHA-256: cea82cf5c9c22a28bef8075750acb7958f766393baebff4597cf21442f71c4b3
+//
+//   Transport selection order:
+//     0. remoteTarget set (--remote / WMUX_REMOTE) → TCP (the devcontainer path,
+//        served by a `wmux bridge` reachable at host.docker.internal:9787)
+//     1. WMUX_PIPE starts with '/' → use as a Unix socket path
+//     2. WSL_DISTRO_NAME / WSLENV set → spawn npiperelay.exe automatically
+//     3. native Windows → connect directly to the named pipe
+// ─────────────────────────────────────────────────────────────────────────────
 function connectTransport(onConnect) {
-    return remoteTarget
-        ? net_1.default.connect({ host: remoteTarget.host, port: remoteTarget.port }, onConnect)
-        : net_1.default.connect({ path: PIPE_PATH }, onConnect);
+    if (remoteTarget)
+        return net_1.default.connect({ host: remoteTarget.host, port: remoteTarget.port }, onConnect);
+    if (PIPE_PATH.startsWith('/'))
+        return net_1.default.connect({ path: PIPE_PATH }, onConnect);
+    if (process.env.WSL_DISTRO_NAME || process.env.WSLENV)
+        return connectViaNpiperelay(PIPE_PATH, onConnect);
+    return net_1.default.connect({ path: PIPE_PATH }, onConnect);
+}
+// Mirrors the selection order above: true when connectTransport() will take the
+// npiperelay branch. That is the only transport whose setup costs anything worth
+// pre-warming — a Unix socket or a native named pipe connects in microseconds.
+/**
+ * This process's transport, as transport-deadline.ts wants it described.
+ *
+ * A function rather than a constant: `remoteTarget` is set while parsing argv,
+ * after module load.
+ */
+function currentTransport() {
+    return { remote: !!remoteTarget, pipePath: PIPE_PATH, env: process.env };
+}
+function usesNpiperelay() {
+    return (0, transport_deadline_1.usesNpiperelay)(currentTransport());
+}
+// Search common installation locations for npiperelay.exe.
+function findNpiperelay() {
+    const readable = (p) => {
+        try {
+            fs_1.default.accessSync(p);
+            return true;
+        }
+        catch {
+            return false;
+        }
+    };
+    const binPaths = (process.env.PATH || process.env.Path || '')
+        .split(path_1.default.delimiter)
+        .filter(Boolean)
+        .map((d) => path_1.default.join(d, 'npiperelay.exe'));
+    const fromPath = binPaths.find(readable);
+    if (fromPath)
+        return fromPath;
+    return ([
+        path_1.default.join(os_1.default.homedir(), '.local', 'bin', 'npiperelay.exe'),
+        '/usr/local/bin/npiperelay.exe',
+        '/usr/bin/npiperelay.exe',
+    ].find(readable) ?? null);
+}
+// Spawn npiperelay.exe and expose its stdin/stdout as a Duplex stream.
+function connectViaNpiperelay(pipePath, onConnect) {
+    const bin = findNpiperelay();
+    if (!bin) {
+        console.error('wmux: npiperelay.exe not found.');
+        console.error('  Install it with scripts/install-npiperelay.sh, or fetch it from:');
+        console.error('  https://github.com/albertony/npiperelay/releases/latest');
+        process.exit(1);
+    }
+    // npiperelay names the pipe with forward slashes: \\.\pipe\wmux → //./pipe/wmux
+    const child = (0, child_process_1.spawn)(bin, ['-ei', '-s', pipePath.replace(/\\/g, '/')], {
+        stdio: ['pipe', 'pipe', 'inherit'],
+    });
+    const duplex = new stream_1.Duplex({
+        read() { },
+        write(chunk, enc, cb) {
+            if (!child.stdin?.writable) {
+                cb(new Error('npiperelay stdin closed'));
+                return;
+            }
+            child.stdin.write(chunk, enc, cb);
+        },
+        final(cb) {
+            child.stdin?.end();
+            cb();
+        },
+        // Kills the relay, discarding anything still buffered in its stdin. Callers
+        // must only reach here on error or after the stream has drained — see the
+        // teardown in cmdBridge.
+        destroy(err, cb) {
+            child.kill();
+            cb(err);
+        },
+        allowHalfOpen: true,
+    });
+    child.stdout?.on('data', (chunk) => duplex.push(chunk));
+    child.stdout?.on('end', () => duplex.push(null));
+    child.on('error', (err) => duplex.destroy(err));
+    child.on('exit', (code) => {
+        if (code !== 0 && code !== null)
+            duplex.destroy(new Error(`npiperelay exited with code ${code}`));
+    });
+    // "Ready" here means the relay process exists — NOT that it has attached to the
+    // named pipe, which over WSL interop can take seconds longer. onConnect must
+    // still fire now regardless: callers write their request from inside it, and the
+    // Duplex buffers those bytes until the pipe is live. (Deferring it until the
+    // first byte comes back would deadlock — nothing would ever be written.)
+    //
+    // The cost is that a caller's deadline starts before the pipe is up, so it has
+    // to cover the attach latency too — that is what SLOW_TRANSPORT_FLOOR_MS is for.
+    process.nextTick(onConnect);
+    return duplex;
 }
 // Auth token for privileged (V2) pipe requests. wmux injects WMUX_PIPE_TOKEN
 // into the shells it spawns; for CLIs launched elsewhere, fall back to the
@@ -65,7 +240,7 @@ function sendV1(command) {
             client.write(line + '\n');
         });
         let data = '';
-        const timer = setTimeout(() => { client.end(); resolve(data.trim()); }, 5000);
+        const timer = setTimeout(() => { client.end(); resolve(data.trim()); }, deadline(5000));
         const finish = () => { clearTimeout(timer); resolve(data.trim()); };
         client.on('data', (chunk) => {
             data += chunk.toString();
@@ -82,16 +257,15 @@ function sendV1(command) {
     });
 }
 /**
- * How long to wait for a V2 reply before giving up.
- *
- * This deadline has to stay LARGER than whatever budget the main process spends
- * serving the same request. When it is shorter the CLI loses a race it should
- * never have been in: a command that succeeds late is reported as a failure, and
- * the server's own diagnosis ('Could not open browser panel', 'browser_not_open',
- * 'ref_not_found: …') is discarded unread because it arrives after we hung up.
- * Only the browser verbs currently need more than this — see BROWSER_CMDS.
+ * How long to wait for a V2 reply before giving up. Only the browser verbs
+ * currently need more than this — see BROWSER_CMDS. The reasoning behind the
+ * number, and behind the floor that raises it on a slow transport, lives with
+ * it in transport-deadline.ts.
  */
-const DEFAULT_V2_TIMEOUT_MS = 5000;
+/** `base`, raised to the slow-transport floor when the transport is a slow one. */
+function deadline(base) {
+    return (0, transport_deadline_1.transportDeadline)(base, currentTransport());
+}
 /**
  * What a stalled request says when it gives up.
  *
@@ -103,7 +277,7 @@ const DEFAULT_V2_TIMEOUT_MS = 5000;
 function timeoutMessage(method, timeoutMs) {
     return `${method} timed out after ${timeoutMs}ms — wmux accepted the request but sent no reply. The command may still have completed.`;
 }
-function sendV2(method, params = {}, timeoutMs = DEFAULT_V2_TIMEOUT_MS) {
+function sendV2(method, params = {}, timeoutMs = transport_deadline_1.DEFAULT_V2_TIMEOUT_MS) {
     // Every command carries the caller's surface (WMUX_SURFACE_ID). Browser
     // commands use it to route each agent to its OWN browser pane, so concurrent
     // agents no longer share and clobber one browser window (issue #62); the
@@ -118,10 +292,11 @@ function sendV2(method, params = {}, timeoutMs = DEFAULT_V2_TIMEOUT_MS) {
             client.write(request + '\n');
         });
         let data = '';
+        const deadlineMs = deadline(timeoutMs);
         const timer = setTimeout(() => {
             client.end();
-            reject(new Error(timeoutMessage(method, timeoutMs)));
-        }, timeoutMs);
+            reject(new Error(timeoutMessage(method, deadlineMs)));
+        }, deadlineMs);
         client.on('data', (chunk) => {
             data += chunk.toString();
             if (data.includes('\n')) {
@@ -525,27 +700,175 @@ async function cmdSsh(args) {
 // wmux's pipe server, so the bridge grants nothing by itself.
 async function cmdBridge(args) {
     const port = parseInt(getFlag(args, '--port') || '', 10) || DEFAULT_BRIDGE_PORT;
-    const host = getFlag(args, '--host') || '127.0.0.1';
-    if (host !== '127.0.0.1' && host !== 'localhost') {
-        console.warn('WARNING: binding beyond localhost exposes the wmux pipe to the network.');
-        console.warn(`Prefer the default 127.0.0.1 + an SSH tunnel: ssh -L ${port}:127.0.0.1:${port} user@host`);
+    // --wsl binds 0.0.0.0 so a container on the Windows host can reach a bridge
+    // running inside WSL2 (issue #19). Under NAT — WSL2's default — the distro has
+    // its own network namespace, so that address is an eth0 on a private 172.x the
+    // container resolves as host.docker.internal, and 127.0.0.1 inside the distro
+    // is not it. Under mirrored networking the distro shares the Windows host's
+    // interfaces instead and 0.0.0.0 is the LAN, so the mode is read at runtime
+    // rather than assumed; see wsl-network.ts for the full reasoning. The pipe
+    // token authenticates every request end to end either way.
+    const wslMode = args.includes('--wsl');
+    const wslEnv = readWslEnvironment();
+    const inWsl2 = (0, wsl_network_1.isWsl2)(wslEnv);
+    const decision = (0, wsl_network_1.chooseBridgeHost)({
+        explicitHost: getFlag(args, '--host'),
+        wslMode,
+        inWsl2,
+        mode: inWsl2 ? (0, wsl_network_1.parseNetworkingMode)(readWslNetworkingMode()) : 'unknown',
+        port,
+    });
+    if (decision.host === null) {
+        console.error(`wmux bridge: ${decision.error}`);
+        process.exit(1);
     }
+    const host = decision.host;
+    for (const line of decision.notices)
+        console.warn(line);
+    // ── Warm relay pool ─────────────────────────────────────────────────────────
+    // Spawn-per-connection made every request pay the relay's whole startup: a fresh
+    // npiperelay.exe launched over WSL interop (AV/EDR scans the binary on each exec
+    // on a corporate-managed host) and then the pipe dial. Measured worst case from a
+    // devcontainer is ~7s — on every hook. Keeping relays open ahead of demand moves
+    // that cost off the request path: a warm relay has already spawned AND attached
+    // by the time a client arrives, so hand-off is just pipe().
+    //
+    // Deliberately a POOL of exclusive relays, not one shared relay multiplexed
+    // across clients. Multiplexing would force the bridge to parse frames and rewrite
+    // JSON-RPC ids to route replies back to the right socket, which:
+    //   * breaks V1 entirely — `pong` / `ok` / `unauthorized` carry no id to route on;
+    //   * makes every client a casualty when the single relay dies;
+    //   * costs the bridge its one real virtue, being a transparent byte pipe (any
+    //     future streaming or server-pushed method would have to be taught to it).
+    // Pooling buys the same latency win and the bridge stays dumb.
+    //
+    // Only on the npiperelay path — elsewhere this would hold idle sockets open to
+    // buy nothing.
+    const warmSize = usesNpiperelay() ? BRIDGE_WARM_RELAYS : 0;
+    const warm = [];
+    let warmFailures = 0;
+    let refillTimer = null;
+    const scheduleRefill = (delayMs) => {
+        if (refillTimer || warm.length >= warmSize)
+            return;
+        refillTimer = setTimeout(() => {
+            refillTimer = null;
+            fillWarm();
+        }, delayMs);
+        refillTimer.unref();
+    };
+    function fillWarm() {
+        while (warm.length < warmSize) {
+            const stream = connectTransport(() => { });
+            const entry = { stream, claim: () => { } };
+            // Dying before being claimed means the upstream isn't there — wmux not
+            // running, or the pipe gone. npiperelay exits immediately in that case, so
+            // without a backoff the bridge would respawn a Windows process in a tight
+            // loop for as long as wmux stays down.
+            const onDead = () => {
+                const i = warm.indexOf(entry);
+                if (i === -1)
+                    return; // already claimed — the client's teardown owns it now
+                warm.splice(i, 1);
+                warmFailures = Math.min(warmFailures + 1, 6);
+                scheduleRefill(Math.min(30000, 500 * 2 ** warmFailures));
+            };
+            entry.claim = () => {
+                stream.off('error', onDead);
+                stream.off('close', onDead);
+            };
+            stream.on('error', onDead);
+            stream.on('close', onDead);
+            warm.push(entry);
+        }
+    }
+    // An idle relay reads nothing, so anything the upstream sent while it waited stays
+    // buffered in the stream and is delivered the moment the client pipes it — no need
+    // to drain before hand-off.
+    const takeWarm = () => {
+        while (warm.length) {
+            const entry = warm.pop();
+            entry.claim();
+            // wmux may have restarted since this relay attached.
+            if (!entry.stream.destroyed && entry.stream.writable) {
+                warmFailures = 0;
+                return entry.stream;
+            }
+            entry.stream.destroy();
+        }
+        return null;
+    };
     const server = net_1.default.createServer((sock) => {
-        const pipe = net_1.default.connect({ path: PIPE_PATH });
+        // Connect to the local wmux through the same selector the CLI uses. In the
+        // bridge process remoteTarget is always null, so this resolves to a Unix
+        // socket, npiperelay (inside WSL2), or the named pipe directly — which is
+        // what lets `wmux bridge` run inside WSL2 and still reach the Windows pipe.
+        // A warm relay is the same thing, already connected.
+        const pipe = takeWarm() ?? connectTransport(() => { });
+        // Replace what we just consumed so the next client is served warm too.
+        scheduleRefill(0);
         sock.pipe(pipe);
         pipe.pipe(sock);
-        const drop = () => { sock.destroy(); pipe.destroy(); };
-        sock.on('error', drop);
-        pipe.on('error', drop);
-        sock.on('close', drop);
-        pipe.on('close', drop);
+        // Teardown is half-close-aware on purpose. Destroying BOTH sides on either
+        // 'close' silently ate hook events: wmux-hook.js writes its frame and end()s
+        // immediately, and over npiperelay the Duplex's destroy() is child.kill() —
+        // so the relay died with the frame still buffered in its stdin and never
+        // forwarded it. Clients that write-then-close are the normal case here
+        // (every Claude Code hook is one), not an abort.
+        //
+        // 'end' (peer finished sending) therefore FLUSHES rather than destroys: end()
+        // the other side so its buffered bytes drain and the pipe sees a clean EOF.
+        // destroy() is reserved for 'error', where there is nothing left to save.
+        let done = false;
+        const destroyBoth = () => {
+            if (done)
+                return;
+            done = true;
+            sock.destroy();
+            pipe.destroy();
+        };
+        // A closed socket can no longer drain anything, so 'close' still tears down —
+        // but only after a grace period, giving an in-flight relay time to finish
+        // forwarding what it already holds.
+        const closeAfterDrain = () => {
+            if (done)
+                return;
+            setTimeout(destroyBoth, BRIDGE_DRAIN_GRACE_MS).unref();
+        };
+        sock.on('error', destroyBoth);
+        pipe.on('error', destroyBoth);
+        sock.on('end', () => { pipe.end(); });
+        pipe.on('end', () => { sock.end(); });
+        sock.on('close', closeAfterDrain);
+        pipe.on('close', closeAfterDrain);
     });
     server.on('error', (err) => { console.error(`bridge error: ${err.message}`); process.exit(1); });
+    // Warm relays hold a live pipe connection (and an npiperelay.exe) for as long as
+    // the bridge runs, so retire them on the way out rather than orphaning them.
+    const shutdown = () => {
+        if (refillTimer)
+            clearTimeout(refillTimer);
+        warm.splice(0).forEach((e) => { e.claim(); e.stream.destroy(); });
+        process.exit(0);
+    };
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
     server.listen(port, host, () => {
         console.log(`wmux bridge listening on ${host}:${port} ↔ ${PIPE_PATH}`);
-        console.log('From another machine:');
-        console.log(`  ssh -L ${port}:127.0.0.1:${port} <user>@<this-host>`);
-        console.log(`  wmux --remote 127.0.0.1:${port} --token <run 'wmux token' here> list-workspaces`);
+        if (warmSize > 0) {
+            fillWarm();
+            console.log(`Keeping ${warmSize} npiperelay relay(s) warm (WMUX_BRIDGE_WARM=0 to disable).`);
+        }
+        if (wslMode) {
+            console.log('WSL2 mode. From a container on this host:');
+            console.log(`  WMUX_REMOTE=host.docker.internal:${port}`);
+            console.log("  WMUX_REMOTE_TOKEN=<run 'wmux token' here>");
+        }
+        else {
+            console.log('From another machine:');
+            console.log(`  ssh -L ${port}:127.0.0.1:${port} <user>@<this-host>`);
+            console.log(`  wmux --remote 127.0.0.1:${port} --token <run 'wmux token' here> list-workspaces`);
+        }
         console.log('Ctrl+C to stop.');
     });
 }
@@ -640,6 +963,46 @@ async function cmdAgentActivity(args) {
     if (args.includes('--active'))
         params.done = false;
     await sendV2('agent.activity', params);
+}
+/**
+ * V1 passthrough for the shell integration (issue #19: devcontainer support).
+ *
+ * wmux-bash-integration.sh writes its state lines straight to the local pipe
+ * when it can reach one. Inside a devcontainer it can't, so it calls
+ * `wmux raw-v1` instead and gets the CLI's transport — including TCP via
+ * --remote / WMUX_REMOTE to a `wmux bridge` (issue #78) — without the CLI
+ * growing a near-identical wrapper per verb. Auth is unchanged: sendV1 still
+ * prefixes `auth <token>`.
+ *
+ * Restricted to the verbs the integration actually emits. A generic passthrough
+ * would make this a permanent side door into V1: every future V1 command becomes
+ * reachable from a container the day it is added, with no review of whether that
+ * was intended, and the pipe's V1 surface stops being something the V1 handler
+ * alone defines. Nothing is lost by naming them — the set is short, and a real
+ * new caller wants a real CLI command anyway.
+ */
+exports.RAW_V1_VERBS = [
+    'report_pwd',
+    'report_git_branch',
+    'clear_git_branch',
+    'report_shell_state',
+    'ports_kick',
+    'report_startup_command',
+];
+function rawV1Error(verb) {
+    if (!verb)
+        return 'Usage: wmux raw-v1 <command> [surfaceId] [args...]';
+    if (exports.RAW_V1_VERBS.includes(verb))
+        return null;
+    return `raw-v1: ${verb} is not a passthrough command. Accepted: ${exports.RAW_V1_VERBS.join(', ')}`;
+}
+async function cmdRawV1(args) {
+    const problem = rawV1Error(args[1]);
+    if (problem) {
+        console.error(problem);
+        process.exit(1);
+    }
+    console.log(await sendV1(args.slice(1).join(' ')));
 }
 // ─── Declared agent state (issue #128) ───────────────────────────────────────
 // The reporting side of the protocol. An agent running inside a wmux pane can
@@ -767,8 +1130,12 @@ const COMMAND_SPECS = {
     'new-window': { usage: 'wmux new-window' },
     // Remote management (issue #78)
     bridge: {
-        usage: 'wmux bridge [--port P] [--host H]   (expose this wmux\'s pipe over TCP, default 127.0.0.1:9787)',
+        usage: [
+            'wmux bridge [--port P] [--host H] [--wsl]   (expose this wmux\'s pipe over TCP, default 127.0.0.1:9787)',
+            '  --wsl   bind 0.0.0.0 so a container on this host can reach a bridge running in WSL2',
+        ].join('\n'),
         value: ['--port', '--host'],
+        bool: ['--wsl'],
     },
     token: { usage: 'wmux token   (print this instance\'s pipe auth token)' },
     // Workspace
@@ -894,6 +1261,10 @@ const COMMAND_SPECS = {
         usage: `wmux agent-activity [--tool T] [--skill S] [--done|--active] [--surface <id>]   ${SURFACE_NOTE}`,
         value: ['--tool', '--skill', '--surface'],
         bool: ['--done', '--active'],
+    },
+    'raw-v1': {
+        usage: 'wmux raw-v1 <command> [surfaceId] [args...]   (send a raw V1 line; used by shell integration)',
+        passthrough: true,
     },
     // Declared agent state (issue #128)
     'report-agent': {
@@ -1116,6 +1487,8 @@ const COMMANDS = {
     },
     hook: cmdHook,
     'agent-activity': cmdAgentActivity,
+    // Devcontainer support (issue #19)
+    'raw-v1': cmdRawV1,
     ...AGENT_STATE_COMMANDS,
 };
 async function main() {
@@ -1168,7 +1541,7 @@ Usage: wmux <command> [options]
 System:     ping, identify, capabilities, list-windows, focus-window <id>, new-window
 Workspace:  new-workspace, close-workspace, select-workspace, rename-workspace, list-workspaces
 Remote:     ssh [ssh options] <user@host> [--title T]   (remote terminal in a new workspace)
-            bridge [--port P] [--host H]   (expose this wmux's pipe over TCP, default 127.0.0.1:9787)
+            bridge [--port P] [--host H] [--wsl]   (expose this wmux's pipe over TCP, default 127.0.0.1:9787)
             token                          (print this instance's auth token, for --token)
 Global:     --remote host[:port] --token <T>   (drive a REMOTE wmux through an SSH tunnel;
             env equivalents: WMUX_REMOTE, WMUX_REMOTE_TOKEN)

--- a/resources/cli/wsl-network.js
+++ b/resources/cli/wsl-network.js
@@ -1,0 +1,155 @@
+"use strict";
+/**
+ * Deciding what `wmux bridge` may bind to, and why, when it runs inside WSL2.
+ *
+ * `--wsl` exists so a container on the Windows host can reach a bridge running
+ * inside the distro (issue #19): `127.0.0.1` in the distro is not an address the
+ * container can dial, so the bridge has to listen on `0.0.0.0`. Whether that is
+ * a modest thing to do or a genuinely bad one depends entirely on which
+ * networking mode WSL2 is running, and the two differ more than the name
+ * suggests:
+ *
+ *   NAT (the default)  The distro gets its own network namespace behind a
+ *                      Hyper-V vSwitch. `0.0.0.0` there is the distro's loopback
+ *                      plus an `eth0` on a private 172.x — reachable from
+ *                      containers on the same host via the Docker host gateway,
+ *                      not reachable from the LAN, and no Windows firewall rule
+ *                      is involved either way.
+ *
+ *   Mirrored           `networkingMode=mirrored` in `.wslconfig` (WSL 2.0+ on
+ *                      Windows 11). The distro no longer has its own namespace —
+ *                      it SHARES the Windows host's interfaces, including the
+ *                      physical LAN adapter and any VPN adapter. `0.0.0.0` in
+ *                      that distro is a bind on the corporate network. Inbound
+ *                      traffic is filtered by the Hyper-V firewall rather than
+ *                      the ordinary Windows Firewall profile, and the
+ *                      widely-copied "make WSL reachable" recipe is
+ *                      `Set-NetFirewallHyperVVMSetting -Name
+ *                      '{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}'
+ *                      -DefaultInboundAction Allow`. Mirrored mode plus that
+ *                      setting puts wmux's control pipe on the LAN.
+ *
+ * The pipe token still authenticates every request in both cases, so mirrored
+ * mode is exposure rather than an open door. It is still not something to pick
+ * on the user's behalf from an inferred default, so the mode is read at runtime
+ * and `--wsl` refuses to choose `0.0.0.0` unless it has confirmed NAT. An
+ * explicit `--host 0.0.0.0` is always honoured — that is a stated choice.
+ *
+ * Everything here is pure so the decision can be tested off Windows entirely;
+ * `readWslEnvironment()` in wmux.ts does the I/O.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isWsl2 = isWsl2;
+exports.parseNetworkingMode = parseNetworkingMode;
+exports.chooseBridgeHost = chooseBridgeHost;
+/**
+ * Whether this process is inside a WSL distro at all.
+ *
+ * Both signals are required, because each is weak alone: the kernel string is
+ * whatever `/proc` says, which a container mounting its own `/proc` can differ
+ * on, and the env vars are inherited by anything a WSL shell launches —
+ * including a process that has since crossed into a container with its own
+ * network stack, which is precisely the case `--wsl` must not fire in.
+ *
+ * It does not separate WSL2 from WSL1, and does not need to: WSL1 predates
+ * `wslinfo` by years, so the mode comes back `unknown` there and the caller
+ * refuses to guess. WSL1 shares the Windows network stack outright, so the
+ * namespace argument `--wsl` rests on never applied to it anyway.
+ */
+function isWsl2(env) {
+    const release = (env.osRelease || '').toLowerCase();
+    const looksLikeWsl = release.includes('microsoft') || release.includes('wsl');
+    return looksLikeWsl && env.hasInteropEnv;
+}
+/**
+ * `wslinfo --networking-mode` prints one bare word. Anything else — the command
+ * missing (WSL older than 2.0.5), a non-zero exit, an unrecognised word — is
+ * `unknown`, which is treated as "not proven safe" rather than folded into the
+ * NAT default. Silently assuming the safe case is how an assumption stops being
+ * load-bearing and starts being a bug.
+ */
+function parseNetworkingMode(output) {
+    const word = (output || '').trim().toLowerCase();
+    if (word === 'nat')
+        return 'nat';
+    if (word === 'mirrored')
+        return 'mirrored';
+    return 'unknown';
+}
+const isLoopback = (host) => host === '127.0.0.1' || host === 'localhost' || host === '::1';
+/** How a bind beyond loopback is described, given what we know about the mode. */
+function exposureNotice(host, req) {
+    if (req.inWsl2 && req.mode === 'mirrored') {
+        return [
+            `WARNING: mirrored networking — ${host} here is the Windows host's real interfaces, including the LAN`,
+            "and any VPN adapter, because a mirrored distro shares them instead of having its own namespace.",
+            "What stands between this bind and the LAN is the Hyper-V firewall's inbound policy, not the ordinary",
+            'Windows Firewall profile. The pipe token still authenticates every request, so this is exposure',
+            'rather than an open door — but bind the specific address the container needs, not 0.0.0.0, if you can.',
+        ];
+    }
+    if (req.inWsl2 && req.mode === 'nat') {
+        return [
+            `NAT networking: ${host} is the WSL2 network namespace, not the LAN — an eth0 on a private 172.x plus`,
+            "this distro's loopback, reachable from containers on this host and from nothing else, with no Windows",
+            'firewall rule involved. That stops being true under mirrored networking, which is why the mode is checked.',
+        ];
+    }
+    return [
+        `WARNING: binding ${host} exposes the wmux pipe beyond localhost.`,
+        `Prefer the default 127.0.0.1 + an SSH tunnel: ssh -L ${req.port}:127.0.0.1:${req.port} user@host`,
+    ];
+}
+/**
+ * The whole `--wsl` / `--host` decision in one place.
+ *
+ * An explicit `--host` always wins, including `--host 0.0.0.0` under mirrored
+ * mode: the user named the address, so the job here is to describe what they
+ * chose, not to overrule it. Only the implicit `0.0.0.0` that `--wsl` used to
+ * pick unconditionally is gated.
+ */
+function chooseBridgeHost(req) {
+    if (req.wslMode && !req.inWsl2) {
+        return {
+            host: null,
+            notices: [],
+            error: '--wsl is for a bridge running inside a WSL2 distro, and this process is not in one ' +
+                '(looked for "microsoft"/"WSL2" in /proc/sys/kernel/osrelease and for WSL_INTEROP or ' +
+                'WSL_DISTRO_NAME in the environment). Drop --wsl for the 127.0.0.1 default, or name the ' +
+                'address you want with --host <addr>.',
+        };
+    }
+    if (req.explicitHost) {
+        return {
+            host: req.explicitHost,
+            notices: isLoopback(req.explicitHost) ? [] : exposureNotice(req.explicitHost, req),
+            error: null,
+        };
+    }
+    if (!req.wslMode)
+        return { host: '127.0.0.1', notices: [], error: null };
+    if (req.mode === 'nat') {
+        return { host: '0.0.0.0', notices: exposureNotice('0.0.0.0', req), error: null };
+    }
+    if (req.mode === 'mirrored') {
+        return {
+            host: null,
+            notices: [],
+            error: 'refusing to pick 0.0.0.0 for you: this distro runs mirrored networking ' +
+                '(wslinfo --networking-mode reports "mirrored"), so it shares the Windows host\'s network ' +
+                'interfaces instead of having its own namespace. 0.0.0.0 here is a bind on the LAN and any ' +
+                'VPN adapter, gated only by the Hyper-V firewall\'s inbound policy — not the private 172.x ' +
+                'that --wsl assumes under NAT. Pass --host <addr> with the address the container actually ' +
+                'reaches, or --host 0.0.0.0 if you have weighed that and want it anyway.',
+        };
+    }
+    return {
+        host: null,
+        notices: [],
+        error: 'could not determine this distro\'s networking mode (wslinfo --networking-mode gave no usable ' +
+            'answer; it needs WSL 2.0.5 or newer). --wsl only picks 0.0.0.0 once it has confirmed NAT, ' +
+            'because under mirrored networking that address is the Windows host\'s real interfaces rather ' +
+            'than an isolated namespace. Check with `wslinfo --networking-mode`, then pass --host <addr> ' +
+            'explicitly.',
+    };
+}

--- a/resources/shell-integration/wmux-bash-integration.sh
+++ b/resources/shell-integration/wmux-bash-integration.sh
@@ -10,7 +10,20 @@ export -f wmux
 
 _wmux_report() {
     local msg="$1"
-    # Write to temp file for main process to pick up
+    # Devcontainer transport (issue #19): a shell inside a Linux container can
+    # reach neither the Windows named pipe nor the host's Temp dir, so the file
+    # drop below is a no-op there and the pane never reports anything. When
+    # WMUX_REMOTE is set, relay the same V1 line through `wmux raw-v1` instead —
+    # the `wmux` shim resolves to `node "$WMUX_CLI"`, which already speaks TCP to
+    # a `wmux bridge` (issue #78). No protocol is duplicated here.
+    #
+    # Fire-and-forget: backgrounded with output discarded, so a slow or absent
+    # bridge delays no prompt and fails no command.
+    if [ -n "${WMUX_REMOTE}" ] && command -v wmux &>/dev/null; then
+        ( wmux raw-v1 "$msg" >/dev/null 2>&1 & )
+        return
+    fi
+    # Native: write to temp file for the main process to pick up
     local tmpdir="/mnt/c/Users/${USER}/AppData/Local/Temp/wmux"
     mkdir -p "$tmpdir" 2>/dev/null
     echo "$msg" >> "$tmpdir/messages"

--- a/scripts/install-npiperelay.sh
+++ b/scripts/install-npiperelay.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# install-npiperelay.sh — Download npiperelay.exe (SHA-256 pinned) into WSL2 so
+# the wmux CLI / `wmux bridge` can reach the Windows \\.\pipe\wmux named pipe via
+# WSL interop (see src/cli/wmux.ts → connectViaNpiperelay).
+#
+# npiperelay.exe is a small open-source Windows binary that forwards a named pipe
+# to its own stdin/stdout; WSL2 executes it via interop, so no socat/Unix-socket
+# pre-setup is needed. This script only installs the binary — the CLI spawns it.
+#
+# Idempotent: re-running is a no-op when the installed binary's hash matches.
+#
+# Usage:
+#   bash scripts/install-npiperelay.sh
+#
+# Requires: curl, sha256sum (both available via apt).
+
+set -euo pipefail
+
+# ── Pinned release (albertony/npiperelay v1.11.4) ─────────────────────────────
+NPIPERELAY_VERSION="v1.11.4"
+NPIPERELAY_URL="https://github.com/albertony/npiperelay/releases/download/${NPIPERELAY_VERSION}/npiperelay_windows_amd64.exe"
+NPIPERELAY_SHA256="cea82cf5c9c22a28bef8075750acb7958f766393baebff4597cf21442f71c4b3"
+NPIPERELAY_CHECKSUMS_URL="https://github.com/albertony/npiperelay/releases/download/${NPIPERELAY_VERSION}/npiperelay_checksums.txt"
+NPIPERELAY_CHECKSUMS_SHA256="313973839744601ae73eb3597f62c9adb5f9e6985e97b4054ed18701f2cb5df7"
+# ──────────────────────────────────────────────────────────────────────────────
+
+INSTALL_DIR="${HOME}/.local/bin"
+NPIPERELAY_BIN="${INSTALL_DIR}/npiperelay.exe"
+
+echo "wmux npiperelay install"
+echo "======================="
+echo "  version : ${NPIPERELAY_VERSION}"
+echo "  target  : ${NPIPERELAY_BIN}"
+echo ""
+
+# ── Prerequisites ─────────────────────────────────────────────────────────────
+for cmd in curl sha256sum; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "ERROR: '$cmd' not found. Install with: sudo apt-get install $cmd"
+    exit 1
+  fi
+done
+
+# ── Skip when the pinned binary is already present and verified ────────────────
+mkdir -p "${INSTALL_DIR}"
+
+if [[ -f "${NPIPERELAY_BIN}" ]]; then
+  existing_hash="$(sha256sum "${NPIPERELAY_BIN}" | awk '{print $1}')"
+  if [[ "${existing_hash}" == "${NPIPERELAY_SHA256}" ]]; then
+    echo "[OK] npiperelay.exe already present and hash verified."
+    exit 0
+  fi
+  echo "[!] Existing npiperelay.exe hash mismatch (got ${existing_hash}), re-downloading..."
+fi
+
+# ── Verify the checksums file itself before trusting it ────────────────────────
+echo "[+] Downloading checksums file..."
+tmp_checksums="$(mktemp)"
+trap 'rm -f "${tmp_checksums:-}" "${tmp_bin:-}"' EXIT
+curl -fsSL "${NPIPERELAY_CHECKSUMS_URL}" -o "${tmp_checksums}"
+actual_checksums_hash="$(sha256sum "${tmp_checksums}" | awk '{print $1}')"
+if [[ "${actual_checksums_hash}" != "${NPIPERELAY_CHECKSUMS_SHA256}" ]]; then
+  echo "ERROR: Checksums file hash mismatch!"
+  echo "  expected: ${NPIPERELAY_CHECKSUMS_SHA256}"
+  echo "  got:      ${actual_checksums_hash}"
+  exit 1
+fi
+
+# Confirm the pinned binary hash is listed in the (now trusted) checksums file.
+if ! grep -q "${NPIPERELAY_SHA256}" "${tmp_checksums}"; then
+  echo "ERROR: Expected binary hash not found in checksums file — pinned hash outdated?"
+  exit 1
+fi
+
+# ── Download the binary and re-verify its hash ────────────────────────────────
+echo "[+] Downloading npiperelay_windows_amd64.exe..."
+tmp_bin="$(mktemp)"
+curl -fsSL "${NPIPERELAY_URL}" -o "${tmp_bin}"
+actual_hash="$(sha256sum "${tmp_bin}" | awk '{print $1}')"
+if [[ "${actual_hash}" != "${NPIPERELAY_SHA256}" ]]; then
+  echo "ERROR: Downloaded binary hash mismatch!"
+  echo "  expected: ${NPIPERELAY_SHA256}"
+  echo "  got:      ${actual_hash}"
+  exit 1
+fi
+
+mv "${tmp_bin}" "${NPIPERELAY_BIN}"
+chmod +x "${NPIPERELAY_BIN}"
+echo "[OK] npiperelay.exe installed to ${NPIPERELAY_BIN} (sha256 ${actual_hash})"

--- a/src/cli/transport-deadline.ts
+++ b/src/cli/transport-deadline.ts
@@ -1,0 +1,79 @@
+/**
+ * How long a wmux client waits for the pipe, derived from the transport rather
+ * than written down per client.
+ *
+ * Two processes talk to wmux over the same socket: the CLI (`wmux.ts`) and the
+ * Claude Code hook helper (`wmux-hook.ts`). Both had their own copy of the same
+ * pair of numbers and their own idea of when to use which — the CLI derived it
+ * from `remoteTarget || usesNpiperelay()`, the hook hardcoded
+ * `remote ? 30000 : 5000`. Same intent, two spellings, and only one of them
+ * knew about npiperelay. A third client, or a change to either number, would
+ * have had to find both.
+ *
+ * So the transport describes itself and the deadline follows. Nothing here does
+ * I/O; the caller supplies what it already knows about its own connection.
+ */
+
+/**
+ * What a local named pipe on the same machine is worth waiting.
+ *
+ * Sized for a round-trip that is sub-millisecond, so the whole budget is the
+ * server's own thinking time. This deadline has to stay LARGER than whatever
+ * the main process spends serving the same request, or the client loses a race
+ * it should never have been in: a command that succeeds late is reported as a
+ * failure and the server's own diagnosis is discarded unread.
+ */
+export const DEFAULT_V2_TIMEOUT_MS = 5000;
+
+/**
+ * A floor under every deadline, for transports slower than a local pipe.
+ *
+ * Neither transport added for issue #19 is a local pipe: TCP to a `wmux bridge`
+ * from inside a devcontainer, and npiperelay over WSL interop. Both measure ~7s
+ * worst case on a corporate-managed host — above the 5s default on their own,
+ * before wmux has done anything — so every request from a container reported a
+ * timeout for a call that had already succeeded.
+ *
+ * A floor rather than a replacement, so a browser verb keeps the longer budget
+ * it asked for and a local run keeps its original timings exactly.
+ */
+export const SLOW_TRANSPORT_FLOOR_MS = 30000;
+
+export interface Transport {
+  /** Talking TCP to a `wmux bridge` instead of a local pipe. */
+  remote: boolean;
+  /** The pipe path this client would dial locally. */
+  pipePath: string;
+  /** Where WSL_DISTRO_NAME / WSLENV / WMUX_RPC_TIMEOUT_MS are read from. */
+  env: NodeJS.ProcessEnv;
+}
+
+/**
+ * Whether the local hop goes through npiperelay.exe over WSL interop.
+ *
+ * A Windows pipe path (`\\.\pipe\wmux`, not something rooted at `/`) reached
+ * from inside a WSL distro cannot be dialled directly — npiperelay is what
+ * bridges it, and spawning a Windows executable over interop is the slow part,
+ * especially where AV scans the binary on each exec.
+ */
+export function usesNpiperelay(t: Transport): boolean {
+  return !t.remote && !t.pipePath.startsWith('/') && Boolean(t.env.WSL_DISTRO_NAME || t.env.WSLENV);
+}
+
+/** Whether this transport needs the floor at all. */
+export function isSlowTransport(t: Transport): boolean {
+  return t.remote || usesNpiperelay(t);
+}
+
+/**
+ * `base`, raised to the slow-transport floor when the transport is a slow one.
+ *
+ * `WMUX_RPC_TIMEOUT_MS` overrides the floor for anyone whose link is slower
+ * still, and is itself a floor rather than a cap — it can only ever lengthen a
+ * deadline, so setting it can never cause the truncation this exists to avoid.
+ */
+export function transportDeadline(base: number, t: Transport): number {
+  const override = parseInt(t.env.WMUX_RPC_TIMEOUT_MS || '', 10);
+  if (Number.isFinite(override) && override > 0) return Math.max(base, override);
+  return isSlowTransport(t) ? Math.max(base, SLOW_TRANSPORT_FLOOR_MS) : base;
+}

--- a/src/cli/wmux-hook.ts
+++ b/src/cli/wmux-hook.ts
@@ -37,8 +37,31 @@ if (argv[0] === '--event') {
 const firedAt = Date.now();
 
 const pipePath = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
-const token = process.env.WMUX_PIPE_TOKEN || '';
 const surfaceId = process.env.WMUX_SURFACE_ID || '';
+
+/**
+ * TCP transport for a hook firing where the pipe does not exist (issue #19).
+ *
+ * Inside a devcontainer, Claude Code runs on Linux while wmux runs on the
+ * Windows host: `\\.\pipe\wmux` is unreachable, so every hook failed silently
+ * and the sidebar never left "Running". WMUX_REMOTE points at a `wmux bridge`
+ * (issue #78) instead — same JSON-RPC frame, same auth, different socket. The
+ * env-var form is deliberate: Claude Code owns this process's argv, so there is
+ * nowhere to put a --remote flag.
+ *
+ * The token is the REMOTE instance's, which is not this machine's: on the
+ * container side WMUX_PIPE_TOKEN is either absent or something else entirely.
+ */
+const remote = (() => {
+  const spec = process.env.WMUX_REMOTE?.trim();
+  if (!spec) return null;
+  const idx = spec.lastIndexOf(':');
+  const port = idx === -1 ? NaN : parseInt(spec.slice(idx + 1), 10);
+  return Number.isFinite(port) && port > 0 && port <= 65535
+    ? { host: spec.slice(0, idx) || '127.0.0.1', port }
+    : { host: spec, port: 9787 };
+})();
+const token = (remote ? process.env.WMUX_REMOTE_TOKEN : process.env.WMUX_PIPE_TOKEN) || '';
 
 let stdinData = '';
 let sent = false;
@@ -55,8 +78,13 @@ const MAX_STDIN = 64 * 1024; // 64KB cap
  * tears the connection down rather than half-closing it. The wmux CLI has
  * always armed this same 5s timer before connecting (see sendV1/sendV2); the
  * hook helper was the one client without it, and matching costs nothing.
+ *
+ * The bridge path gets longer: there the frame crosses a TCP hop and then
+ * npiperelay over WSL interop, which measures ~7s worst case on a corporate
+ * host. Firing at 5s there would destroy() the socket mid-flight and drop the
+ * very event this process exists to deliver.
  */
-const PIPE_DEADLINE_MS = 5000;
+const PIPE_DEADLINE_MS = remote ? 30000 : 5000;
 
 /** Cleared once we stop reading, so the happy path is not held open by it. */
 let stdinTimer: NodeJS.Timeout | null = null;
@@ -98,7 +126,7 @@ function sendHook(): void {
   if (message) params.message = message;
   if (surfaceId) params.surfaceId = surfaceId;
 
-  const client = net.connect({ path: pipePath }, () => {
+  const client = net.connect(remote ? { host: remote.host, port: remote.port } : { path: pipePath }, () => {
     const msg = JSON.stringify({ method: 'hook.event', params, id: 1, token });
     client.write(msg + '\n', () => client.end());
     // Drain the reply we do not care about. This is not cosmetic: wmux answers

--- a/src/cli/wmux-hook.ts
+++ b/src/cli/wmux-hook.ts
@@ -15,6 +15,7 @@
  * WMUX_SURFACE_ID (set by wmux in each pane's shell) ties the event to its pane.
  */
 import net from 'net';
+import { DEFAULT_V2_TIMEOUT_MS, transportDeadline } from './transport-deadline';
 
 const argv = process.argv.slice(2);
 let tool = '';
@@ -76,15 +77,20 @@ const MAX_STDIN = 64 * 1024; // 64KB cap
  * an absent, a responsive and a wedged (accepts, never answers) server, the
  * hook exits on its own in every case, because on Windows named pipes `end()`
  * tears the connection down rather than half-closing it. The wmux CLI has
- * always armed this same 5s timer before connecting (see sendV1/sendV2); the
- * hook helper was the one client without it, and matching costs nothing.
+ * always armed this same timer before connecting (see sendV1/sendV2); the hook
+ * helper was the one client without it, and matching costs nothing.
  *
- * The bridge path gets longer: there the frame crosses a TCP hop and then
- * npiperelay over WSL interop, which measures ~7s worst case on a corporate
- * host. Firing at 5s there would destroy() the socket mid-flight and drop the
- * very event this process exists to deliver.
+ * Derived rather than written down. This used to be `remote ? 30000 : 5000` —
+ * the same intent as the CLI's `deadline()` in a second spelling that did not
+ * know about npiperelay, so the two could drift and only one would be found by
+ * anyone changing a number. Both now ask transport-deadline.ts, describing the
+ * same connection the same way.
  */
-const PIPE_DEADLINE_MS = remote ? 30000 : 5000;
+const PIPE_DEADLINE_MS = transportDeadline(DEFAULT_V2_TIMEOUT_MS, {
+  remote: !!remote,
+  pipePath,
+  env: process.env,
+});
 
 /** Cleared once we stop reading, so the happy path is not held open by it. */
 let stdinTimer: NodeJS.Timeout | null = null;

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -934,18 +934,42 @@ async function cmdAgentActivity(args: string[]): Promise<void> {
   await sendV2('agent.activity', params);
 }
 
-// Generic V1 passthrough (issue #19: devcontainer support). Lets a caller send
-// any raw V1 command line (report_pwd, report_git_branch, report_shell_state,
-// report_startup_command, …) without the CLI growing a near-identical wrapper
-// for each. wmux-bash-integration.sh writes those lines straight to the local
-// pipe when it can reach one; inside a devcontainer it can't, so it calls
-// `wmux raw-v1` instead and gets the CLI's transport — including TCP via
-// --remote / WMUX_REMOTE to a `wmux bridge` (issue #78) — for free. Auth is
-// unchanged: sendV1 still prefixes `auth <token>`.
+/**
+ * V1 passthrough for the shell integration (issue #19: devcontainer support).
+ *
+ * wmux-bash-integration.sh writes its state lines straight to the local pipe
+ * when it can reach one. Inside a devcontainer it can't, so it calls
+ * `wmux raw-v1` instead and gets the CLI's transport — including TCP via
+ * --remote / WMUX_REMOTE to a `wmux bridge` (issue #78) — without the CLI
+ * growing a near-identical wrapper per verb. Auth is unchanged: sendV1 still
+ * prefixes `auth <token>`.
+ *
+ * Restricted to the verbs the integration actually emits. A generic passthrough
+ * would make this a permanent side door into V1: every future V1 command becomes
+ * reachable from a container the day it is added, with no review of whether that
+ * was intended, and the pipe's V1 surface stops being something the V1 handler
+ * alone defines. Nothing is lost by naming them — the set is short, and a real
+ * new caller wants a real CLI command anyway.
+ */
+export const RAW_V1_VERBS = [
+  'report_pwd',
+  'report_git_branch',
+  'clear_git_branch',
+  'report_shell_state',
+  'ports_kick',
+  'report_startup_command',
+] as const;
+
+export function rawV1Error(verb: string | undefined): string | null {
+  if (!verb) return 'Usage: wmux raw-v1 <command> [surfaceId] [args...]';
+  if ((RAW_V1_VERBS as readonly string[]).includes(verb)) return null;
+  return `raw-v1: ${verb} is not a passthrough command. Accepted: ${RAW_V1_VERBS.join(', ')}`;
+}
+
 async function cmdRawV1(args: string[]): Promise<void> {
-  const line = args.slice(1).join(' ');
-  if (!line) { console.error('Usage: wmux raw-v1 <command> [surfaceId] [args...]'); process.exit(1); }
-  console.log(await sendV1(line));
+  const problem = rawV1Error(args[1]);
+  if (problem) { console.error(problem); process.exit(1); }
+  console.log(await sendV1(args.slice(1).join(' ')));
 }
 
 // ─── Declared agent state (issue #128) ───────────────────────────────────────

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -4,6 +4,8 @@ import net from 'net';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { spawn } from 'child_process';
+import { Duplex } from 'stream';
 
 // Respect WMUX_PIPE when set (e.g. by a parent wmux running with WMUX_INSTANCE),
 // so the CLI talks to the same instance that spawned the shell.
@@ -18,6 +20,26 @@ const PIPE_PATH = process.env.WMUX_PIPE || '\\\\.\\pipe\\wmux';
 const DEFAULT_BRIDGE_PORT = 9787;
 let remoteTarget: { host: string; port: number } | null = null;
 
+// How long `wmux bridge` lets a relay keep draining after its client socket has
+// closed, before forcing teardown. Must exceed the pipe round-trip, or the frame
+// a write-then-close client just sent is discarded mid-flight. Measured worst
+// case inside a devcontainer on a corporate-managed Windows host is ~7s (a fresh
+// npiperelay.exe is spawned per connection over WSL interop, and AV/EDR scans it
+// on every exec), so the default leaves generous headroom. The relay normally
+// exits on its own well before this — the timer is only the backstop.
+const BRIDGE_DRAIN_GRACE_MS = parseInt(process.env.WMUX_BRIDGE_DRAIN_MS || '', 10) || 15000;
+
+// How many npiperelay relays `wmux bridge` keeps spawned and attached to the pipe
+// ahead of demand (see the pool in cmdBridge). 0 disables pre-warming and restores
+// spawn-per-connection. Only ever used on the npiperelay path — the Unix-socket and
+// native-pipe transports connect instantly and have nothing to pre-warm.
+const BRIDGE_WARM_RELAYS = (() => {
+  const raw = process.env.WMUX_BRIDGE_WARM?.trim();
+  if (!raw) return 2;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 2;
+})();
+
 function parseRemoteTarget(spec: string): { host: string; port: number } {
   const idx = spec.lastIndexOf(':');
   if (idx === -1) return { host: spec, port: DEFAULT_BRIDGE_PORT };
@@ -29,10 +51,122 @@ function parseRemoteTarget(spec: string): { host: string; port: number } {
   return { host: spec.slice(0, idx) || '127.0.0.1', port };
 }
 
-function connectTransport(onConnect: () => void): net.Socket {
-  return remoteTarget
-    ? net.connect({ host: remoteTarget.host, port: remoteTarget.port }, onConnect)
-    : net.connect({ path: PIPE_PATH }, onConnect);
+// ─── WSL2 transport: reach the Windows \\.\pipe\wmux from inside WSL2 ─────────
+//
+// A wmux CLI (or `wmux bridge`) running inside WSL2 needs to talk to the wmux
+// process on the Windows host over the \\.\pipe\wmux named pipe. AF_VSOCK,
+// TCP-over-gateway and cross-boundary Unix sockets were all evaluated and
+// rejected (HCS-managed WSL2 UVMs ignore GuestCommunicationServices; gateway
+// IPs/firewall policy are unreliable on corporate networks; 9P does not forward
+// AF_UNIX). The chosen mechanism is npiperelay.exe:
+//
+//   npiperelay.exe is a tiny (~2MB) open-source Windows binary that forwards a
+//   named pipe to its own stdin/stdout. WSL2 executes Windows binaries via
+//   interop, so from inside WSL2 we spawn it and use its stdio as the transport
+//   duplex — zero pre-setup, no socat needed. Install it (SHA-256 pinned) with
+//   scripts/install-npiperelay.sh; see docs/DEVCONTAINER.md for the full setup.
+//   Source: https://github.com/albertony/npiperelay (MIT, fork of jstarks/npiperelay)
+//   Pinned version: v1.11.4  SHA-256: cea82cf5c9c22a28bef8075750acb7958f766393baebff4597cf21442f71c4b3
+//
+//   Transport selection order:
+//     0. remoteTarget set (--remote / WMUX_REMOTE) → TCP (the devcontainer path,
+//        served by a `wmux bridge` reachable at host.docker.internal:9787)
+//     1. WMUX_PIPE starts with '/' → use as a Unix socket path
+//     2. WSL_DISTRO_NAME / WSLENV set → spawn npiperelay.exe automatically
+//     3. native Windows → connect directly to the named pipe
+// ─────────────────────────────────────────────────────────────────────────────
+function connectTransport(onConnect: () => void): net.Socket | Duplex {
+  if (remoteTarget) return net.connect({ host: remoteTarget.host, port: remoteTarget.port }, onConnect);
+  if (PIPE_PATH.startsWith('/')) return net.connect({ path: PIPE_PATH }, onConnect);
+  if (process.env.WSL_DISTRO_NAME || process.env.WSLENV) return connectViaNpiperelay(PIPE_PATH, onConnect);
+  return net.connect({ path: PIPE_PATH }, onConnect);
+}
+
+// Mirrors the selection order above: true when connectTransport() will take the
+// npiperelay branch. That is the only transport whose setup costs anything worth
+// pre-warming — a Unix socket or a native named pipe connects in microseconds.
+function usesNpiperelay(): boolean {
+  return (
+    !remoteTarget && !PIPE_PATH.startsWith('/') && Boolean(process.env.WSL_DISTRO_NAME || process.env.WSLENV)
+  );
+}
+
+// Search common installation locations for npiperelay.exe.
+function findNpiperelay(): string | null {
+  const readable = (p: string): boolean => {
+    try {
+      fs.accessSync(p);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const binPaths = (process.env.PATH || process.env.Path || '')
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map((d) => path.join(d, 'npiperelay.exe'));
+  const fromPath = binPaths.find(readable);
+  if (fromPath) return fromPath;
+  return (
+    [
+      path.join(os.homedir(), '.local', 'bin', 'npiperelay.exe'),
+      '/usr/local/bin/npiperelay.exe',
+      '/usr/bin/npiperelay.exe',
+    ].find(readable) ?? null
+  );
+}
+
+// Spawn npiperelay.exe and expose its stdin/stdout as a Duplex stream.
+function connectViaNpiperelay(pipePath: string, onConnect: () => void): Duplex {
+  const bin = findNpiperelay();
+  if (!bin) {
+    console.error('wmux: npiperelay.exe not found.');
+    console.error('  Install it with scripts/install-npiperelay.sh, or fetch it from:');
+    console.error('  https://github.com/albertony/npiperelay/releases/latest');
+    process.exit(1);
+  }
+  // npiperelay names the pipe with forward slashes: \\.\pipe\wmux → //./pipe/wmux
+  const child = spawn(bin, ['-ei', '-s', pipePath.replace(/\\/g, '/')], {
+    stdio: ['pipe', 'pipe', 'inherit'],
+  });
+  const duplex = new Duplex({
+    read() {},
+    write(chunk, enc, cb) {
+      if (!child.stdin?.writable) {
+        cb(new Error('npiperelay stdin closed'));
+        return;
+      }
+      child.stdin.write(chunk, enc, cb);
+    },
+    final(cb) {
+      child.stdin?.end();
+      cb();
+    },
+    // Kills the relay, discarding anything still buffered in its stdin. Callers
+    // must only reach here on error or after the stream has drained — see the
+    // teardown in cmdBridge.
+    destroy(err, cb) {
+      child.kill();
+      cb(err);
+    },
+    allowHalfOpen: true,
+  });
+  child.stdout?.on('data', (chunk: Buffer) => duplex.push(chunk));
+  child.stdout?.on('end', () => duplex.push(null));
+  child.on('error', (err: Error) => duplex.destroy(err));
+  child.on('exit', (code: number | null) => {
+    if (code !== 0 && code !== null) duplex.destroy(new Error(`npiperelay exited with code ${code}`));
+  });
+  // "Ready" here means the relay process exists — NOT that it has attached to the
+  // named pipe, which over WSL interop can take seconds longer. onConnect must
+  // still fire now regardless: callers write their request from inside it, and the
+  // Duplex buffers those bytes until the pipe is live. (Deferring it until the
+  // first byte comes back would deadlock — nothing would ever be written.)
+  //
+  // The cost is that a caller's deadline starts before the pipe is up, so it has
+  // to cover the attach latency too — that is what SLOW_TRANSPORT_FLOOR_MS is for.
+  process.nextTick(onConnect);
+  return duplex;
 }
 
 // Auth token for privileged (V2) pipe requests. wmux injects WMUX_PIPE_TOKEN
@@ -61,7 +195,7 @@ function sendV1(command: string): Promise<string> {
       client.write(line + '\n');
     });
     let data = '';
-    const timer = setTimeout(() => { client.end(); resolve(data.trim()); }, 5000);
+    const timer = setTimeout(() => { client.end(); resolve(data.trim()); }, deadline(5000));
     const finish = () => { clearTimeout(timer); resolve(data.trim()); };
     client.on('data', (chunk) => {
       data += chunk.toString();
@@ -86,6 +220,29 @@ function sendV1(command: string): Promise<string> {
  * Only the browser verbs currently need more than this — see BROWSER_CMDS.
  */
 const DEFAULT_V2_TIMEOUT_MS = 5000;
+
+/**
+ * A floor under every deadline, for transports slower than a local named pipe.
+ *
+ * The budgets above are all sized for a pipe on the same machine, where a
+ * round-trip is sub-millisecond and the whole deadline is the server's own
+ * thinking time. Neither transport this file grew for issue #19 is that: TCP to
+ * a `wmux bridge` from inside a devcontainer, and npiperelay over WSL interop,
+ * both measure ~7s worst case on a corporate-managed host — above the 5s default
+ * on their own, before wmux has done anything. Every request from a container
+ * therefore reported a timeout for a call that had already succeeded.
+ *
+ * A floor rather than a replacement, so a browser verb keeps the longer budget
+ * it asked for, and a local run keeps master's timings unchanged (floor 0).
+ */
+const SLOW_TRANSPORT_FLOOR_MS = 30000;
+
+/** `base`, raised to the slow-transport floor when the transport is a slow one. */
+function deadline(base: number): number {
+  const override = parseInt(process.env.WMUX_RPC_TIMEOUT_MS || '', 10);
+  if (Number.isFinite(override) && override > 0) return Math.max(base, override);
+  return remoteTarget || usesNpiperelay() ? Math.max(base, SLOW_TRANSPORT_FLOOR_MS) : base;
+}
 
 /**
  * What a stalled request says when it gives up.
@@ -118,10 +275,11 @@ function sendV2(
       client.write(request + '\n');
     });
     let data = '';
+    const deadlineMs = deadline(timeoutMs);
     const timer = setTimeout(() => {
       client.end();
-      reject(new Error(timeoutMessage(method, timeoutMs)));
-    }, timeoutMs);
+      reject(new Error(timeoutMessage(method, deadlineMs)));
+    }, deadlineMs);
     client.on('data', (chunk) => {
       data += chunk.toString();
       if (data.includes('\n')) {
@@ -490,27 +648,163 @@ async function cmdSsh(args: string[]): Promise<void> {
 // wmux's pipe server, so the bridge grants nothing by itself.
 async function cmdBridge(args: string[]): Promise<void> {
   const port = parseInt(getFlag(args, '--port') || '', 10) || DEFAULT_BRIDGE_PORT;
-  const host = getFlag(args, '--host') || '127.0.0.1';
+  // --wsl binds 0.0.0.0 so a container on the Windows host can reach a bridge
+  // running inside WSL2 (issue #19). WSL2's NAT gives the distro an address the
+  // container resolves as host.docker.internal, but 127.0.0.1 inside the distro
+  // is not it. The pipe token still authenticates every request end to end.
+  const wslMode = args.includes('--wsl');
+  const host = getFlag(args, '--host') || (wslMode ? '0.0.0.0' : '127.0.0.1');
   if (host !== '127.0.0.1' && host !== 'localhost') {
     console.warn('WARNING: binding beyond localhost exposes the wmux pipe to the network.');
     console.warn(`Prefer the default 127.0.0.1 + an SSH tunnel: ssh -L ${port}:127.0.0.1:${port} user@host`);
   }
+
+  // ── Warm relay pool ─────────────────────────────────────────────────────────
+  // Spawn-per-connection made every request pay the relay's whole startup: a fresh
+  // npiperelay.exe launched over WSL interop (AV/EDR scans the binary on each exec
+  // on a corporate-managed host) and then the pipe dial. Measured worst case from a
+  // devcontainer is ~7s — on every hook. Keeping relays open ahead of demand moves
+  // that cost off the request path: a warm relay has already spawned AND attached
+  // by the time a client arrives, so hand-off is just pipe().
+  //
+  // Deliberately a POOL of exclusive relays, not one shared relay multiplexed
+  // across clients. Multiplexing would force the bridge to parse frames and rewrite
+  // JSON-RPC ids to route replies back to the right socket, which:
+  //   * breaks V1 entirely — `pong` / `ok` / `unauthorized` carry no id to route on;
+  //   * makes every client a casualty when the single relay dies;
+  //   * costs the bridge its one real virtue, being a transparent byte pipe (any
+  //     future streaming or server-pushed method would have to be taught to it).
+  // Pooling buys the same latency win and the bridge stays dumb.
+  //
+  // Only on the npiperelay path — elsewhere this would hold idle sockets open to
+  // buy nothing.
+  const warmSize = usesNpiperelay() ? BRIDGE_WARM_RELAYS : 0;
+  const warm: Array<{ stream: net.Socket | Duplex; claim: () => void }> = [];
+  let warmFailures = 0;
+  let refillTimer: NodeJS.Timeout | null = null;
+
+  const scheduleRefill = (delayMs: number): void => {
+    if (refillTimer || warm.length >= warmSize) return;
+    refillTimer = setTimeout(() => {
+      refillTimer = null;
+      fillWarm();
+    }, delayMs);
+    refillTimer.unref();
+  };
+
+  function fillWarm(): void {
+    while (warm.length < warmSize) {
+      const stream = connectTransport(() => {});
+      const entry = { stream, claim: () => {} };
+      // Dying before being claimed means the upstream isn't there — wmux not
+      // running, or the pipe gone. npiperelay exits immediately in that case, so
+      // without a backoff the bridge would respawn a Windows process in a tight
+      // loop for as long as wmux stays down.
+      const onDead = (): void => {
+        const i = warm.indexOf(entry);
+        if (i === -1) return; // already claimed — the client's teardown owns it now
+        warm.splice(i, 1);
+        warmFailures = Math.min(warmFailures + 1, 6);
+        scheduleRefill(Math.min(30000, 500 * 2 ** warmFailures));
+      };
+      entry.claim = () => {
+        stream.off('error', onDead);
+        stream.off('close', onDead);
+      };
+      stream.on('error', onDead);
+      stream.on('close', onDead);
+      warm.push(entry);
+    }
+  }
+
+  // An idle relay reads nothing, so anything the upstream sent while it waited stays
+  // buffered in the stream and is delivered the moment the client pipes it — no need
+  // to drain before hand-off.
+  const takeWarm = (): net.Socket | Duplex | null => {
+    while (warm.length) {
+      const entry = warm.pop()!;
+      entry.claim();
+      // wmux may have restarted since this relay attached.
+      if (!entry.stream.destroyed && entry.stream.writable) {
+        warmFailures = 0;
+        return entry.stream;
+      }
+      entry.stream.destroy();
+    }
+    return null;
+  };
+
   const server = net.createServer((sock) => {
-    const pipe = net.connect({ path: PIPE_PATH });
+    // Connect to the local wmux through the same selector the CLI uses. In the
+    // bridge process remoteTarget is always null, so this resolves to a Unix
+    // socket, npiperelay (inside WSL2), or the named pipe directly — which is
+    // what lets `wmux bridge` run inside WSL2 and still reach the Windows pipe.
+    // A warm relay is the same thing, already connected.
+    const pipe = takeWarm() ?? connectTransport(() => {});
+    // Replace what we just consumed so the next client is served warm too.
+    scheduleRefill(0);
     sock.pipe(pipe);
     pipe.pipe(sock);
-    const drop = () => { sock.destroy(); pipe.destroy(); };
-    sock.on('error', drop);
-    pipe.on('error', drop);
-    sock.on('close', drop);
-    pipe.on('close', drop);
+
+    // Teardown is half-close-aware on purpose. Destroying BOTH sides on either
+    // 'close' silently ate hook events: wmux-hook.js writes its frame and end()s
+    // immediately, and over npiperelay the Duplex's destroy() is child.kill() —
+    // so the relay died with the frame still buffered in its stdin and never
+    // forwarded it. Clients that write-then-close are the normal case here
+    // (every Claude Code hook is one), not an abort.
+    //
+    // 'end' (peer finished sending) therefore FLUSHES rather than destroys: end()
+    // the other side so its buffered bytes drain and the pipe sees a clean EOF.
+    // destroy() is reserved for 'error', where there is nothing left to save.
+    let done = false;
+    const destroyBoth = (): void => {
+      if (done) return;
+      done = true;
+      sock.destroy();
+      pipe.destroy();
+    };
+    // A closed socket can no longer drain anything, so 'close' still tears down —
+    // but only after a grace period, giving an in-flight relay time to finish
+    // forwarding what it already holds.
+    const closeAfterDrain = (): void => {
+      if (done) return;
+      setTimeout(destroyBoth, BRIDGE_DRAIN_GRACE_MS).unref();
+    };
+
+    sock.on('error', destroyBoth);
+    pipe.on('error', destroyBoth);
+    sock.on('end', () => { pipe.end(); });
+    pipe.on('end', () => { sock.end(); });
+    sock.on('close', closeAfterDrain);
+    pipe.on('close', closeAfterDrain);
   });
   server.on('error', (err) => { console.error(`bridge error: ${err.message}`); process.exit(1); });
+
+  // Warm relays hold a live pipe connection (and an npiperelay.exe) for as long as
+  // the bridge runs, so retire them on the way out rather than orphaning them.
+  const shutdown = (): void => {
+    if (refillTimer) clearTimeout(refillTimer);
+    warm.splice(0).forEach((e) => { e.claim(); e.stream.destroy(); });
+    process.exit(0);
+  };
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+
   server.listen(port, host, () => {
     console.log(`wmux bridge listening on ${host}:${port} ↔ ${PIPE_PATH}`);
-    console.log('From another machine:');
-    console.log(`  ssh -L ${port}:127.0.0.1:${port} <user>@<this-host>`);
-    console.log(`  wmux --remote 127.0.0.1:${port} --token <run 'wmux token' here> list-workspaces`);
+    if (warmSize > 0) {
+      fillWarm();
+      console.log(`Keeping ${warmSize} npiperelay relay(s) warm (WMUX_BRIDGE_WARM=0 to disable).`);
+    }
+    if (wslMode) {
+      console.log('WSL2 mode. From a container on this host:');
+      console.log(`  WMUX_REMOTE=host.docker.internal:${port}`);
+      console.log("  WMUX_REMOTE_TOKEN=<run 'wmux token' here>");
+    } else {
+      console.log('From another machine:');
+      console.log(`  ssh -L ${port}:127.0.0.1:${port} <user>@<this-host>`);
+      console.log(`  wmux --remote 127.0.0.1:${port} --token <run 'wmux token' here> list-workspaces`);
+    }
     console.log('Ctrl+C to stop.');
   });
 }
@@ -589,6 +883,20 @@ async function cmdAgentActivity(args: string[]): Promise<void> {
   if (args.includes('--done')) params.done = true;
   if (args.includes('--active')) params.done = false;
   await sendV2('agent.activity', params);
+}
+
+// Generic V1 passthrough (issue #19: devcontainer support). Lets a caller send
+// any raw V1 command line (report_pwd, report_git_branch, report_shell_state,
+// report_startup_command, …) without the CLI growing a near-identical wrapper
+// for each. wmux-bash-integration.sh writes those lines straight to the local
+// pipe when it can reach one; inside a devcontainer it can't, so it calls
+// `wmux raw-v1` instead and gets the CLI's transport — including TCP via
+// --remote / WMUX_REMOTE to a `wmux bridge` (issue #78) — for free. Auth is
+// unchanged: sendV1 still prefixes `auth <token>`.
+async function cmdRawV1(args: string[]): Promise<void> {
+  const line = args.slice(1).join(' ');
+  if (!line) { console.error('Usage: wmux raw-v1 <command> [surfaceId] [args...]'); process.exit(1); }
+  console.log(await sendV1(line));
 }
 
 // ─── Declared agent state (issue #128) ───────────────────────────────────────
@@ -738,8 +1046,12 @@ const COMMAND_SPECS = {
 
   // Remote management (issue #78)
   bridge: {
-    usage: 'wmux bridge [--port P] [--host H]   (expose this wmux\'s pipe over TCP, default 127.0.0.1:9787)',
+    usage: [
+      'wmux bridge [--port P] [--host H] [--wsl]   (expose this wmux\'s pipe over TCP, default 127.0.0.1:9787)',
+      '  --wsl   bind 0.0.0.0 so a container on this host can reach a bridge running in WSL2',
+    ].join('\n'),
     value: ['--port', '--host'],
+    bool: ['--wsl'],
   },
   token: { usage: 'wmux token   (print this instance\'s pipe auth token)' },
 
@@ -877,6 +1189,10 @@ const COMMAND_SPECS = {
     usage: `wmux agent-activity [--tool T] [--skill S] [--done|--active] [--surface <id>]   ${SURFACE_NOTE}`,
     value: ['--tool', '--skill', '--surface'],
     bool: ['--done', '--active'],
+  },
+  'raw-v1': {
+    usage: 'wmux raw-v1 <command> [surfaceId] [args...]   (send a raw V1 line; used by shell integration)',
+    passthrough: true,
   },
 
   // Declared agent state (issue #128)
@@ -1110,6 +1426,8 @@ const COMMANDS: Record<CommandName, (args: string[]) => Promise<void> | void> = 
   },
   hook: cmdHook,
   'agent-activity': cmdAgentActivity,
+  // Devcontainer support (issue #19)
+  'raw-v1': cmdRawV1,
   ...AGENT_STATE_COMMANDS,
 };
 
@@ -1166,7 +1484,7 @@ Usage: wmux <command> [options]
 System:     ping, identify, capabilities, list-windows, focus-window <id>, new-window
 Workspace:  new-workspace, close-workspace, select-workspace, rename-workspace, list-workspaces
 Remote:     ssh [ssh options] <user@host> [--title T]   (remote terminal in a new workspace)
-            bridge [--port P] [--host H]   (expose this wmux's pipe over TCP, default 127.0.0.1:9787)
+            bridge [--port P] [--host H] [--wsl]   (expose this wmux's pipe over TCP, default 127.0.0.1:9787)
             token                          (print this instance's auth token, for --token)
 Global:     --remote host[:port] --token <T>   (drive a REMOTE wmux through an SSH tunnel;
             env equivalents: WMUX_REMOTE, WMUX_REMOTE_TOKEN)

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -12,6 +12,12 @@ import {
   parseNetworkingMode,
   type WslEnvironment,
 } from './wsl-network';
+import {
+  DEFAULT_V2_TIMEOUT_MS,
+  transportDeadline,
+  usesNpiperelay as usesNpiperelayFor,
+  type Transport,
+} from './transport-deadline';
 
 /** The two signals wsl-network.ts uses to decide we are inside a WSL distro. */
 function readWslEnvironment(): WslEnvironment {
@@ -120,10 +126,18 @@ function connectTransport(onConnect: () => void): net.Socket | Duplex {
 // Mirrors the selection order above: true when connectTransport() will take the
 // npiperelay branch. That is the only transport whose setup costs anything worth
 // pre-warming — a Unix socket or a native named pipe connects in microseconds.
+/**
+ * This process's transport, as transport-deadline.ts wants it described.
+ *
+ * A function rather than a constant: `remoteTarget` is set while parsing argv,
+ * after module load.
+ */
+function currentTransport(): Transport {
+  return { remote: !!remoteTarget, pipePath: PIPE_PATH, env: process.env };
+}
+
 function usesNpiperelay(): boolean {
-  return (
-    !remoteTarget && !PIPE_PATH.startsWith('/') && Boolean(process.env.WSL_DISTRO_NAME || process.env.WSLENV)
-  );
+  return usesNpiperelayFor(currentTransport());
 }
 
 // Search common installation locations for npiperelay.exe.
@@ -245,38 +259,15 @@ function sendV1(command: string): Promise<string> {
 }
 
 /**
- * How long to wait for a V2 reply before giving up.
- *
- * This deadline has to stay LARGER than whatever budget the main process spends
- * serving the same request. When it is shorter the CLI loses a race it should
- * never have been in: a command that succeeds late is reported as a failure, and
- * the server's own diagnosis ('Could not open browser panel', 'browser_not_open',
- * 'ref_not_found: …') is discarded unread because it arrives after we hung up.
- * Only the browser verbs currently need more than this — see BROWSER_CMDS.
+ * How long to wait for a V2 reply before giving up. Only the browser verbs
+ * currently need more than this — see BROWSER_CMDS. The reasoning behind the
+ * number, and behind the floor that raises it on a slow transport, lives with
+ * it in transport-deadline.ts.
  */
-const DEFAULT_V2_TIMEOUT_MS = 5000;
-
-/**
- * A floor under every deadline, for transports slower than a local named pipe.
- *
- * The budgets above are all sized for a pipe on the same machine, where a
- * round-trip is sub-millisecond and the whole deadline is the server's own
- * thinking time. Neither transport this file grew for issue #19 is that: TCP to
- * a `wmux bridge` from inside a devcontainer, and npiperelay over WSL interop,
- * both measure ~7s worst case on a corporate-managed host — above the 5s default
- * on their own, before wmux has done anything. Every request from a container
- * therefore reported a timeout for a call that had already succeeded.
- *
- * A floor rather than a replacement, so a browser verb keeps the longer budget
- * it asked for, and a local run keeps master's timings unchanged (floor 0).
- */
-const SLOW_TRANSPORT_FLOOR_MS = 30000;
 
 /** `base`, raised to the slow-transport floor when the transport is a slow one. */
 function deadline(base: number): number {
-  const override = parseInt(process.env.WMUX_RPC_TIMEOUT_MS || '', 10);
-  if (Number.isFinite(override) && override > 0) return Math.max(base, override);
-  return remoteTarget || usesNpiperelay() ? Math.max(base, SLOW_TRANSPORT_FLOOR_MS) : base;
+  return transportDeadline(base, currentTransport());
 }
 
 /**

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -4,8 +4,43 @@ import net from 'net';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import { Duplex } from 'stream';
+import {
+  chooseBridgeHost,
+  isWsl2,
+  parseNetworkingMode,
+  type WslEnvironment,
+} from './wsl-network';
+
+/** The two signals wsl-network.ts uses to decide we are inside a WSL distro. */
+function readWslEnvironment(): WslEnvironment {
+  let osRelease: string | null = null;
+  try {
+    osRelease = fs.readFileSync('/proc/sys/kernel/osrelease', 'utf-8');
+  } catch {
+    // Not Linux, or a kernel that does not expose it — either way, not WSL.
+  }
+  return {
+    osRelease,
+    hasInteropEnv: !!(process.env.WSL_INTEROP || process.env.WSL_DISTRO_NAME),
+  };
+}
+
+/**
+ * `wslinfo --networking-mode`, or null if it cannot answer. Absent before WSL
+ * 2.0.5, so a null here is ordinary rather than exceptional; parseNetworkingMode
+ * turns it into `unknown` and the caller refuses to guess from there.
+ */
+function readWslNetworkingMode(): string | null {
+  try {
+    const probe = spawnSync('wslinfo', ['--networking-mode'], { encoding: 'utf-8', timeout: 5000 });
+    if (probe.error || probe.status !== 0) return null;
+    return probe.stdout;
+  } catch {
+    return null;
+  }
+}
 
 // Respect WMUX_PIPE when set (e.g. by a parent wmux running with WMUX_INSTANCE),
 // so the CLI talks to the same instance that spawned the shell.
@@ -649,15 +684,29 @@ async function cmdSsh(args: string[]): Promise<void> {
 async function cmdBridge(args: string[]): Promise<void> {
   const port = parseInt(getFlag(args, '--port') || '', 10) || DEFAULT_BRIDGE_PORT;
   // --wsl binds 0.0.0.0 so a container on the Windows host can reach a bridge
-  // running inside WSL2 (issue #19). WSL2's NAT gives the distro an address the
-  // container resolves as host.docker.internal, but 127.0.0.1 inside the distro
-  // is not it. The pipe token still authenticates every request end to end.
+  // running inside WSL2 (issue #19). Under NAT — WSL2's default — the distro has
+  // its own network namespace, so that address is an eth0 on a private 172.x the
+  // container resolves as host.docker.internal, and 127.0.0.1 inside the distro
+  // is not it. Under mirrored networking the distro shares the Windows host's
+  // interfaces instead and 0.0.0.0 is the LAN, so the mode is read at runtime
+  // rather than assumed; see wsl-network.ts for the full reasoning. The pipe
+  // token authenticates every request end to end either way.
   const wslMode = args.includes('--wsl');
-  const host = getFlag(args, '--host') || (wslMode ? '0.0.0.0' : '127.0.0.1');
-  if (host !== '127.0.0.1' && host !== 'localhost') {
-    console.warn('WARNING: binding beyond localhost exposes the wmux pipe to the network.');
-    console.warn(`Prefer the default 127.0.0.1 + an SSH tunnel: ssh -L ${port}:127.0.0.1:${port} user@host`);
+  const wslEnv = readWslEnvironment();
+  const inWsl2 = isWsl2(wslEnv);
+  const decision = chooseBridgeHost({
+    explicitHost: getFlag(args, '--host'),
+    wslMode,
+    inWsl2,
+    mode: inWsl2 ? parseNetworkingMode(readWslNetworkingMode()) : 'unknown',
+    port,
+  });
+  if (decision.host === null) {
+    console.error(`wmux bridge: ${decision.error}`);
+    process.exit(1);
   }
+  const host = decision.host;
+  for (const line of decision.notices) console.warn(line);
 
   // ── Warm relay pool ─────────────────────────────────────────────────────────
   // Spawn-per-connection made every request pay the relay's whole startup: a fresh

--- a/src/cli/wsl-network.ts
+++ b/src/cli/wsl-network.ts
@@ -1,0 +1,192 @@
+/**
+ * Deciding what `wmux bridge` may bind to, and why, when it runs inside WSL2.
+ *
+ * `--wsl` exists so a container on the Windows host can reach a bridge running
+ * inside the distro (issue #19): `127.0.0.1` in the distro is not an address the
+ * container can dial, so the bridge has to listen on `0.0.0.0`. Whether that is
+ * a modest thing to do or a genuinely bad one depends entirely on which
+ * networking mode WSL2 is running, and the two differ more than the name
+ * suggests:
+ *
+ *   NAT (the default)  The distro gets its own network namespace behind a
+ *                      Hyper-V vSwitch. `0.0.0.0` there is the distro's loopback
+ *                      plus an `eth0` on a private 172.x — reachable from
+ *                      containers on the same host via the Docker host gateway,
+ *                      not reachable from the LAN, and no Windows firewall rule
+ *                      is involved either way.
+ *
+ *   Mirrored           `networkingMode=mirrored` in `.wslconfig` (WSL 2.0+ on
+ *                      Windows 11). The distro no longer has its own namespace —
+ *                      it SHARES the Windows host's interfaces, including the
+ *                      physical LAN adapter and any VPN adapter. `0.0.0.0` in
+ *                      that distro is a bind on the corporate network. Inbound
+ *                      traffic is filtered by the Hyper-V firewall rather than
+ *                      the ordinary Windows Firewall profile, and the
+ *                      widely-copied "make WSL reachable" recipe is
+ *                      `Set-NetFirewallHyperVVMSetting -Name
+ *                      '{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}'
+ *                      -DefaultInboundAction Allow`. Mirrored mode plus that
+ *                      setting puts wmux's control pipe on the LAN.
+ *
+ * The pipe token still authenticates every request in both cases, so mirrored
+ * mode is exposure rather than an open door. It is still not something to pick
+ * on the user's behalf from an inferred default, so the mode is read at runtime
+ * and `--wsl` refuses to choose `0.0.0.0` unless it has confirmed NAT. An
+ * explicit `--host 0.0.0.0` is always honoured — that is a stated choice.
+ *
+ * Everything here is pure so the decision can be tested off Windows entirely;
+ * `readWslEnvironment()` in wmux.ts does the I/O.
+ */
+
+export type WslNetworkingMode = 'nat' | 'mirrored' | 'unknown';
+
+export interface WslEnvironment {
+  /** `/proc/sys/kernel/osrelease`, or null when it could not be read. */
+  osRelease: string | null;
+  /** Whether WSL_INTEROP or WSL_DISTRO_NAME is set in the environment. */
+  hasInteropEnv: boolean;
+}
+
+/**
+ * Whether this process is inside a WSL distro at all.
+ *
+ * Both signals are required, because each is weak alone: the kernel string is
+ * whatever `/proc` says, which a container mounting its own `/proc` can differ
+ * on, and the env vars are inherited by anything a WSL shell launches —
+ * including a process that has since crossed into a container with its own
+ * network stack, which is precisely the case `--wsl` must not fire in.
+ *
+ * It does not separate WSL2 from WSL1, and does not need to: WSL1 predates
+ * `wslinfo` by years, so the mode comes back `unknown` there and the caller
+ * refuses to guess. WSL1 shares the Windows network stack outright, so the
+ * namespace argument `--wsl` rests on never applied to it anyway.
+ */
+export function isWsl2(env: WslEnvironment): boolean {
+  const release = (env.osRelease || '').toLowerCase();
+  const looksLikeWsl = release.includes('microsoft') || release.includes('wsl');
+  return looksLikeWsl && env.hasInteropEnv;
+}
+
+/**
+ * `wslinfo --networking-mode` prints one bare word. Anything else — the command
+ * missing (WSL older than 2.0.5), a non-zero exit, an unrecognised word — is
+ * `unknown`, which is treated as "not proven safe" rather than folded into the
+ * NAT default. Silently assuming the safe case is how an assumption stops being
+ * load-bearing and starts being a bug.
+ */
+export function parseNetworkingMode(output: string | null): WslNetworkingMode {
+  const word = (output || '').trim().toLowerCase();
+  if (word === 'nat') return 'nat';
+  if (word === 'mirrored') return 'mirrored';
+  return 'unknown';
+}
+
+export interface BindDecision {
+  /** Address to listen on, or null when the bridge must not start. */
+  host: string | null;
+  /** Lines to print before listening. */
+  notices: string[];
+  /** Reason to refuse, printed to stderr. Set exactly when host is null. */
+  error: string | null;
+}
+
+export interface BindRequest {
+  /** Value of --host, if the user passed one. */
+  explicitHost?: string;
+  /** Whether --wsl was passed. */
+  wslMode: boolean;
+  /** Whether this process is actually running under WSL2. */
+  inWsl2: boolean;
+  /** Networking mode as reported by wslinfo. */
+  mode: WslNetworkingMode;
+  /** Port, for the SSH-tunnel suggestion. */
+  port: number;
+}
+
+const isLoopback = (host: string): boolean =>
+  host === '127.0.0.1' || host === 'localhost' || host === '::1';
+
+/** How a bind beyond loopback is described, given what we know about the mode. */
+function exposureNotice(host: string, req: BindRequest): string[] {
+  if (req.inWsl2 && req.mode === 'mirrored') {
+    return [
+      `WARNING: mirrored networking — ${host} here is the Windows host's real interfaces, including the LAN`,
+      "and any VPN adapter, because a mirrored distro shares them instead of having its own namespace.",
+      "What stands between this bind and the LAN is the Hyper-V firewall's inbound policy, not the ordinary",
+      'Windows Firewall profile. The pipe token still authenticates every request, so this is exposure',
+      'rather than an open door — but bind the specific address the container needs, not 0.0.0.0, if you can.',
+    ];
+  }
+  if (req.inWsl2 && req.mode === 'nat') {
+    return [
+      `NAT networking: ${host} is the WSL2 network namespace, not the LAN — an eth0 on a private 172.x plus`,
+      "this distro's loopback, reachable from containers on this host and from nothing else, with no Windows",
+      'firewall rule involved. That stops being true under mirrored networking, which is why the mode is checked.',
+    ];
+  }
+  return [
+    `WARNING: binding ${host} exposes the wmux pipe beyond localhost.`,
+    `Prefer the default 127.0.0.1 + an SSH tunnel: ssh -L ${req.port}:127.0.0.1:${req.port} user@host`,
+  ];
+}
+
+/**
+ * The whole `--wsl` / `--host` decision in one place.
+ *
+ * An explicit `--host` always wins, including `--host 0.0.0.0` under mirrored
+ * mode: the user named the address, so the job here is to describe what they
+ * chose, not to overrule it. Only the implicit `0.0.0.0` that `--wsl` used to
+ * pick unconditionally is gated.
+ */
+export function chooseBridgeHost(req: BindRequest): BindDecision {
+  if (req.wslMode && !req.inWsl2) {
+    return {
+      host: null,
+      notices: [],
+      error:
+        '--wsl is for a bridge running inside a WSL2 distro, and this process is not in one ' +
+        '(looked for "microsoft"/"WSL2" in /proc/sys/kernel/osrelease and for WSL_INTEROP or ' +
+        'WSL_DISTRO_NAME in the environment). Drop --wsl for the 127.0.0.1 default, or name the ' +
+        'address you want with --host <addr>.',
+    };
+  }
+
+  if (req.explicitHost) {
+    return {
+      host: req.explicitHost,
+      notices: isLoopback(req.explicitHost) ? [] : exposureNotice(req.explicitHost, req),
+      error: null,
+    };
+  }
+
+  if (!req.wslMode) return { host: '127.0.0.1', notices: [], error: null };
+
+  if (req.mode === 'nat') {
+    return { host: '0.0.0.0', notices: exposureNotice('0.0.0.0', req), error: null };
+  }
+
+  if (req.mode === 'mirrored') {
+    return {
+      host: null,
+      notices: [],
+      error:
+        'refusing to pick 0.0.0.0 for you: this distro runs mirrored networking ' +
+        '(wslinfo --networking-mode reports "mirrored"), so it shares the Windows host\'s network ' +
+        'interfaces instead of having its own namespace. 0.0.0.0 here is a bind on the LAN and any ' +
+        'VPN adapter, gated only by the Hyper-V firewall\'s inbound policy — not the private 172.x ' +
+        'that --wsl assumes under NAT. Pass --host <addr> with the address the container actually ' +
+        'reaches, or --host 0.0.0.0 if you have weighed that and want it anyway.',
+    };
+  }
+
+  return {
+    host: null,
+    notices: [],
+    error:
+      'could not determine this distro\'s networking mode (wslinfo --networking-mode gave no usable ' +
+      'answer; it needs WSL 2.0.5 or newer). --wsl only picks 0.0.0.0 once it has confirmed NAT, ' +
+      'because under mirrored networking that address is the Windows host\'s real interfaces rather ' +
+      'than an isolated namespace. Check with `wslinfo --networking-mode`, then pass --host <addr> ' +
+      'explicitly.',
+  };
+}

--- a/src/main/pipe-server.ts
+++ b/src/main/pipe-server.ts
@@ -132,6 +132,7 @@ export class PipeServer extends EventEmitter {
     let args: string[];
     switch (command) {
       case 'report_pwd':
+      case 'report_startup_command':
       case 'notify':
         // Single free-text argument — may contain spaces (issue #53).
         args = argsRaw ? [argsRaw] : [];

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -198,8 +198,12 @@ function buildShellArgs(
     // strips every Windows env var, so the notification framework, sidebar and
     // `wmux` CLI inside WSL can't reach the host. /u = pass through, /up = pass
     // through AND translate the Windows path to a WSL mount (/mnt/c/...).
+    // WMUX_REMOTE / WMUX_REMOTE_TOKEN ride along so a devcontainer launched from
+    // this WSL shell inherits them and its CLI can reach wmux over the bridge
+    // (issue #19). Harmless when unset — WSLENV skips a variable with no value.
     const wmuxWslEnv =
-      'WMUX/u:WMUX_SURFACE_ID/u:WMUX_CLI/up:WMUX_PIPE/u:WMUX_PIPE_TOKEN/u:WMUX_INTEGRATION/u';
+      'WMUX/u:WMUX_SURFACE_ID/u:WMUX_CLI/up:WMUX_PIPE/u:WMUX_PIPE_TOKEN/u:WMUX_INTEGRATION/u'
+      + ':WMUX_REMOTE/u:WMUX_REMOTE_TOKEN/u';
     env.WSLENV = env.WSLENV ? `${env.WSLENV}:${wmuxWslEnv}` : wmuxWslEnv;
     // A restored WSL/POSIX cwd (issue #60) can't be a Win32 process cwd (error
     // 267). Open it INSIDE the distro via --cd instead; the Win32-side cwd is

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { v4 as uuid } from 'uuid';
 import { useStore } from './store';
-import { PaneId, SurfaceId, WorkspaceId, WorkspaceInfo, SplitNode } from '../shared/types';
+import { PaneId, SurfaceId, SurfaceRef, WorkspaceId, WorkspaceInfo, SplitNode } from '../shared/types';
 import { cwdReportPatch } from '../shared/paths';
 import SplitContainer from './components/SplitPane/SplitContainer';
 import { updateRatio, getAllPaneIds, findLeaf, replaceSoleTerminalSurface, freezeSurfaceCwds } from './store/split-utils';
@@ -284,6 +284,18 @@ function applyShellState(cmd: any, ws: WorkspaceInfo, deps: MetaDeps): void {
   fireNotification(cmd.surfaceId, ws.id, msg, deps.addNotification);
 }
 
+/** Apply a patch to one surface of `ws`, wherever in the split tree it lives. */
+function patchSurface(ws: WorkspaceInfo, surfaceId: SurfaceId, patch: Partial<SurfaceRef>): void {
+  const { updateSurface } = useStore.getState();
+  for (const paneId of getAllPaneIds(ws.splitTree)) {
+    const leaf = findLeaf(ws.splitTree, paneId);
+    if (leaf?.surfaces.some((s) => s.id === surfaceId)) {
+      updateSurface(ws.id, paneId, surfaceId, patch);
+      return;
+    }
+  }
+}
+
 /** Dispatch a surface-scoped metadata command to the owning workspace. */
 function handleSurfaceMetadata(cmd: any, ws: WorkspaceInfo, deps: MetaDeps): void {
   switch (cmd.command) {
@@ -294,16 +306,22 @@ function handleSurfaceMetadata(cmd: any, ws: WorkspaceInfo, deps: MetaDeps): voi
       // pane in the workspace gets `--cd ~`.
       deps.updateWorkspaceMetadata(ws.id, cwdReportPatch(pwd));
       // Also store cwd at the surface level so the tab label can show the project folder.
-      if (pwd && cmd.surfaceId) {
-        const { updateSurface } = useStore.getState();
-        for (const paneId of getAllPaneIds(ws.splitTree)) {
-          const leaf = findLeaf(ws.splitTree, paneId);
-          if (leaf?.surfaces.some((s) => s.id === cmd.surfaceId)) {
-            updateSurface(ws.id, paneId, cmd.surfaceId, { currentCwd: pwd });
-            break;
-          }
-        }
-      }
+      if (pwd && cmd.surfaceId) patchSurface(ws, cmd.surfaceId, { currentCwd: pwd });
+      break;
+    }
+    case 'report_startup_command': {
+      // A shell declares how to bring its own surface back after a restart —
+      // a devcontainer shell reports the launcher that re-enters the container,
+      // so a restored pane starts in WSL and runs it (issue #19). Reported per
+      // surface, stored per surface: two containers in one pane restore to two
+      // different containers. No argument clears it.
+      //
+      // The command must be cwd-independent (`cd '<path>' && …`): the restored
+      // pane's shell is a fresh login shell whose rc files have had their say,
+      // so nothing guarantees it starts where the reporting shell was.
+      if (!cmd.surfaceId) break;
+      const command = cmd.args?.[0];
+      patchSurface(ws, cmd.surfaceId, { startupCommands: command ? [command] : undefined });
       break;
     }
     case 'report_git_branch':

--- a/src/shell-integration/wmux-bash-integration.sh
+++ b/src/shell-integration/wmux-bash-integration.sh
@@ -10,7 +10,20 @@ export -f wmux
 
 _wmux_report() {
     local msg="$1"
-    # Write to temp file for main process to pick up
+    # Devcontainer transport (issue #19): a shell inside a Linux container can
+    # reach neither the Windows named pipe nor the host's Temp dir, so the file
+    # drop below is a no-op there and the pane never reports anything. When
+    # WMUX_REMOTE is set, relay the same V1 line through `wmux raw-v1` instead —
+    # the `wmux` shim resolves to `node "$WMUX_CLI"`, which already speaks TCP to
+    # a `wmux bridge` (issue #78). No protocol is duplicated here.
+    #
+    # Fire-and-forget: backgrounded with output discarded, so a slow or absent
+    # bridge delays no prompt and fails no command.
+    if [ -n "${WMUX_REMOTE}" ] && command -v wmux &>/dev/null; then
+        ( wmux raw-v1 "$msg" >/dev/null 2>&1 & )
+        return
+    fi
+    # Native: write to temp file for the main process to pick up
     local tmpdir="/mnt/c/Users/${USER}/AppData/Local/Temp/wmux"
     mkdir -p "$tmpdir" 2>/dev/null
     echo "$msg" >> "$tmpdir/messages"

--- a/tests/unit/packaging.test.ts
+++ b/tests/unit/packaging.test.ts
@@ -91,4 +91,49 @@ describe('electron-builder packaging', () => {
   it('ships the OpenCode plugin (#149)', () => {
     expect(extraResources).toContainEqual({ from: 'resources/opencode-plugin', to: 'opencode-plugin' });
   });
+
+  /**
+   * The CLI files are packaged one by one, not as a directory, so anything they
+   * `require` from beside themselves has to be listed too — and unlike the
+   * resource lookups above, a miss here is not a silently-absent feature but a
+   * MODULE_NOT_FOUND on the first line of `wmux ping` and of every Claude Code
+   * hook. `npm run dev` cannot see it: the module is right there in dist/.
+   *
+   * Derived rather than enumerated, for the same reason as the scan above — a
+   * list of the ones we already know about is what #149 walked past.
+   */
+  function siblingImports(entry: string): string[] {
+    const seen = new Set<string>();
+    const queue = [entry];
+    while (queue.length) {
+      const name = queue.shift() as string;
+      const file = path.join(repoRoot, 'src/cli', `${name}.ts`);
+      if (!fs.existsSync(file)) continue;
+      for (const m of fs.readFileSync(file, 'utf8').matchAll(/(?:from|require\()\s*['"]\.\/([^'"]+)['"]/g)) {
+        if (!seen.has(m[1])) { seen.add(m[1]); queue.push(m[1]); }
+      }
+    }
+    return [...seen];
+  }
+
+  it('packages every sibling module the shipped CLI files require', () => {
+    const entries = extraResources
+      .filter((e) => e.from.startsWith('dist/cli/'))
+      .map((e) => path.basename(e.from, '.js'));
+    const shipped = new Set(entries);
+    const missing: string[] = [];
+    for (const entry of entries) {
+      for (const dep of siblingImports(entry)) {
+        if (!shipped.has(dep)) missing.push(`dist/cli/${dep}.js (required by ${entry}.js)`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('finds the sibling imports it is meant to be checking', () => {
+    // Guards the guard: if the CLI stops sharing modules this goes vacuous, and
+    // the next one added would slip through unnoticed.
+    expect(siblingImports('wmux')).toContain('transport-deadline');
+    expect(siblingImports('wmux-hook')).toContain('transport-deadline');
+  });
 });

--- a/tests/unit/pipe-server.test.ts
+++ b/tests/unit/pipe-server.test.ts
@@ -59,6 +59,26 @@ describe('PipeServer', () => {
     expect(commands[0].args).toEqual(['C:\\Users\\test']);
   });
 
+  // A restore command is a whole shell line — `cd '/some/path' && ./relaunch.sh`
+  // (issue #19). Splitting it on whitespace like the default V1 case would turn
+  // it into eight useless args, so it joins report_pwd/notify in the
+  // single-free-text-argument group.
+  it('keeps a report_startup_command line intact, spaces and all', async () => {
+    const pipe = uniquePipe();
+    server = new PipeServer(pipe, 'test-token');
+    const commands: any[] = [];
+    server.on('v1', (cmd) => commands.push(cmd));
+    server.start();
+    await new Promise(r => setTimeout(r, 200));
+
+    const line = "cd '/workspaces/my project' && ./relaunch.sh --attach";
+    const response = await connectAndSend(pipe, `auth test-token report_startup_command surf-123 ${line}`);
+    expect(response).toBe('ok');
+    expect(commands[0].command).toBe('report_startup_command');
+    expect(commands[0].surfaceId).toBe('surf-123');
+    expect(commands[0].args).toEqual([line]);
+  });
+
   it('rejects V1 state updates without a token', async () => {
     const pipe = uniquePipe();
     server = new PipeServer(pipe, 'secret');

--- a/tests/unit/raw-v1-allowlist.test.ts
+++ b/tests/unit/raw-v1-allowlist.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { RAW_V1_VERBS, rawV1Error } from '../../src/cli/wmux';
+
+/**
+ * `wmux raw-v1` exists so the bash integration can report shell state from
+ * inside a devcontainer, where it cannot reach the pipe directly (issue #19).
+ * It began as a generic passthrough: whatever line you handed it went to the V1
+ * handler.
+ *
+ * That makes it a standing side door. Every V1 command added later becomes
+ * reachable from a container the day it lands, without anyone deciding it should
+ * be, and the V1 surface stops being defined by the V1 handler alone. The set
+ * the integration actually emits is six verbs long, so name them.
+ */
+
+const INTEGRATION = path.resolve(__dirname, '../../src/shell-integration/wmux-bash-integration.sh');
+
+describe('raw-v1 allowlist', () => {
+  it('accepts every verb the shipped bash integration emits', () => {
+    // Read from the script rather than restating the list: the allowlist and the
+    // integration drifting apart is the one failure that breaks reporting in a
+    // container, and it would otherwise be invisible until someone ran one.
+    const emitted = [...fs.readFileSync(INTEGRATION, 'utf8').matchAll(/_wmux_report "([a-z_]+)/g)].map((m) => m[1]);
+    expect(emitted.length).toBeGreaterThan(0);
+    for (const verb of new Set(emitted)) {
+      expect(rawV1Error(verb), `${verb} is emitted by the integration but not allowlisted`).toBeNull();
+    }
+  });
+
+  it('accepts report_startup_command, which comes from the devcontainer side', () => {
+    // Not in the shipped script — the devcontainer feature appends it to its own
+    // copy so a restored pane can be relaunched. Asserted separately so the loop
+    // above staying green does not hide its removal.
+    expect(rawV1Error('report_startup_command')).toBeNull();
+  });
+
+  it('rejects a V1 verb the integration does not emit, naming the accepted set', () => {
+    // notify and report_pr are real V1 commands the pipe server handles. They are
+    // not the shell integration's to send, so they are not reachable this way.
+    for (const verb of ['notify', 'report_pr']) {
+      const err = rawV1Error(verb);
+      expect(err).toContain(verb);
+      expect(err).toContain('report_pwd');
+    }
+  });
+
+  it('rejects an unknown verb rather than passing it through', () => {
+    expect(rawV1Error('rm')).toMatch(/not a passthrough command/);
+  });
+
+  it('prints usage when no verb is given at all', () => {
+    expect(rawV1Error(undefined)).toMatch(/^Usage: wmux raw-v1/);
+    expect(rawV1Error('')).toMatch(/^Usage: wmux raw-v1/);
+  });
+
+  it('matches on the verb alone, not on the rest of the line', () => {
+    // args[1] is the verb; the surface id and payload follow as separate argv
+    // entries, so a path with spaces cannot turn a good verb into a bad one.
+    expect(rawV1Error('report_pwd')).toBeNull();
+    // ...and a verb cannot be smuggled in by gluing it to another one.
+    expect(rawV1Error('report_pwd notify')).toMatch(/not a passthrough command/);
+  });
+
+  it('is the six verbs and no more', () => {
+    expect([...RAW_V1_VERBS].sort()).toEqual([
+      'clear_git_branch',
+      'ports_kick',
+      'report_git_branch',
+      'report_pwd',
+      'report_shell_state',
+      'report_startup_command',
+    ]);
+  });
+});

--- a/tests/unit/transport-deadline.test.ts
+++ b/tests/unit/transport-deadline.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  DEFAULT_V2_TIMEOUT_MS,
+  SLOW_TRANSPORT_FLOOR_MS,
+  isSlowTransport,
+  transportDeadline,
+  usesNpiperelay,
+  type Transport,
+} from '../../src/cli/transport-deadline';
+
+/**
+ * The CLI and the Claude Code hook helper are two processes talking to the same
+ * socket, and they each used to carry their own deadline. The CLI derived one
+ * from the transport; the hook wrote `remote ? 30000 : 5000`. Same intent, two
+ * spellings, and the hook's did not know about npiperelay — so a WSL hook armed
+ * a 5s timer for a hop that measures ~7s and destroyed the socket mid-flight.
+ *
+ * Sharing the derivation is the fix. These tests cover the derivation itself and
+ * then check the two call sites still go through it, because a re-hardcoded
+ * literal is exactly how this came back the first time.
+ */
+
+const WIN_PIPE = '\\\\.\\pipe\\wmux';
+
+const t = (over: Partial<Transport> = {}): Transport => ({
+  remote: false,
+  pipePath: WIN_PIPE,
+  env: {},
+  ...over,
+});
+
+describe('usesNpiperelay', () => {
+  it('is true only for a Windows pipe path dialled from inside WSL', () => {
+    expect(usesNpiperelay(t({ env: { WSL_DISTRO_NAME: 'Ubuntu' } }))).toBe(true);
+    expect(usesNpiperelay(t({ env: { WSLENV: 'PATH/l' } }))).toBe(true);
+    // Native Windows: the pipe is dialled directly.
+    expect(usesNpiperelay(t({ env: {} }))).toBe(false);
+    // A POSIX socket path is not a Windows pipe, whatever the environment says.
+    expect(usesNpiperelay(t({ pipePath: '/tmp/wmux.sock', env: { WSL_DISTRO_NAME: 'Ubuntu' } }))).toBe(false);
+  });
+
+  it('is false when a remote target has taken over the transport', () => {
+    // TCP to a bridge replaces the local hop; there is no pipe left to relay.
+    expect(usesNpiperelay(t({ remote: true, env: { WSL_DISTRO_NAME: 'Ubuntu' } }))).toBe(false);
+  });
+});
+
+describe('transportDeadline', () => {
+  it('leaves a local pipe exactly as it was', () => {
+    // The floor must not move timings for the platform wmux ships for.
+    expect(transportDeadline(DEFAULT_V2_TIMEOUT_MS, t())).toBe(DEFAULT_V2_TIMEOUT_MS);
+    expect(transportDeadline(45000, t())).toBe(45000);
+  });
+
+  it('raises a short deadline to the floor on both slow transports', () => {
+    for (const slow of [t({ remote: true }), t({ env: { WSL_DISTRO_NAME: 'Ubuntu' } })]) {
+      expect(isSlowTransport(slow)).toBe(true);
+      expect(transportDeadline(DEFAULT_V2_TIMEOUT_MS, slow)).toBe(SLOW_TRANSPORT_FLOOR_MS);
+    }
+  });
+
+  it('is a floor, not a replacement — a browser verb keeps its longer budget', () => {
+    expect(transportDeadline(45000, t({ remote: true }))).toBe(45000);
+  });
+
+  it('lets WMUX_RPC_TIMEOUT_MS lengthen a deadline but never shorten one', () => {
+    const env = { WMUX_RPC_TIMEOUT_MS: '90000' };
+    expect(transportDeadline(DEFAULT_V2_TIMEOUT_MS, t({ env }))).toBe(90000);
+    // Below the base it cannot truncate: the override is itself a floor, so
+    // setting it can never cause the mid-flight cutoff this all exists to avoid.
+    expect(transportDeadline(45000, t({ env: { WMUX_RPC_TIMEOUT_MS: '1000' } }))).toBe(45000);
+  });
+
+  it('ignores an override that is not a positive number', () => {
+    for (const raw of ['', 'soon', '0', '-1', 'NaN']) {
+      expect(transportDeadline(DEFAULT_V2_TIMEOUT_MS, t({ env: { WMUX_RPC_TIMEOUT_MS: raw } }))).toBe(
+        DEFAULT_V2_TIMEOUT_MS,
+      );
+    }
+  });
+});
+
+describe('the CLI and the hook agree', () => {
+  const read = (f: string): string => fs.readFileSync(path.resolve(__dirname, '../../src/cli', f), 'utf8');
+
+  it('both derive their deadline from this module', () => {
+    for (const file of ['wmux.ts', 'wmux-hook.ts']) {
+      expect(read(file), `${file} should import the shared derivation`).toMatch(
+        /from '\.\/transport-deadline'/,
+      );
+    }
+  });
+
+  it('neither declares its own copy of the two constants', () => {
+    // The literals belong in transport-deadline.ts and nowhere else. This is the
+    // regression that already happened once, so it is asserted rather than
+    // trusted: `remote ? 30000 : 5000` in the hook was a copy of the CLI's rule
+    // that stopped tracking it. (A bare /30000/ scan would be stricter but wrong
+    // — wmux.ts legitimately spends 30s elsewhere, on CDP navigation and the
+    // warm-pool backoff.)
+    for (const file of ['wmux.ts', 'wmux-hook.ts']) {
+      const code = read(file).replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, '');
+      expect(code, `${file} should import the floor, not redeclare it`).not.toMatch(
+        /const\s+(DEFAULT_V2_TIMEOUT_MS|SLOW_TRANSPORT_FLOOR_MS)\s*=/,
+      );
+      // The hook's original spelling, in any arrangement of the ternary.
+      expect(code, `${file} should not pick a deadline inline`).not.toMatch(
+        /\?[^;]*\b(30000|5000)\b[^;]*:[^;]*\b(30000|5000)\b/,
+      );
+    }
+  });
+
+  it('gives the same answer for the same connection', () => {
+    // Both describe a connection with {remote, pipePath, env} and get one number
+    // back, so "the hook waits 5s where the CLI waits 30s" cannot recur without
+    // one of them ceasing to call this.
+    const inContainer = t({ remote: true, pipePath: WIN_PIPE, env: {} });
+    const inWsl = t({ remote: false, pipePath: WIN_PIPE, env: { WSL_DISTRO_NAME: 'Ubuntu' } });
+    expect(transportDeadline(DEFAULT_V2_TIMEOUT_MS, inContainer)).toBe(SLOW_TRANSPORT_FLOOR_MS);
+    expect(transportDeadline(DEFAULT_V2_TIMEOUT_MS, inWsl)).toBe(SLOW_TRANSPORT_FLOOR_MS);
+  });
+});

--- a/tests/unit/wmux-bridge-transport.test.ts
+++ b/tests/unit/wmux-bridge-transport.test.ts
@@ -28,11 +28,19 @@ function freePort(): Promise<number> {
   });
 }
 
-// Spawn `node wmux.js bridge --wsl --port <port>` and resolve once it logs that
-// it is listening. Returns the child so the test can kill it in afterEach.
+// Spawn `node wmux.js bridge --port <port>` and resolve once it logs that it is
+// listening. Returns the child so the test can kill it in afterEach.
+//
+// Deliberately without --wsl. Every test here connects over 127.0.0.1, so the
+// flag only ever chose the bind ADDRESS, which is a separate question from the
+// upstream transport these tests are about — and it is now a claim the CLI
+// verifies against the running environment rather than a synonym for "bind
+// 0.0.0.0". Passing it here would make the suite fail wherever it happens to run
+// outside a real WSL2 distro, for reasons unrelated to what is being asserted.
+// The bind decision has its own table test in wsl-network.test.ts.
 function startBridge(port: number, env: Record<string, string>): Promise<ChildProcess> {
   return new Promise((resolve, reject) => {
-    const child = spawn('node', [BRIDGE_SCRIPT, 'bridge', '--wsl', '--port', String(port)], { env });
+    const child = spawn('node', [BRIDGE_SCRIPT, 'bridge', '--port', String(port)], { env });
     const timer = setTimeout(() => reject(new Error('bridge did not start listening in time')), 5000);
     child.stdout.on('data', (chunk: Buffer) => {
       if (chunk.toString().includes('listening')) {
@@ -65,6 +73,39 @@ describe('wmux bridge transport selection (WSL2 devcontainer path)', () => {
 
   afterEach(() => {
     while (cleanups.length) cleanups.pop()!();
+  });
+
+  // The one thing about --wsl that a pure function cannot cover: whether the
+  // environment probe reads what it thinks it reads. chooseBridgeHost() is given
+  // `inWsl2`; readWslEnvironment() is what has to produce it, from
+  // /proc/sys/kernel/osrelease and the interop vars, on the real machine.
+  //
+  // Worth an end-to-end assertion because the obvious spelling of that probe is
+  // wrong in a way that is easy to ship: a Linux container on a Windows host runs
+  // on the WSL2 KERNEL, so its osrelease says "microsoft-standard-WSL2" while it
+  // is emphatically not a WSL2 distro with a Windows host to reach. Matching
+  // osrelease alone would bind 0.0.0.0 in every devcontainer on Windows. The
+  // interop vars are what tell the two apart — and this suite runs in exactly
+  // that container, so the case is covered rather than imagined.
+  it.skipIf(isWslRuntime || process.platform === 'win32')('refuses --wsl outside a WSL2 distro rather than binding 0.0.0.0', async () => {
+    const port = await freePort();
+    const { code, stderr } = await new Promise<{ code: number | null; stderr: string }>((resolve, reject) => {
+      const child = spawn('node', [BRIDGE_SCRIPT, 'bridge', '--wsl', '--port', String(port)], {
+        env: { ...process.env, WMUX_REMOTE: '', WMUX_PIPE: '' } as Record<string, string>,
+      });
+      let err = '';
+      child.stderr.on('data', (c: Buffer) => { err += c.toString(); });
+      child.on('error', reject);
+      child.on('exit', (c) => resolve({ code: c, stderr: err }));
+    });
+
+    expect(code).toBe(1);
+    // Naming what it looked for, so the failure is actionable rather than a bare
+    // refusal the user has to guess at.
+    expect(stderr).toContain('--wsl');
+    expect(stderr).toMatch(/osrelease|WSL_INTEROP|WSL_DISTRO_NAME/);
+    // And it must point at the way forward, not just the way blocked.
+    expect(stderr).toContain('--host');
   });
 
   it.skipIf(process.platform === 'win32')('relays TCP ↔ a Unix-socket upstream when WMUX_PIPE is a /path', async () => {

--- a/tests/unit/wmux-bridge-transport.test.ts
+++ b/tests/unit/wmux-bridge-transport.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawn, ChildProcess } from 'child_process';
+import net from 'net';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Exercises the real compiled wmux.js (resources/cli/wmux.js) `bridge` command
+// end-to-end. `wmux bridge` is a pure byte relay: it accepts TCP connections and
+// forwards them to the local wmux via connectTransport(). This verifies the two
+// non-TCP transport branches the bridge must pick between:
+//   * WMUX_PIPE=/path        → Unix-socket upstream
+//   * inside WSL2            → spawn npiperelay.exe and use its stdio
+// so a `wmux bridge` running inside WSL2 reaches the Windows-host named pipe.
+
+const BRIDGE_SCRIPT = path.resolve(__dirname, '../../resources/cli/wmux.js');
+
+// Bind to :0 to discover a free port, then release it for the bridge to reuse.
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+// Spawn `node wmux.js bridge --wsl --port <port>` and resolve once it logs that
+// it is listening. Returns the child so the test can kill it in afterEach.
+function startBridge(port: number, env: Record<string, string>): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [BRIDGE_SCRIPT, 'bridge', '--wsl', '--port', String(port)], { env });
+    const timer = setTimeout(() => reject(new Error('bridge did not start listening in time')), 5000);
+    child.stdout.on('data', (chunk: Buffer) => {
+      if (chunk.toString().includes('listening')) {
+        clearTimeout(timer);
+        resolve(child);
+      }
+    });
+    child.on('error', (err) => { clearTimeout(timer); reject(err); });
+    child.on('exit', (code) => { clearTimeout(timer); reject(new Error(`bridge exited early (code ${code})`)); });
+  });
+}
+
+// Round-trip a payload through the bridge: connect over TCP, send, and collect
+// whatever the (echoing) upstream sends back.
+function roundTrip(port: number, payload: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const sock = net.connect({ host: '127.0.0.1', port }, () => sock.write(payload));
+    let received = '';
+    sock.on('data', (chunk) => { received += chunk.toString(); });
+    sock.on('end', () => resolve(received));
+    sock.on('close', () => resolve(received));
+    sock.on('error', reject);
+    setTimeout(() => { sock.destroy(); resolve(received); }, 2000);
+  });
+}
+
+describe('wmux bridge transport selection (WSL2 devcontainer path)', () => {
+  const cleanups: Array<() => void> = [];
+  const isWslRuntime = Boolean(process.env.WSL_DISTRO_NAME || process.env.WSLENV);
+
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()!();
+  });
+
+  it.skipIf(process.platform === 'win32')('relays TCP ↔ a Unix-socket upstream when WMUX_PIPE is a /path', async () => {
+    // Stand-in for the local pipe: a Unix-socket echo server.
+    const sockPath = path.join(os.tmpdir(), `wmux-bridge-test-${process.pid}.sock`);
+    try { fs.unlinkSync(sockPath); } catch { /* not present */ }
+    const upstream = net.createServer((c) => c.pipe(c)); // echo
+    await new Promise<void>((r) => upstream.listen(sockPath, r));
+    cleanups.push(() => { upstream.close(); try { fs.unlinkSync(sockPath); } catch { /* gone */ } });
+
+    const port = await freePort();
+    // WMUX_PIPE starting with '/' selects the Unix-socket branch regardless of
+    // WSL detection, so this branch needs no fake npiperelay. WMUX_REMOTE must
+    // be cleared: it takes precedence (TCP) and is set when this suite itself
+    // runs inside a wmux devcontainer.
+    const child = await startBridge(port, {
+      ...process.env,
+      WMUX_REMOTE: '',
+      WMUX_REMOTE_TOKEN: '',
+      WMUX_PIPE: sockPath,
+    } as Record<string, string>);
+    cleanups.push(() => child.kill());
+
+    const echoed = await roundTrip(port, 'ping-unix\n');
+    expect(echoed).toContain('ping-unix');
+  });
+
+  it.skipIf(!isWslRuntime)('relays TCP ↔ npiperelay.exe stdio when running inside WSL2', async () => {
+    // Fake npiperelay.exe: ignores its args (-ei -s //./pipe/wmux) and echoes
+    // stdin→stdout, standing in for the Windows named pipe over interop.
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-npiperelay-'));
+    const fakeBin = path.join(binDir, 'npiperelay.exe');
+    fs.writeFileSync(fakeBin, '#!/usr/bin/env node\nprocess.stdin.pipe(process.stdout);\n');
+    fs.chmodSync(fakeBin, 0o755);
+    cleanups.push(() => fs.rmSync(binDir, { recursive: true, force: true }));
+
+    const port = await freePort();
+    // WSL_DISTRO_NAME set + WMUX_PIPE cleared (falls back to the \\.\pipe\wmux
+    // default, which is not a '/path') selects the npiperelay branch;
+    // findNpiperelay() picks up our fake via PATH.
+    const child = await startBridge(port, {
+      ...process.env,
+      WMUX_PIPE: '',
+      WMUX_REMOTE: '',
+      WSL_DISTRO_NAME: 'test-distro',
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+    } as Record<string, string>);
+    cleanups.push(() => child.kill());
+
+    const echoed = await roundTrip(port, 'ping-npiperelay\n');
+    expect(echoed).toContain('ping-npiperelay');
+  });
+
+  // Regression: the bridge used to destroy BOTH sides on either 'close', so a
+  // client that wrote a frame and closed immediately — which is exactly what
+  // wmux-hook.js does for every Claude Code hook — had its frame killed inside a
+  // still-draining npiperelay relay (the Duplex's destroy() is child.kill()). The
+  // hook exited 0, the sidebar never updated, and nothing logged an error.
+  //
+  // Measured against a live bridge before the fix, delivery depended purely on how
+  // long the client held the socket open relative to the ~7s pipe round-trip:
+  //     end() after 0ms ✗   2000ms ✗   6000ms ~   9000ms ✓
+  // 0ms is what the hook actually does, hence the bug.
+  it.skipIf(!isWslRuntime)('delivers a frame from a client that closes immediately, even to a slow relay', async () => {
+    // Fake npiperelay that takes its time, standing in for a real one that needs
+    // seconds to attach to the Windows pipe over WSL interop. It records what it
+    // received to a file, so the assertion is "the upstream actually got the
+    // bytes" rather than "a reply came back" — pre-fix the relay is killed before
+    // either could happen.
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-slowrelay-'));
+    const fakeBin = path.join(binDir, 'npiperelay.exe');
+    const received = path.join(binDir, 'received.txt');
+    const RELAY_DELAY_MS = 1500;
+    fs.writeFileSync(
+      fakeBin,
+      '#!/usr/bin/env node\n' +
+        "const fs = require('fs');\n" +
+        "let buf = '';\n" +
+        "process.stdin.on('data', (d) => { buf += d; });\n" +
+        // Forward only once stdin has been ENDED and the delay has elapsed. A
+        // bridge that kills us on client close never gets here.
+        "process.stdin.on('end', () => {\n" +
+        `  setTimeout(() => { fs.writeFileSync(${JSON.stringify(received)}, buf); process.stdout.write(buf); }, ${RELAY_DELAY_MS});\n` +
+        '});\n'
+    );
+    fs.chmodSync(fakeBin, 0o755);
+    cleanups.push(() => fs.rmSync(binDir, { recursive: true, force: true }));
+
+    const port = await freePort();
+    const child = await startBridge(port, {
+      ...process.env,
+      WMUX_PIPE: '',
+      WMUX_REMOTE: '',
+      WSL_DISTRO_NAME: 'test-distro',
+      // Comfortably longer than RELAY_DELAY_MS, short enough to keep the suite
+      // quick. Pinned rather than inherited so the test does not depend on the
+      // shipped default.
+      WMUX_BRIDGE_DRAIN_MS: '8000',
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+    } as Record<string, string>);
+    cleanups.push(() => child.kill());
+
+    // The bug trigger: write one frame, then close at once without awaiting a reply.
+    const frame = JSON.stringify({ method: 'hook.event', params: { event: 'Notification' }, id: 1 });
+    await new Promise<void>((resolve, reject) => {
+      const sock = net.connect({ host: '127.0.0.1', port }, () => {
+        sock.write(frame + '\n', () => sock.end());
+      });
+      sock.on('close', () => resolve());
+      sock.on('error', reject);
+    });
+
+    // Poll rather than sleep a fixed span, so a fast machine finishes early and a
+    // slow one still gets its full window.
+    const deadline = Date.now() + RELAY_DELAY_MS + 6000;
+    let got = '';
+    while (Date.now() < deadline) {
+      if (fs.existsSync(received)) {
+        got = fs.readFileSync(received, 'utf-8');
+        if (got.includes('hook.event')) break;
+      }
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    expect(got).toContain('hook.event');
+  }, 20000);
+
+  // The other half of the devcontainer latency problem: the bridge used to spawn a
+  // fresh npiperelay.exe per connection, so every hook paid the exec (AV/EDR-scanned
+  // on a corporate host) plus the pipe dial — ~7s measured. The pool spawns relays
+  // ahead of demand so a client gets one already attached.
+  describe('warm relay pool', () => {
+    // Fake npiperelay that records each spawn to a log file, then echoes. Counting
+    // the log is how the test distinguishes "pre-warmed" from "spawned on demand".
+    function makeCountingRelay(): { binDir: string; spawnLog: string } {
+      const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-warm-'));
+      const spawnLog = path.join(binDir, 'spawns.log');
+      fs.writeFileSync(
+        path.join(binDir, 'npiperelay.exe'),
+        '#!/usr/bin/env node\n' +
+          `require('fs').appendFileSync(${JSON.stringify(spawnLog)}, 'x');\n` +
+          'process.stdin.pipe(process.stdout);\n'
+      );
+      fs.chmodSync(path.join(binDir, 'npiperelay.exe'), 0o755);
+      return { binDir, spawnLog };
+    }
+
+    const spawnCount = (logPath: string): number =>
+      (fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf-8').length : 0);
+
+    async function waitFor(fn: () => boolean, timeoutMs = 5000): Promise<void> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline && !fn()) await new Promise((r) => setTimeout(r, 50));
+    }
+
+    it.skipIf(!isWslRuntime)('spawns relays before any client connects, and refills after one is claimed', async () => {
+      const { binDir, spawnLog } = makeCountingRelay();
+      cleanups.push(() => fs.rmSync(binDir, { recursive: true, force: true }));
+
+      const port = await freePort();
+      const child = await startBridge(port, {
+        ...process.env,
+        WMUX_PIPE: '',
+        WMUX_REMOTE: '',
+        WSL_DISTRO_NAME: 'test-distro',
+        WMUX_BRIDGE_WARM: '2',
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      } as Record<string, string>);
+      cleanups.push(() => child.kill());
+
+      // Pre-warm happens in the listen callback — no client has connected yet.
+      await waitFor(() => spawnCount(spawnLog) >= 2);
+      expect(spawnCount(spawnLog)).toBe(2);
+
+      // The warm relay must be a working transport, not just a spawned process.
+      expect(await roundTrip(port, 'ping-warm\n')).toContain('ping-warm');
+
+      // Claiming one triggers a replacement, so the next client is served warm too.
+      await waitFor(() => spawnCount(spawnLog) >= 3);
+      expect(spawnCount(spawnLog)).toBe(3);
+    }, 20000);
+
+    it.skipIf(!isWslRuntime)('spawns nothing ahead of time when WMUX_BRIDGE_WARM=0', async () => {
+      const { binDir, spawnLog } = makeCountingRelay();
+      cleanups.push(() => fs.rmSync(binDir, { recursive: true, force: true }));
+
+      const port = await freePort();
+      const child = await startBridge(port, {
+        ...process.env,
+        WMUX_PIPE: '',
+        WMUX_REMOTE: '',
+        WSL_DISTRO_NAME: 'test-distro',
+        WMUX_BRIDGE_WARM: '0',
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      } as Record<string, string>);
+      cleanups.push(() => child.kill());
+
+      await new Promise((r) => setTimeout(r, 500));
+      expect(spawnCount(spawnLog)).toBe(0);
+
+      // Opting out restores spawn-per-connection, which must still work.
+      expect(await roundTrip(port, 'ping-cold\n')).toContain('ping-cold');
+      expect(spawnCount(spawnLog)).toBe(1);
+    }, 20000);
+  });
+});

--- a/tests/unit/wmux-hook-remote-transport.test.ts
+++ b/tests/unit/wmux-hook-remote-transport.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFile } from 'child_process';
+import net from 'net';
+import path from 'path';
+
+// Exercises the real compiled wmux-hook.js (resources/cli/wmux-hook.js) over
+// its TCP remote-mode transport (WMUX_REMOTE, issue #19/#78) against a raw
+// TCP server standing in for `wmux bridge`. Unlike the named-pipe path, this
+// script has no exported functions to unit test directly (it's a
+// fire-and-forget CLI leaf), so we verify its actual process behavior
+// end-to-end instead.
+
+const HOOK_SCRIPT = path.resolve(__dirname, '../../resources/cli/wmux-hook.js');
+
+function runHook(args: string[], env: Record<string, string>, stdin = ''): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = execFile('node', [HOOK_SCRIPT, ...args], { env, timeout: 5000 }, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+    child.stdin?.end(stdin);
+  });
+}
+
+function startCapturingServer(): Promise<{ port: number; requests: Promise<any>; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    let resolveRequest: (v: any) => void;
+    const requests = new Promise<any>((r) => { resolveRequest = r; });
+
+    const server = net.createServer((socket) => {
+      let data = '';
+      socket.on('data', (chunk) => {
+        data += chunk.toString();
+        if (data.includes('\n')) {
+          resolveRequest(JSON.parse(data.trim()));
+          socket.end();
+        }
+      });
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({ port, requests, close: () => new Promise((r) => server.close(() => r())) });
+    });
+  });
+}
+
+describe('wmux-hook.js TCP remote-mode transport (issue #19)', () => {
+  let close: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (close) await close();
+    close = undefined;
+  });
+
+  it('sends hook.event over TCP with the token when WMUX_REMOTE is set', async () => {
+    const server = await startCapturingServer();
+    close = server.close;
+
+    await runHook(['Bash'], {
+      ...process.env,
+      WMUX_REMOTE: `127.0.0.1:${server.port}`,
+      WMUX_REMOTE_TOKEN: 'secret-token',
+      WMUX_SURFACE_ID: 'pane-1',
+    } as Record<string, string>);
+
+    const req = await server.requests;
+    expect(req.method).toBe('hook.event');
+    expect(req.token).toBe('secret-token');
+    // Same frame the pipe path sends, including the `at` fire stamp wmux orders
+    // racing hook processes by (issue #151) — the transport is all that differs.
+    expect(req.params).toEqual({ tool: 'Bash', surfaceId: 'pane-1', at: expect.any(Number) });
+    expect(req.params.at).toBeGreaterThan(0);
+  });
+
+  it('includes file_path from PostToolUse Edit/Write stdin payloads', async () => {
+    const server = await startCapturingServer();
+    close = server.close;
+
+    await runHook(
+      ['Edit'],
+      { ...process.env, WMUX_REMOTE: `127.0.0.1:${server.port}`, WMUX_REMOTE_TOKEN: 't', WMUX_SURFACE_ID: 'pane-2' } as Record<string, string>,
+      JSON.stringify({ tool_input: { file_path: '/workspaces/repo/foo.ts' } }),
+    );
+
+    const req = await server.requests;
+    expect(req.params).toEqual({ tool: 'Edit', file: '/workspaces/repo/foo.ts', surfaceId: 'pane-2', at: expect.any(Number) });
+  });
+
+  it('sends the --event flag as the event field for Notification/Stop', async () => {
+    const server = await startCapturingServer();
+    close = server.close;
+
+    await runHook(
+      ['--event', 'Notification'],
+      { ...process.env, WMUX_REMOTE: `127.0.0.1:${server.port}`, WMUX_REMOTE_TOKEN: 't', WMUX_SURFACE_ID: '' } as Record<string, string>,
+      JSON.stringify({ message: 'Permission needed' }),
+    );
+
+    const req = await server.requests;
+    expect(req.params).toEqual({ event: 'Notification', message: 'Permission needed', at: expect.any(Number) });
+  });
+
+  it('defaults to port 9787 when WMUX_REMOTE has no explicit port', async () => {
+    // Can't bind 9787 in a shared test env reliably, so just assert it doesn't
+    // fall back to the named pipe (would hang/error differently) — connection
+    // refused on the default port is the expected, quick failure mode here.
+    await expect(
+      runHook(['Bash'], {
+        ...process.env,
+        WMUX_REMOTE: '127.0.0.1',
+        WMUX_REMOTE_TOKEN: 't',
+      } as Record<string, string>),
+    ).resolves.toBeUndefined();
+  });
+
+  it('exits cleanly (does not hang or throw) when the remote target is unreachable', async () => {
+    await expect(
+      runHook(['Bash'], {
+        ...process.env,
+        WMUX_REMOTE: '127.0.0.1:1', // nothing listens on port 1
+        WMUX_REMOTE_TOKEN: 't',
+      } as Record<string, string>),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/wsl-network.test.ts
+++ b/tests/unit/wsl-network.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import {
+  chooseBridgeHost,
+  isWsl2,
+  parseNetworkingMode,
+  type BindRequest,
+  type WslNetworkingMode,
+} from '../../src/cli/wsl-network';
+
+/**
+ * `wmux bridge --wsl` used to pick `0.0.0.0` on the strength of a comment:
+ *
+ *     // WSL2's NAT gives the distro an address the container resolves as
+ *     // host.docker.internal, but 127.0.0.1 inside the distro is not it.
+ *
+ * True under NAT, and NAT is the default — but under `networkingMode=mirrored`
+ * the distro has no namespace of its own, it shares the Windows host's
+ * interfaces. `0.0.0.0` there is the LAN and any VPN adapter, held back only by
+ * the Hyper-V firewall's inbound policy, which the widely-copied "make WSL
+ * reachable" recipe sets to Allow. That is a configuration people run, not a
+ * hypothetical future WSL change, so the mode is checked rather than inferred.
+ *
+ * Pure functions, so the whole decision table runs on any platform — including
+ * the mirrored branch, which cannot be exercised on a NAT host.
+ */
+
+const req = (over: Partial<BindRequest> = {}): BindRequest => ({
+  wslMode: true,
+  inWsl2: true,
+  mode: 'nat',
+  port: 9787,
+  ...over,
+});
+
+describe('isWsl2', () => {
+  it('needs the kernel string and interop together, not either alone', () => {
+    const release = '5.15.167.4-microsoft-standard-WSL2';
+    expect(isWsl2({ osRelease: release, hasInteropEnv: true })).toBe(true);
+    // A container mounting its own /proc can carry the host's kernel string
+    // while having a network stack of its own — the case --wsl must not fire in.
+    expect(isWsl2({ osRelease: release, hasInteropEnv: false })).toBe(false);
+    // And the env vars are inherited by anything a WSL shell launches, including
+    // a process that has since crossed out of the distro.
+    expect(isWsl2({ osRelease: '6.6.87.2-generic', hasInteropEnv: true })).toBe(false);
+  });
+
+  it('says no when /proc could not be read at all', () => {
+    expect(isWsl2({ osRelease: null, hasInteropEnv: true })).toBe(false);
+  });
+});
+
+describe('parseNetworkingMode', () => {
+  it('reads the one word wslinfo prints, trailing newline and case included', () => {
+    expect(parseNetworkingMode('nat\n')).toBe('nat');
+    expect(parseNetworkingMode('  Mirrored  ')).toBe('mirrored');
+  });
+
+  it('calls anything it cannot read "unknown" rather than falling back to nat', () => {
+    // wslinfo predates WSL 2.0.5, so null is the ordinary answer on older WSL.
+    // Folding it into `nat` is exactly the assumption this module exists to stop
+    // making: it would restore the old silent 0.0.0.0 on every host too old to
+    // report, which is also every host most likely to be misconfigured.
+    for (const bad of [null, '', 'nat mirrored', 'bridged', 'error: unknown option']) {
+      expect(parseNetworkingMode(bad)).toBe('unknown');
+    }
+  });
+});
+
+describe('chooseBridgeHost', () => {
+  it('binds loopback and says nothing when --wsl is absent', () => {
+    const d = chooseBridgeHost(req({ wslMode: false, inWsl2: false, mode: 'unknown' }));
+    expect(d).toEqual({ host: '127.0.0.1', notices: [], error: null });
+  });
+
+  it('binds 0.0.0.0 under confirmed NAT, and says why that is contained', () => {
+    const d = chooseBridgeHost(req({ mode: 'nat' }));
+    expect(d.host).toBe('0.0.0.0');
+    expect(d.error).toBeNull();
+    expect(d.notices.join(' ')).toMatch(/NAT networking/);
+    expect(d.notices.join(' ')).toMatch(/not the LAN/);
+    // The point of saying it out loud is that it is conditional.
+    expect(d.notices.join(' ')).toMatch(/mirrored/);
+  });
+
+  it('refuses to pick 0.0.0.0 under mirrored networking', () => {
+    const d = chooseBridgeHost(req({ mode: 'mirrored' }));
+    expect(d.host).toBeNull();
+    expect(d.error).toMatch(/mirrored/);
+    // Name the mechanism, not just the verdict: someone reading this on a
+    // machine they administer needs to know which firewall decides.
+    expect(d.error).toMatch(/Hyper-V firewall/);
+    expect(d.error).toMatch(/--host/);
+  });
+
+  it('refuses when the mode could not be determined', () => {
+    const d = chooseBridgeHost(req({ mode: 'unknown' }));
+    expect(d.host).toBeNull();
+    expect(d.error).toMatch(/could not determine/);
+    expect(d.error).toMatch(/2\.0\.5/);
+  });
+
+  it('refuses --wsl outside a WSL distro, naming what it looked for', () => {
+    for (const mode of ['nat', 'mirrored', 'unknown'] as WslNetworkingMode[]) {
+      const d = chooseBridgeHost(req({ inWsl2: false, mode }));
+      expect(d.host).toBeNull();
+      expect(d.error).toMatch(/osrelease/);
+      expect(d.error).toMatch(/WSL_INTEROP/);
+    }
+  });
+
+  it('honours an explicit --host in every mode, including 0.0.0.0 under mirrored', () => {
+    // A stated choice, not an inherited default. Overruling it would just push
+    // people to a shell wrapper, and they would lose the warning with it.
+    for (const mode of ['nat', 'mirrored', 'unknown'] as WslNetworkingMode[]) {
+      for (const wslMode of [true, false]) {
+        const d = chooseBridgeHost(req({ explicitHost: '0.0.0.0', mode, wslMode }));
+        expect(d.host).toBe('0.0.0.0');
+        expect(d.error).toBeNull();
+      }
+    }
+  });
+
+  it('upgrades the exposure notice for an explicit bind under mirrored', () => {
+    const generic = chooseBridgeHost(req({ explicitHost: '0.0.0.0', mode: 'unknown', wslMode: false, inWsl2: false }));
+    expect(generic.notices.join(' ')).toMatch(/exposes the wmux pipe beyond localhost/);
+    expect(generic.notices.join(' ')).not.toMatch(/mirrored/);
+
+    const mirrored = chooseBridgeHost(req({ explicitHost: '0.0.0.0', mode: 'mirrored' }));
+    expect(mirrored.notices.join(' ')).toMatch(/mirrored networking/);
+    expect(mirrored.notices.join(' ')).toMatch(/Hyper-V firewall/);
+    expect(mirrored.notices.join(' ')).toMatch(/VPN/);
+  });
+
+  it('stays quiet for an explicit loopback bind, however spelled', () => {
+    for (const host of ['127.0.0.1', 'localhost', '::1']) {
+      for (const mode of ['nat', 'mirrored', 'unknown'] as WslNetworkingMode[]) {
+        const d = chooseBridgeHost(req({ explicitHost: host, mode }));
+        expect(d).toEqual({ host, notices: [], error: null });
+      }
+    }
+  });
+
+  it('never returns both a host and an error', () => {
+    for (const mode of ['nat', 'mirrored', 'unknown'] as WslNetworkingMode[]) {
+      for (const inWsl2 of [true, false]) {
+        for (const wslMode of [true, false]) {
+          for (const explicitHost of [undefined, '0.0.0.0', '127.0.0.1']) {
+            const d = chooseBridgeHost(req({ mode, inWsl2, wslMode, explicitHost }));
+            expect(d.host === null).toBe(d.error !== null);
+          }
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
Third and last of the three PRs #166 was split into. #168 and #169 are merged, so this is the remainder the split was for: the bridge itself, on its own, with regenerated artifacts and `docs/DEVCONTAINER.md`.

Rebuilt on current master (`3078b48`, 1.0.1) rather than rebased — four of the eleven commits on the old branch are now upstream and had nothing left to carry:

| old commit | why it is gone |
|---|---|
| `fix(cli): ask the instance for the config path` | merged as `1bc0089` |
| `fix(cli): improve path handling…` | merged as `7a90462`, minus the npiperelay half, which folds into commit 1 here — it is a fix to a function this branch introduces |
| `test(bash-path): assert the candidate order…` | merged as `1283433`; the three test files are byte-identical to what is on master |
| `fix(shell-integration): sync the packaged bash integration` | superseded by `c573842`, which did all three copies |

`tests/unit/cli-config-path.test.ts` is master's version untouched — spawning `dist/cli/` with a `beforeAll` build is better than what #166 had, and nothing here needs to touch it.

## What it does

`wmux bridge` exposes the local pipe on TCP so a devcontainer can drive the wmux running on the Windows host (issue #19, on top of the bridge from #78). The container has no `\\.\pipe\wmux`, so every CLI call and every Claude Code hook failed silently — the sidebar sat on "Running" while the agent idled.

Rejected alternatives are written up in `docs/DEVCONTAINER.md` (AF_VSOCK, a Windows-side listener, cross-boundary Unix sockets).

## Changes since #166

Four, from the review there.

### 1. The `0.0.0.0` bind is now checked, not assumed

#166 asked what the blast radius of `--wsl` binding `0.0.0.0` was. The honest answer is that it depends on a WSL setting the code never looked at:

- **NAT mode** (WSL2's default, and what the old comment described). The distro has its own network namespace behind a Hyper-V vSwitch. `0.0.0.0` is `eth0` on a private 172.x plus loopback — reachable from containers via the host gateway, genuinely not reachable from the LAN, no firewall rule involved. The comment was right, and it is kept verbatim as the NAT explanation.
- **Mirrored mode** (`networkingMode=mirrored` in `.wslconfig`). The distro has no namespace of its own — it *shares the Windows host's interfaces*, including the physical LAN adapter and any VPN adapter. `0.0.0.0` there is a bind on the corporate network. Inbound traffic to a mirrored distro is filtered by the **Hyper-V firewall**, not the ordinary Windows Firewall profile, and the widely-copied "make WSL reachable" recipe is `Set-NetFirewallHyperVVMSetting -Name '{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}' -DefaultInboundAction Allow`. Mirrored **plus** that setting puts wmux's control pipe on the LAN. The pipe token still authenticates every request, so it is exposure rather than an open door — but it is a configuration people actually run, not a hypothetical.

So the mode is read from `wslinfo --networking-mode` (WSL 2.0.5+) and the bind follows from it:

| mode | `--wsl` does |
|---|---|
| `nat` | binds `0.0.0.0`, and says why that is safe here |
| `mirrored` | **refuses**, explains that the distro shares the host's adapters, points at `--host <addr>` |
| unknown / no `wslinfo` | **refuses** — treated as unknown, not as NAT |
| `--host` given explicitly | honoured; a non-loopback bind warns, and the warning names the mode |

The decision is a pure function (`src/cli/wsl-network.ts`), table-tested over mode × in-WSL2 × explicit-host, so none of it needs WSL to run.

One thing worth flagging, because the obvious spelling of the WSL2 probe is wrong in a way that ships easily: **a Linux container on a Windows host runs on the WSL2 kernel.** Its `/proc/sys/kernel/osrelease` reads `microsoft-standard-WSL2` while it is not a WSL2 distro and has no interop to reach a Windows host with. Matching osrelease alone would bind `0.0.0.0` in every devcontainer on Windows — the exact opposite of the intent. `isWsl2()` requires the interop vars too, and there is an end-to-end test for it that passes precisely because CI-style containers are that case.

### 2. `raw-v1` is an allowlist

It was a generic passthrough: whatever line you gave it reached the V1 handler. That is a standing side door — every V1 command added later becomes container-reachable the day it lands, without anyone deciding it should be. Now restricted to the six verbs the shell integration actually emits (`report_pwd`, `report_git_branch`, `clear_git_branch`, `report_shell_state`, `ports_kick`, `report_startup_command`); anything else exits non-zero naming the accepted set.

The test derives the expected verbs by scanning `_wmux_report` call sites in `src/shell-integration/wmux-bash-integration.sh`, so the allowlist and the integration cannot drift apart silently.

### 3. One transport-derived deadline, not two

`wmux.ts` derived its deadline from `remoteTarget || usesNpiperelay()`; `wmux-hook.ts` had its own `remote ? 30000 : 5000`. Same intent, two spellings — and the hook's did not know about npiperelay, so a hook firing from a WSL shell armed the 5s local-pipe timer for a hop that measures ~7s and killed a call that was going to succeed.

Both now describe their connection the same way and ask `transport-deadline.ts`. No behaviour change for a local pipe: the floor only ever raises a deadline.

### 4. Artifacts regenerated

`resources/cli/*.js` from a clean `npm run build:main` on the final tree, as the last commit.

`42e3cca` changed what that commit means, for the better. It is now an invariant `npm run verify:resources` checks byte-for-byte rather than bookkeeping that can slip, and — more to the point of the split — it is finally *readable*. The same regeneration in #166 was +1412/-445, because the checked-in copy had drifted ~1700 diff lines behind its own source and the bridge's output was buried in unrelated rot. Against today's master it is +443/-36 plus the two new modules, and all of it is the bridge.

That check also covers `resources/shell-integration/`, which is why the bash integration's `WMUX_REMOTE` branch is applied to both copies in commit 1: #169 resynced from a pre-bridge `src/`, so the packaged copy has the `wmux` shim but not the transport, and leaving it that way fails `npm test`.

## One thing this turned up

Splitting those two modules out exposed a packaging gap. `extraResources` ships `dist/cli/wmux.js` and `dist/cli/wmux-hook.js` **file-by-file**, not the directory — harmless while each was self-contained, but a shared sibling module is `MODULE_NOT_FOUND` on the first line of `wmux ping` and of every Claude Code hook in an installed build. `npm run dev` cannot show it; the module is sitting right there in `dist/`.

That is a worse failure than the one `packaging.test.ts` already guards (a missing *resource* is a silently-absent feature behind an `existsSync` warning), so the check is derived the same way that file's `process.resourcesPath` scan is: walk the relative imports out of each shipped CLI entry point and require each to be packaged too. `wsl-network.js` was already missing when I added it — found by the check, not by review.

## Verification

`npm run typecheck` clean. `npm run lint` reports 29 problems (16 errors, 13 warnings) — identical to master, none in files this branch touches. `npm run verify:resources` passes.

Full suite against a detached `upstream/master` worktree sharing the same `node_modules`:

| | test files | tests |
|---|---|---|
| `master` (`3078b48`) | 4 failed, 82 passed | 6 failed, 1005 passed, 2 skipped |
| this branch | 4 failed, 87 passed | 6 failed, **1045 passed**, 6 skipped |

The failing set is **identical one-for-one** — the Windows-path and live-`Win32_Process` cases (`orchestration-watcher`, `pty-ledger` ×2, `pty-manager`, `shell-context-menu` ×3) that do not pass on Linux on master either. The 4 added skips are the npiperelay round-trip cases, which need a real WSL2 distro; the suites they live in do run, at 65 passed / 4 skipped across the eight bridge-related files.

Checked by hand from the container this was built in:

- `node resources/cli/wmux.js --help` — the packaged copies resolve their new siblings
- `raw-v1 definitely_not_a_verb …` → exits 1, naming the six accepted verbs
- `bridge --wsl` → exits 1, naming what it looked for and pointing at `--host`. This container *is* the false-positive case from §1: WSL2 kernel in `osrelease`, no interop vars, correctly refused
- `resources/cli/*.js` byte-identical to a fresh `npm run build:main`

**Not verified, and I am not going to imply otherwise: the mirrored-mode branch.** This was developed on a NAT host. Exercising it needs `networkingMode=mirrored` in `.wslconfig` and a `wsl --shutdown` on a scratch machine, where `wslinfo --networking-mode` should print `mirrored`, `--wsl` should refuse, `--host 0.0.0.0` should bind with the upgraded warning, and `ip addr` inside the distro should show the host's LAN adapter — which is the observation that makes the risk concrete rather than argued. The refusal is the safe default whether or not anyone gets to that.

Draft until you have had a look at the split — happy to reshape the commit series.
