### PR TITLE
test(pty): let a Store-only PowerShell pass the alias test

### DIFF
--- a/tests/unit/pty-manager.test.ts
+++ b/tests/unit/pty-manager.test.ts
@@ -254,7 +254,18 @@ describe('resolveExistingShellPath', () => {
     const resolved = resolveExistingShellPath('pwsh.exe');
     expect(resolved).toBeTruthy();
     expect(fs.existsSync(resolved!)).toBe(true);
-    expect(resolved!.includes('WindowsApps')).toBe(false);
+    // Not "the path contains WindowsApps". On a machine where PowerShell 7 is
+    // installed ONLY from the Store — the case this test exists for — the real
+    // exe *is* under that tree, at
+    //   %ProgramFiles%\WindowsApps\Microsoft.PowerShell_<ver>_<arch>__<pub>\pwsh.exe
+    // and findStorePwsh returns exactly that. Excluding the whole tree therefore
+    // failed on the only installation shape that exercises the alias path.
+    //
+    // What must be excluded is the ALIAS, and the package directory is what
+    // tells them apart: the alias is a direct child of an App Execution Alias
+    // dir (%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe), the real exe never
+    // is. Same distinction the pwsh-preview case below draws.
+    expect(path.basename(path.dirname(resolved!)).toLowerCase()).not.toBe('windowsapps');
   });
 
   it('resolves pwsh-preview to a real Store pwsh.exe, not the alias', () => {


### PR DESCRIPTION
Follow-up to #172. The test it added fails on the one PowerShell installation shape it was written to cover.

## The bug

`resolveExistingShellPath > skips WindowsApps aliases and finds a real file for pwsh` asserts:

```js
expect(resolved!.includes('WindowsApps')).toBe(false);
```

That reads as *"not an alias"*, but it means *"not anywhere under the WindowsApps tree"* — and those come apart on a Store-only PowerShell 7 install, where the **real** binary lives under that tree:

```
%ProgramFiles%\WindowsApps\Microsoft.PowerShell_<ver>_<arch>__<pub>\pwsh.exe
```

which is precisely what `findStorePwsh()` exists to return. So the assertion fails on the installation that actually exercises the alias path, and passes on a classic MSI install (`C:\Program Files\PowerShell\7\pwsh.exe`) that never reaches it.

## The fix

The alias and the real exe are told apart by the **package directory**: the alias is a direct child of an App Execution Alias dir (`%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe`), the real exe never is. So assert on the parent directory — the same distinction the `pwsh-preview` case immediately below already draws with `not.toContain('\\windowsapps\\pwsh-preview')`.

```js
expect(path.basename(path.dirname(resolved!)).toLowerCase()).not.toBe('windowsapps');
```

Checked against all four shapes:

| Path | Parent dir | Result |
|---|---|---|
| `…\Local\Microsoft\WindowsApps\pwsh.exe` (alias) | `windowsapps` | rejected |
| `…\Local\Microsoft\WindowsApps\pwsh-preview.exe` (alias) | `windowsapps` | rejected |
| `%ProgramFiles%\WindowsApps\Microsoft.PowerShell_7.6.5.0_x64__…\pwsh.exe` | `microsoft.powershell_7.6.5.0_x64__…` | accepted |
| `C:\Program Files\PowerShell\7\pwsh.exe` | `7` | accepted |

## No behaviour change

`resolveExistingShellPath` was correct throughout — only the assertion was wrong. Verified on a Store-only machine (PowerShell 7.6.5, no MSI install):

```
where pwsh
  C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.5.0_x64__8wekyb3d8bbwe\pwsh.exe
  C:\Users\<user>\AppData\Local\Microsoft\WindowsApps\pwsh.exe
```

| Path | `fs.existsSync` | Size |
|---|---|---|
| Store package exe | `true` | 301,368 B |
| App Execution Alias | `false` (EACCES) | — |

The alias is correctly skipped and the resolved exe spawns and reports `7.6.5`.

## Tests

`npm test` — 1144 passed, 1 skipped, **0 failing** (was 1143 passed / 1 failing on this machine). `npm run typecheck` clean.
