### PR TITLE
fix(cli): match raw-v1 on the verb, not on the whole argv entry

### DIFF
--- a/resources/cli/wmux.js
+++ b/resources/cli/wmux.js
@@ -9,6 +9,7 @@ exports.timeoutMessage = timeoutMessage;
 exports.browserRequest = browserRequest;
 exports.subcommandError = subcommandError;
 exports.rawV1Error = rawV1Error;
+exports.rawV1Parse = rawV1Parse;
 const net_1 = __importDefault(require("net"));
 const fs_1 = __importDefault(require("fs"));
 const os_1 = __importDefault(require("os"));
@@ -996,13 +997,38 @@ function rawV1Error(verb) {
         return null;
     return `raw-v1: ${verb} is not a passthrough command. Accepted: ${exports.RAW_V1_VERBS.join(', ')}`;
 }
+/**
+ * Split a `raw-v1` argv into the V1 line to send and the verb to check.
+ *
+ * The two callers disagree about argv, and both are legitimate. A hand-typed
+ * call splits naturally — `wmux raw-v1 report_pwd surf-1 /tmp` — but
+ * wmux-bash-integration.sh builds the line as a single string and passes it
+ * quoted: `wmux raw-v1 "report_pwd $surface_id $(pwd)"`. There the whole line
+ * is args[1].
+ *
+ * Checking args[1] against the allowlist therefore rejected every report the
+ * shell integration ever sent: "report_pwd surf-1 /tmp" is not in RAW_V1_VERBS,
+ * so the CLI exited 1 before sendV1 was reached. Nothing reached the wire, and
+ * because the integration fires into `>/dev/null 2>&1 &` there was no symptom
+ * beyond a sidebar that never showed a cwd or a branch.
+ *
+ * Taking the first whitespace token is not a loosening — it is what the server
+ * already does. pipe-server.ts handleV1() parses the command as the first token
+ * of the line, so this makes the allowlist agree with the parser it guards
+ * rather than with one caller's argv habits.
+ */
+function rawV1Parse(args) {
+    const line = args.slice(1).join(' ');
+    return { line, verb: line.trim().split(/\s+/)[0] ?? '' };
+}
 async function cmdRawV1(args) {
-    const problem = rawV1Error(args[1]);
+    const { line, verb } = rawV1Parse(args);
+    const problem = rawV1Error(verb);
     if (problem) {
         console.error(problem);
         process.exit(1);
     }
-    console.log(await sendV1(args.slice(1).join(' ')));
+    console.log(await sendV1(line));
 }
 // ─── Declared agent state (issue #128) ───────────────────────────────────────
 // The reporting side of the protocol. An agent running inside a wmux pane can

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -957,10 +957,36 @@ export function rawV1Error(verb: string | undefined): string | null {
   return `raw-v1: ${verb} is not a passthrough command. Accepted: ${RAW_V1_VERBS.join(', ')}`;
 }
 
+/**
+ * Split a `raw-v1` argv into the V1 line to send and the verb to check.
+ *
+ * The two callers disagree about argv, and both are legitimate. A hand-typed
+ * call splits naturally — `wmux raw-v1 report_pwd surf-1 /tmp` — but
+ * wmux-bash-integration.sh builds the line as a single string and passes it
+ * quoted: `wmux raw-v1 "report_pwd $surface_id $(pwd)"`. There the whole line
+ * is args[1].
+ *
+ * Checking args[1] against the allowlist therefore rejected every report the
+ * shell integration ever sent: "report_pwd surf-1 /tmp" is not in RAW_V1_VERBS,
+ * so the CLI exited 1 before sendV1 was reached. Nothing reached the wire, and
+ * because the integration fires into `>/dev/null 2>&1 &` there was no symptom
+ * beyond a sidebar that never showed a cwd or a branch.
+ *
+ * Taking the first whitespace token is not a loosening — it is what the server
+ * already does. pipe-server.ts handleV1() parses the command as the first token
+ * of the line, so this makes the allowlist agree with the parser it guards
+ * rather than with one caller's argv habits.
+ */
+export function rawV1Parse(args: string[]): { line: string; verb: string } {
+  const line = args.slice(1).join(' ');
+  return { line, verb: line.trim().split(/\s+/)[0] ?? '' };
+}
+
 async function cmdRawV1(args: string[]): Promise<void> {
-  const problem = rawV1Error(args[1]);
+  const { line, verb } = rawV1Parse(args);
+  const problem = rawV1Error(verb);
   if (problem) { console.error(problem); process.exit(1); }
-  console.log(await sendV1(args.slice(1).join(' ')));
+  console.log(await sendV1(line));
 }
 
 // ─── Declared agent state (issue #128) ───────────────────────────────────────

--- a/tests/unit/raw-v1-allowlist.test.ts
+++ b/tests/unit/raw-v1-allowlist.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
-import { RAW_V1_VERBS, rawV1Error } from '../../src/cli/wmux';
+import { RAW_V1_VERBS, rawV1Error, rawV1Parse } from '../../src/cli/wmux';
 
 /**
  * `wmux raw-v1` exists so the bash integration can report shell state from
@@ -56,8 +56,10 @@ describe('raw-v1 allowlist', () => {
   });
 
   it('matches on the verb alone, not on the rest of the line', () => {
-    // args[1] is the verb; the surface id and payload follow as separate argv
-    // entries, so a path with spaces cannot turn a good verb into a bad one.
+    // rawV1Error takes a verb, never a whole line — extracting the verb from
+    // argv is rawV1Parse's job (see below). Asserting that here is what let the
+    // two drift: this stayed green while the shipped caller handed the CLI an
+    // entire line and had every report rejected.
     expect(rawV1Error('report_pwd')).toBeNull();
     // ...and a verb cannot be smuggled in by gluing it to another one.
     expect(rawV1Error('report_pwd notify')).toMatch(/not a passthrough command/);
@@ -72,5 +74,92 @@ describe('raw-v1 allowlist', () => {
       'report_shell_state',
       'report_startup_command',
     ]);
+  });
+});
+
+/**
+ * The allowlist above was correct and still rejected every real report, because
+ * nothing tested how the verb is recovered from argv.
+ *
+ * wmux-bash-integration.sh builds the V1 line as one string and passes it
+ * quoted — `wmux raw-v1 "report_pwd $surface_id $(pwd)"` — so args[1] is the
+ * whole line, not the verb. Checking args[1] meant checking
+ * "report_pwd surf-1 /tmp" against a list of bare verbs: never a match, exit 1
+ * before sendV1, and silence, since the caller fires into `>/dev/null 2>&1 &`.
+ *
+ * These cover the argv layer specifically. Asserting on rawV1Error alone cannot
+ * catch this class of bug, which is exactly how it shipped.
+ */
+describe('raw-v1 argv parsing', () => {
+  const SURFACE = 'surf-1';
+
+  it('recovers the verb when the whole line arrives as one argument', () => {
+    // THE regression: the shape wmux-bash-integration.sh actually sends.
+    const { line, verb } = rawV1Parse(['raw-v1', `report_pwd ${SURFACE} /tmp/x`]);
+
+    expect(verb).toBe('report_pwd');
+    expect(rawV1Error(verb)).toBeNull();
+    expect(line).toBe('report_pwd surf-1 /tmp/x');
+  });
+
+  it('recovers the verb when argv is pre-split, as a hand-typed call is', () => {
+    const { line, verb } = rawV1Parse(['raw-v1', 'report_pwd', SURFACE, '/tmp/x']);
+
+    expect(verb).toBe('report_pwd');
+    expect(rawV1Error(verb)).toBeNull();
+    expect(line).toBe('report_pwd surf-1 /tmp/x');
+  });
+
+  it('treats both argv shapes as the same request', () => {
+    // The shape a caller happens to use must not change what the server sees;
+    // that equivalence is the whole contract of the passthrough.
+    const quoted = rawV1Parse(['raw-v1', `report_git_branch ${SURFACE} main dirty`]);
+    const split = rawV1Parse(['raw-v1', 'report_git_branch', SURFACE, 'main', 'dirty']);
+
+    expect(quoted).toEqual(split);
+  });
+
+  it('still rejects a non-allowlisted verb in the one-argument shape', () => {
+    // The fix must not become a hole: taking the first token is only safe if a
+    // bad first token is still refused.
+    const { verb } = rawV1Parse(['raw-v1', `rm -rf / ${SURFACE}`]);
+
+    expect(rawV1Error(verb)).toMatch(/not a passthrough command/);
+  });
+
+  it('cannot be tricked into allowing a second verb further down the line', () => {
+    // "report_pwd notify" is a report_pwd whose surface id is "notify" — the
+    // pipe server reads the command as the first token too, so allowlist and
+    // parser agree on what was requested.
+    const { verb } = rawV1Parse(['raw-v1', 'report_pwd notify']);
+
+    expect(verb).toBe('report_pwd');
+  });
+
+  it('preserves a path containing spaces', () => {
+    // report_pwd's payload is free text and the V1 handler keeps it as one
+    // argument, so the line must survive the round trip byte for byte.
+    const { line, verb } = rawV1Parse(['raw-v1', `report_pwd ${SURFACE} /tmp/my dir/sub`]);
+
+    expect(verb).toBe('report_pwd');
+    expect(line).toBe('report_pwd surf-1 /tmp/my dir/sub');
+  });
+
+  it('asks for usage when no line is given', () => {
+    expect(rawV1Error(rawV1Parse(['raw-v1']).verb)).toMatch(/^Usage: wmux raw-v1/);
+    expect(rawV1Error(rawV1Parse(['raw-v1', '   ']).verb)).toMatch(/^Usage: wmux raw-v1/);
+  });
+
+  it('accepts every line the shipped bash integration can actually emit', () => {
+    // The drift guard above proves the verbs are allowlisted. This proves they
+    // survive the transport the integration uses to send them — the half that
+    // was broken. Built from the script so a new report cannot skip the check.
+    const emitted = [...fs.readFileSync(INTEGRATION, 'utf8').matchAll(/_wmux_report "([a-z_]+)/g)].map((m) => m[1]);
+    expect(emitted.length).toBeGreaterThan(0);
+
+    for (const emittedVerb of new Set(emitted)) {
+      const { verb } = rawV1Parse(['raw-v1', `${emittedVerb} ${SURFACE} payload`]);
+      expect(rawV1Error(verb), `${emittedVerb} is emitted but rejected in the one-argument shape`).toBeNull();
+    }
   });
 });


### PR DESCRIPTION
## What breaks

Every V1 report the bash shell integration sends from a devcontainer is dropped by the CLI before it reaches the wire. In the sidebar that shows up as a pane with no cwd, no git branch, no shell state and no restore command. All six allowlisted verbs are affected.

## Why

`src/shell-integration/wmux-bash-integration.sh` builds the V1 line as one string and passes it quoted:

```bash
( wmux raw-v1 "report_pwd $surface_id $(pwd)" >/dev/null 2>&1 & )
```

so `args[1]` is the whole line. `cmdRawV1` checked `args[1]` against `RAW_V1_VERBS`, which holds bare verbs:

```ts
const problem = rawV1Error(args[1]);   // "report_pwd surf-1 /home/me"
```

`RAW_V1_VERBS.includes("report_pwd surf-1 /home/me")` is false, so the CLI printed an error and `process.exit(1)` before `sendV1` was reached.

Nothing surfaced it. The caller fires into `>/dev/null 2>&1 &`, so the error went nowhere, and `ping` / `identify` / `list-surfaces` stayed healthy the whole time because the transport was never the problem.

Provenance: the allowlist (`e32a6dd`) landed *after* the quoted single-argument call site (`3d6d52d`), and `tests/unit/raw-v1-allowlist.test.ts` only ever called `rawV1Error()` with bare verbs — a shape no real caller uses. Its comment even asserted "args[1] is the verb; the surface id and payload follow as separate argv entries", describing a caller that does not exist. That is why it shipped green.

## The fix

Take the first whitespace token of the joined line:

```ts
export function rawV1Parse(args: string[]): { line: string; verb: string } {
  const line = args.slice(1).join(' ');
  return { line, verb: line.trim().split(/\s+/)[0] ?? '' };
}
```

This is not a loosening of the allowlist. `pipe-server.ts` `handleV1()` already parses the command as the first token, so the allowlist now agrees with the parser it guards rather than with one caller's argv habits. Concretely:

- a pre-split argv (`wmux raw-v1 report_pwd surf-1 /tmp`) is unchanged — both shapes produce the same line and the same verb
- `"report_pwd notify"` is a `report_pwd` whose surface id is `notify`, not a smuggled `notify`
- an unknown first token is still refused, now naming just the verb instead of echoing the whole line back

`rawV1Error` is untouched, so every existing assertion still holds.

## Tests

The gap *is* the bug, so the new cases target the argv layer specifically: the one-argument shape, the equivalence of both shapes, a path containing spaces, a non-allowlisted verb in the one-argument shape, and every verb scraped out of the shipped shell script — sent the way the script sends them, not the way the old test pretended.

Six of the fifteen fail without the source change; all fifteen pass with it. Verified in both directions.

## Artifacts

`resources/cli/wmux.js` is regenerated (`npm run build:main`, copy, `npm run verify:resources`). It is what actually executes, so a source-only fix would ship nothing.

## Verification

`npm run typecheck` clean, `npm run verify:resources` clean. Against a dead port, so nothing reaches a real server:

```
# before — rejected locally, never sent
$ WMUX_REMOTE=127.0.0.1:1 node <old>/wmux.js raw-v1 "report_git_branch surf-1 main"
raw-v1: report_git_branch surf-1 main is not a passthrough command...

# after — allowlist passes, transport is reached
$ WMUX_REMOTE=127.0.0.1:1 node <new>/wmux.js raw-v1 "report_git_branch surf-1 main"
wmux is not running

# still refused
$ ... raw-v1 "notify surf-1 hello"
raw-v1: notify is not a passthrough command...
```

Full suite on a Windows host: **1069 passed, 0 failures.**

Earlier runs of this branch showed 6 failures (`shell-context-menu`, `pty-ledger`, `pty-manager`). Those were run from a Linux devcontainer, where the ConPTY and Windows-shell suites cannot execute; they were confirmed identical on pristine `master` at the time. On Windows they pass. Nothing in this change touches them either way — the earlier failures were the environment, not the branch.



🤖 Generated with [Claude Code](https://claude.com/claude-code)

