### PR TITLE
fix(pty): resolve Windows App Execution Aliases before spawn

### DIFF
--- a/src/main/config-loader.ts
+++ b/src/main/config-loader.ts
@@ -24,6 +24,8 @@ interface WTProfile {
   name?: string;
   commandline?: string;
   startingDirectory?: string;
+  /** WT dynamic-profile source (e.g. "Windows.Terminal.PowershellCore"). */
+  source?: string;
   hidden?: boolean;
   font?: { face?: string; size?: number };
   fontSize?: number;
@@ -231,6 +233,40 @@ export function loadProjectProfiles(cwd: string): QuickLaunchProfile[] {
 }
 
 /**
+ * WT's dynamic PowerShell Core profile ("PowerShell" / "PowerShell 7 Preview")
+ * ships without a `commandline` — WT itself resolves it at launch. Without an
+ * explicit mapping, the imported wmux profile ends up shell-less and silently
+ * launches the default pwsh instead of the chosen (preview) build. Map it to
+ * the App Execution Alias; at spawn time resolveShell verifies it and falls
+ * back to the default if the aliases are absent.
+ */
+function shellForDynamicPowerShell(name: string): string {
+  return /preview/i.test(name) ? 'pwsh-preview' : 'pwsh';
+}
+
+/**
+ * Pure mapping of a Windows Terminal profile list to Quick-launch profiles.
+ * A profile's `commandline` becomes its `shell`; dynamic PowerShell Core
+ * profiles (no commandline) map to `pwsh`/`pwsh-preview` by name.
+ */
+export function mapWindowsTerminalProfiles(profiles: WTProfile[]): QuickLaunchProfile[] {
+  return profiles
+    .filter((p) => !p.hidden && (p.name || p.commandline))
+    .map((p, i) => {
+      const name = (p.name || p.commandline || `Profile ${i + 1}`).trim();
+      const dynamicPs = !p.commandline && p.source === 'Windows.Terminal.PowershellCore';
+      return {
+        id: `wt-${p.guid || i}`,
+        name,
+        type: 'terminal' as SurfaceType,
+        source: 'global' as const,
+        ...(p.commandline ? { shell: p.commandline } : dynamicPs ? { shell: shellForDynamicPowerShell(name) } : {}),
+        ...(p.startingDirectory ? { cwd: p.startingDirectory.replace(/%([^%]+)%/g, (_m, v) => process.env[v] || _m) } : {}),
+      };
+    });
+}
+
+/**
  * Import Windows Terminal profiles as quick-launch profiles, mapping each
  * non-hidden profile's `commandline` (→ shell) and `startingDirectory` (→ cwd).
  * This finishes the WT import that previously kept only the color scheme.
@@ -254,19 +290,7 @@ export function importWindowsTerminalProfiles(): QuickLaunchProfile[] {
     } else if (settings.profiles && Array.isArray(settings.profiles.list)) {
       profiles = settings.profiles.list;
     }
-    return profiles
-      .filter((p) => !p.hidden && (p.name || p.commandline))
-      .map((p, i) => {
-        const name = (p.name || p.commandline || `Profile ${i + 1}`).trim();
-        return {
-          id: `wt-${p.guid || i}`,
-          name,
-          type: 'terminal' as SurfaceType,
-          source: 'global' as const,
-          ...(p.commandline ? { shell: p.commandline } : {}),
-          ...(p.startingDirectory ? { cwd: p.startingDirectory.replace(/%([^%]+)%/g, (_m, v) => process.env[v] || _m) } : {}),
-        };
-      });
+    return mapWindowsTerminalProfiles(profiles);
   } catch {
     return [];
   }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -26,23 +26,58 @@ export function isPtyCrashGuardInstalled(): boolean {
 }
 
 // ─── Shell resolution ──────────────────────────────────────────────────────
-// Validates that a shell executable exists before spawning.
-// Falls back through: pwsh.exe → powershell.exe → cmd.exe
+// Validates that a shell executable exists as a real file before spawning.
+// node-pty's Windows SearchPath concatenates PATH + the bare name and then
+// GetFileAttributes — App Execution Aliases (0-byte WindowsApps reparse
+// points) fail that check, so spawn('pwsh-preview') throws "File not found: "
+// with an empty path. `where` finds those aliases; fs.existsSync does not.
+// Fall back through: requested shell → pwsh.exe → powershell.exe → cmd.exe
 
 let cachedDefaultShell: string | null = null;
 
-function isShellAvailable(shell: string): boolean {
-  if (!shell) return false;
-  if (path.isAbsolute(shell)) {
-    return fs.existsSync(shell);
-  }
+/** First `where`/`which` hit that is a real file (skips WindowsApps aliases). */
+function firstExistingOnPath(name: string): string | undefined {
   try {
     const cmd = process.platform === 'win32' ? 'where' : 'which';
-    execFileSync(cmd, [shell], { windowsHide: true, timeout: 3000, stdio: 'ignore' });
-    return true;
+    const hits = execFileSync(cmd, [name], { windowsHide: true, timeout: 3000, encoding: 'utf8' })
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return hits.find((p) => fs.existsSync(p));
   } catch {
-    return false;
+    return undefined;
   }
+}
+
+/** Store-installed PowerShell Preview: WindowsApps\<pkg>\pwsh.exe. */
+function findStorePwshPreview(): string | undefined {
+  const root = path.join(process.env.ProgramFiles || 'C:\\Program Files', 'WindowsApps');
+  try {
+    const dirs = fs.readdirSync(root)
+      .filter((d) => d.startsWith('Microsoft.PowerShellPreview_'))
+      .sort()
+      .reverse();
+    for (const d of dirs) {
+      const exe = path.join(root, d, 'pwsh.exe');
+      if (fs.existsSync(exe)) return exe;
+    }
+  } catch {
+    // ACL-denied listing is fine — caller falls back.
+  }
+  return undefined;
+}
+
+/** Absolute path of a real file node-pty can spawn, or undefined. */
+export function resolveExistingShellPath(shell: string): string | undefined {
+  if (!shell) return undefined;
+  if (path.isAbsolute(shell) && fs.existsSync(shell)) return shell;
+  const onPath = firstExistingOnPath(shell);
+  if (onPath) return onPath;
+  // Bare alias with no real PATH hit (the preview App Execution Alias).
+  if (process.platform === 'win32' && /pwsh-preview/i.test(shell)) {
+    return findStorePwshPreview();
+  }
+  return undefined;
 }
 
 function getDefaultShell(): string {
@@ -51,21 +86,20 @@ function getDefaultShell(): string {
     ? ['pwsh.exe', 'powershell.exe', 'cmd.exe']
     : [process.env.SHELL || '/bin/sh'];
   for (const cmd of candidates) {
-    if (isShellAvailable(cmd)) {
-      cachedDefaultShell = cmd;
-      return cmd;
+    const resolved = resolveExistingShellPath(cmd);
+    if (resolved) {
+      cachedDefaultShell = resolved;
+      return resolved;
     }
   }
-  // cmd.exe is always available on Windows
   cachedDefaultShell = process.platform === 'win32' ? 'cmd.exe' : '/bin/sh';
   return cachedDefaultShell;
 }
 
-function resolveShell(shell: string | undefined): string {
-  if (shell && isShellAvailable(shell)) {
-    return shell;
-  }
+export function resolveShell(shell: string | undefined): string {
   if (shell) {
+    const resolved = resolveExistingShellPath(shell);
+    if (resolved) return resolved;
     console.warn(`[wmux] Shell not found: "${shell}", falling back to ${getDefaultShell()}`);
   }
   return getDefaultShell();
@@ -130,7 +164,7 @@ let cachedWsl: boolean | null = null;
 export const shellEnv = {
   isWindows: (): boolean => process.platform === 'win32',
   hasWsl: (): boolean => {
-    if (cachedWsl === null) cachedWsl = isShellAvailable('wsl.exe');
+    if (cachedWsl === null) cachedWsl = firstExistingOnPath('wsl.exe') !== undefined;
     return cachedWsl;
   },
 };
@@ -330,8 +364,9 @@ export class PtyManager {
     const spec = parseShellSpec(options.shell);
     // A POSIX cwd forces wsl.exe — pwsh/cmd cannot open that directory at all
     // and would silently start in %USERPROFILE% instead of the project.
-    const shell = resolveShellForCwd(resolveShell(spec.command), options.cwd);
-    const shellExtraArgs = shell === spec.command ? spec.args : [];
+    const requested = resolveExistingShellPath(spec.command);
+    const shell = resolveShellForCwd(requested ?? resolveShell(spec.command), options.cwd);
+    const shellExtraArgs = requested ? spec.args : [];
     const shellType = getShellType(shell);
     const integrationDir = getShellIntegrationPath();
     const cliPath = getCliPath();

--- a/tests/unit/config-loader.test.ts
+++ b/tests/unit/config-loader.test.ts
@@ -3,6 +3,7 @@ import { getDefaultTheme } from '../../src/main/theme-loader';
 import {
   parseGhosttyConfigString,
   parseWindowsTerminalSettingsJson,
+  mapWindowsTerminalProfiles,
 } from '../../src/main/config-loader';
 
 // ---------------------------------------------------------------------------
@@ -250,5 +251,45 @@ describe('parseWindowsTerminalSettingsJson', () => {
     // Empty settings should not throw and should return a ThemeConfig (with defaults)
     // or null — either is acceptable, but it must not throw.
     expect(() => parseWindowsTerminalSettingsJson({})).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapWindowsTerminalProfiles
+// ---------------------------------------------------------------------------
+
+describe('mapWindowsTerminalProfiles', () => {
+  it('maps commandline to shell and startingDirectory to cwd', () => {
+    const result = mapWindowsTerminalProfiles([
+      {
+        guid: 'a',
+        name: 'Git Bash',
+        commandline: '"C:\\Program Files\\Git\\bin\\bash.exe" -i -l',
+        startingDirectory: '%USERPROFILE%',
+      },
+    ]);
+    expect(result[0].shell).toBe('"C:\\Program Files\\Git\\bin\\bash.exe" -i -l');
+    expect(result[0].cwd).toBe(process.env.USERPROFILE || '');
+  });
+
+  it('maps dynamic stable PowerShell Core profile to pwsh', () => {
+    const result = mapWindowsTerminalProfiles([
+      { guid: 'b', name: 'PowerShell', source: 'Windows.Terminal.PowershellCore' },
+    ]);
+    expect(result[0].shell).toBe('pwsh');
+  });
+
+  it('maps dynamic preview PowerShell Core profile to pwsh-preview', () => {
+    const result = mapWindowsTerminalProfiles([
+      { guid: 'c', name: 'PowerShell 7 Preview', source: 'Windows.Terminal.PowershellCore' },
+    ]);
+    expect(result[0].shell).toBe('pwsh-preview');
+  });
+
+  it('leaves a dynamic profile with no PowerShellCore source shell-less', () => {
+    const result = mapWindowsTerminalProfiles([
+      { guid: 'd', name: 'Ubuntu', source: 'Windows.Terminal.Wsl' },
+    ]);
+    expect(result[0].shell).toBeUndefined();
   });
 });

--- a/tests/unit/pty-manager.test.ts
+++ b/tests/unit/pty-manager.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { PtyManager, parseShellSpec, resolveSpawnCwd, resolveShellForCwd, shellEnv } from '../../src/main/pty-manager';
+import { PtyManager, parseShellSpec, resolveSpawnCwd, resolveShellForCwd, resolveExistingShellPath, shellEnv } from '../../src/main/pty-manager';
 import type { SurfaceId } from '../../src/shared/types';
 
 const TEST_SHELL = 'cmd.exe';
@@ -236,6 +236,37 @@ describe('parseShellSpec (issue #78 — shell command lines with args)', () => {
     });
   });
 });
+
+describe('resolveExistingShellPath', () => {
+  it('returns undefined for empty input', () => {
+    expect(resolveExistingShellPath('')).toBeUndefined();
+  });
+
+  it('returns an existing absolute path unchanged', () => {
+    const exe = process.platform === 'win32'
+      ? path.join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'cmd.exe')
+      : '/bin/sh';
+    expect(resolveExistingShellPath(exe)).toBe(exe);
+  });
+
+  it('skips WindowsApps aliases and finds a real file for pwsh', () => {
+    if (process.platform !== 'win32') return;
+    const resolved = resolveExistingShellPath('pwsh.exe');
+    expect(resolved).toBeTruthy();
+    expect(fs.existsSync(resolved!)).toBe(true);
+    expect(resolved!.includes('WindowsApps')).toBe(false);
+  });
+
+  it('resolves pwsh-preview to a real Store pwsh.exe, not the alias', () => {
+    if (process.platform !== 'win32') return;
+    const resolved = resolveExistingShellPath('pwsh-preview');
+    if (!resolved) return; // preview not installed
+    expect(fs.existsSync(resolved)).toBe(true);
+    expect(resolved.toLowerCase()).not.toContain('\\windowsapps\\pwsh-preview');
+    expect(path.basename(resolved).toLowerCase()).toBe('pwsh.exe');
+  });
+});
+
 
 /**
  * CreateProcess fails with error 267 (ERROR_DIRECTORY) when handed a working


### PR DESCRIPTION
Fixes #173.

## Decision

Import Windows Terminal dynamic PowerShell Core profiles as `pwsh` / `pwsh-preview`, then resolve that name to a **real file** before `pty.spawn`. node-pty cannot spawn Windows App Execution Aliases.

## Why

WT's **PowerShell 7 Preview** profile has `source: Windows.Terminal.PowershellCore` and no `commandline`. Import used to leave it shell-less. Mapping it to `pwsh-preview` still crashed:

```
Failed to create terminal: File not found:
```

(empty path). `where pwsh-preview` finds the 0-byte WindowsApps alias. node-pty's SearchPath concatenates PATH + the bare name (no PATHEXT) and `GetFileAttributes` fails, so `get_shell_path` returns empty.

Preview on this machine is Store-only: `WindowsApps\Microsoft.PowerShellPreview_*\pwsh.exe`.

## Scope

- `mapWindowsTerminalProfiles`: dynamic PS Core → `pwsh` / `pwsh-preview` by name
- `resolveExistingShellPath`: first `where` hit that `existsSync`s; Preview falls back to the Store package `pwsh.exe`
- `resolveShell` / default shell use that path so already-saved `pwsh-preview` profiles work without re-import
- Extra args stay attached when the **requested** shell resolved (not when we fell back)

## Out of scope

Other dynamic WT profiles (WSL, Azure, VS Dev Prompt) stay shell-less and still fall back to the default shell.

## Verify

- `npx vitest run tests/unit/config-loader.test.ts tests/unit/pty-manager.test.ts` (48 passed)
- Open imported **PowerShell 7 Preview** on Windows with Store Preview installed — PTY starts, `$PSVersionTable` is 7.7.x preview