### PR TITLE
fix(sidebar): render the PR icon, and let a stale PR badge come back down

### DIFF
--- a/resources/shell-integration/wmux-powershell-integration.ps1
+++ b/resources/shell-integration/wmux-powershell-integration.ps1
@@ -41,6 +41,192 @@ function Report-Cwd {
     }
 }
 
+# Publish the live cwd for the PR poller.
+#
+# The poller runs in a child runspace, which takes the location it was created
+# in and keeps it, so it needs to be told where the pane has got to. An env var
+# cannot carry that: the job is already running by the time the pane moves.
+#
+# Nor can the pipe, which is the obvious candidate and the one to rule out
+# explicitly. It runs one direction — shell to wmux — and the consumer here is
+# another *shell* process, not wmux. The prompt already sends this exact value
+# over as report_pwd; routing the hand-off through the pipe would mean adding
+# currentCwd to the surface listing, a V2 method and a CLI verb to read it back,
+# then spawning node on every 45s tick, so that the shell can ask wmux for
+# something the shell itself just told it. This is a shell-to-shell hand-off, so
+# it stays between the shells.
+#
+# The directory is the one wmux-bash-integration.sh already uses for its own
+# hand-off, rather than a second scratch location.
+$global:_wmux_cwd_file = if ($env:WMUX_SURFACE_ID) {
+    $dir = Join-Path ([System.IO.Path]::GetTempPath()) "wmux"
+    try { $null = New-Item -ItemType Directory -Path $dir -Force -ErrorAction Stop } catch {}
+    Join-Path $dir "cwd-$($env:WMUX_SURFACE_ID).txt"
+} else { $null }
+
+function Update-WmuxCwdFile {
+    if (-not $global:_wmux_cwd_file) { return }
+    try {
+        Set-Content -LiteralPath $global:_wmux_cwd_file -Value $PWD.ProviderPath -Encoding UTF8 -ErrorAction Stop
+    } catch {
+        # Nothing to do — the poller just keeps its last known location.
+    }
+}
+
+# What the shell owes on the way out: its own hand-off file, so a pane that
+# closes leaves nothing behind. Parameterized so it can be driven directly in
+# a test instead of only through a real process exit.
+#
+# The PR badge is deliberately NOT this function's business. A shell that is
+# killed rather than asked to leave (Ctrl+W, `wmux close-pane`, closing the
+# workspace) runs no exit handler at all, and a last-gasp pipe write is
+# best-effort by nature — so the badge is dropped where the renderer already
+# learns the process is gone: the `pty:exit` handler in useTerminal.ts, which
+# heals the stuck "Running" badge and the leftover progress indicator for
+# exactly the same reason. That path covers the graceful `exit` too, so there
+# is nothing left here for it to do.
+function Invoke-WmuxExitCleanup {
+    param([string]$CwdFile)
+    if ($CwdFile) {
+        Remove-Item -LiteralPath $CwdFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Hand-off files outlive panes that were killed rather than closed: a kill
+# runs no exit handler, so nothing removes theirs and `<temp>\wmux` grows one
+# small file per pane, forever.
+#
+# Age is what separates the two, and a live pane keeps its own file young from
+# both ends: the prompt rewrites it on every command, and its poller touches it
+# on every tick — 45 seconds apart, whether or not anyone is typing. So a file
+# nothing has touched for a day belonged to a pane that is gone, and none of
+# this requires asking wmux which surfaces still exist.
+function Remove-StaleWmuxCwdFiles {
+    param(
+        [string]$Directory,
+        [datetime]$OlderThan
+    )
+    if (-not $Directory) { return }
+    try {
+        Get-ChildItem -LiteralPath $Directory -Filter 'cwd-*.txt' -File -ErrorAction Stop |
+            Where-Object { $_.LastWriteTime -lt $OlderThan } |
+            ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue }
+    } catch {
+        # The directory may not exist yet, or may be unreadable — either way
+        # there is nothing to prune and nothing worth reporting.
+    }
+}
+
+$null = Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PSEngineEvent]::Exiting) -Action {
+    Invoke-WmuxExitCleanup -CwdFile $global:_wmux_cwd_file
+}
+
+# What a poller tick should send. Pure so the decision can be tested without a
+# job, a pipe, or a GitHub repo. An empty result means "say nothing".
+function Get-WmuxPrMessage {
+    param(
+        [string]$SurfaceId,
+        [string]$PrJson,
+        [int]$ExitCode,
+        [bool]$InRepo,
+        [bool]$Reported
+    )
+    # A pane standing outside a repo knows nothing about anyone else's PR, so it
+    # must not speak for the workspace at large — but it does still answer for
+    # the claim it made itself. Leaving that claim up is how a badge outlives
+    # the repo it came from: `cd ~` clears the branch off the row and leaves the
+    # PR sitting next to it. The ownership gate on the renderer side
+    # (`applyPrCommand`) drops a clear from any pane that isn't the recorded
+    # owner, so retracting here can only ever take down this pane's own badge.
+    if (-not $InRepo) {
+        if ($Reported) { return "clear_pr $SurfaceId" }
+        return ""
+    }
+
+    if ($ExitCode -eq 0 -and $PrJson) {
+        try {
+            $pr = $PrJson | ConvertFrom-Json -ErrorAction Stop
+            if ($null -ne $pr -and $pr.number) {
+                return "report_pr $SurfaceId $($pr.number) $($pr.state) $($pr.title)"
+            }
+        } catch {
+            # Fall through: unreadable output tells us nothing about the PR, and
+            # whatever this pane last claimed may no longer hold.
+        }
+    }
+
+    # We are looking at a branch and gh found no PR on it. Only retract a claim
+    # this pane actually made: PR metadata is workspace-scoped and every pwsh
+    # pane polls, so a pane clearing unconditionally would speak for panes it
+    # knows nothing about — two panes in one workspace would take turns
+    # reporting and clearing every 45 seconds.
+    if ($Reported) { return "clear_pr $SurfaceId" }
+    return ""
+}
+
+# What the poller should trust as "the pane is here" this tick. Pure other
+# than reading the hand-off file, so it can be tested directly against real
+# files rather than only through the job.
+#
+# Anything that leaves genuine doubt about where the pane currently is — the
+# file missing, empty, unreadable, or naming a path that Set-Location would
+# reject outright (deleted since the write, or a non-filesystem provider
+# location such as `cd Env:` whose ProviderPath is not a directory at all) —
+# returns $null rather than a best guess. A caller that fell back to "wherever
+# the job runspace last was" would go on polling (and reporting on) a stale
+# repo, which is the frozen-cwd bug this file exists to fix — the exit handler
+# above deletes this same file when the shell closes, so this also stops a job
+# that briefly outlives its shell from reporting on it.
+function Resolve-WmuxPaneCwd {
+    param([string]$CwdFile)
+    if (-not $CwdFile) { return $null }
+    if (-not (Test-Path -LiteralPath $CwdFile -PathType Leaf)) { return $null }
+    try {
+        $live = Get-Content -LiteralPath $CwdFile -Raw -ErrorAction Stop
+    } catch {
+        return $null
+    }
+    if (-not $live) { return $null }
+    $live = $live.Trim()
+    if (-not $live) { return $null }
+    try {
+        if (-not (Test-Path -LiteralPath $live -PathType Container -ErrorAction Stop)) { return $null }
+    } catch {
+        return $null
+    }
+    return $live
+}
+
+# Carries out one tick's send and updates the "did I claim this PR" flag from
+# the outcome, not from the decision. The send is handed in as a scriptblock
+# so this can be exercised without a live pipe: production passes the real
+# named-pipe write, tests pass a stub that can be made to fail on demand.
+#
+# The flag must only advance on a send that actually landed. The earlier shape
+# flipped it right after deciding what to send, before attempting the write —
+# so a clear_pr that failed to go out (pipe not up yet, wmux busy, connect
+# timeout) still left the pane believing it had nothing left to retract, and
+# no later tick would ever try that clear again: the badge this file exists to
+# unstick would get stuck the same way, just on the send instead of the
+# decision. Leaving the flag where it was makes the next tick recompute the
+# same message and retry it.
+function Invoke-WmuxPrTick {
+    param(
+        [string]$Message,
+        [bool]$CurrentlyReported,
+        [scriptblock]$Send
+    )
+    if (-not $Message) { return $CurrentlyReported }
+    $ok = $false
+    try {
+        $ok = [bool](& $Send $Message)
+    } catch {
+        $ok = $false
+    }
+    if (-not $ok) { return $CurrentlyReported }
+    return $Message.StartsWith('report_pr')
+}
+
 # Report git branch
 function Report-GitBranch {
     $surfaceId = $env:WMUX_SURFACE_ID
@@ -84,6 +270,7 @@ if (Get-Module -Name PSReadLine -ErrorAction SilentlyContinue) {
 $_wmux_original_prompt = $function:prompt
 function prompt {
     Report-Cwd
+    Update-WmuxCwdFile
     Report-GitBranch
     # Detect if last command was interrupted (Ctrl+C → exit code -1073741510 on Windows)
     if ($LASTEXITCODE -eq -1073741510 -or $LASTEXITCODE -eq 130) {
@@ -111,26 +298,74 @@ $global:_wmux_pr_started = $false
 $null = Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PSEngineEvent]::OnIdle) -Action {
     if ($global:_wmux_pr_started) { return }
     $global:_wmux_pr_started = $true
-    $global:_wmux_pr_job = Start-Job -ScriptBlock {
-        param($surfaceId, $pipeName, $pipeToken)
+    # Sweep hand-off files left behind by panes that were killed. Done here
+    # rather than during init for the same reason the job is: the first prompt
+    # should not wait on it.
+    if ($global:_wmux_cwd_file) {
+        Remove-StaleWmuxCwdFiles -Directory (Split-Path -Parent $global:_wmux_cwd_file) -OlderThan (Get-Date).AddDays(-1)
+    }
+    # A job runs in its own runspace and sees none of this session's functions,
+    # so the tick's decision functions are carried across as its initialization.
+    $_wmux_pr_init = [scriptblock]::Create("function Get-WmuxPrMessage {`n$(${function:Get-WmuxPrMessage})`n}`nfunction Resolve-WmuxPaneCwd {`n$(${function:Resolve-WmuxPaneCwd})`n}`nfunction Invoke-WmuxPrTick {`n$(${function:Invoke-WmuxPrTick})`n}")
+    $global:_wmux_pr_job = Start-Job -InitializationScript $_wmux_pr_init -ScriptBlock {
+        param($surfaceId, $pipeName, $pipeToken, $cwdFile)
+        # Whether the PR currently on the row is this pane's own claim.
+        $reported = $false
         while ($true) {
             Start-Sleep -Seconds 45
+            $msg = ""
             try {
-                $prJson = gh pr view --json number,state,title 2>$null
-                if ($LASTEXITCODE -eq 0 -and $prJson) {
-                    $pr = $prJson | ConvertFrom-Json
-                    $msg = "report_pr $surfaceId $($pr.number) $($pr.state) $($pr.title)"
-                    if ($pipeToken) { $msg = "auth $pipeToken $msg" }
+                # Follow the pane. This runspace's location is the one it was
+                # created in and never moves on its own, so a pane that has
+                # since cd'd into another repo would keep being answered for
+                # the first one — unless the hand-off can't be trusted this
+                # tick, in which case there is nothing to probe: staying on the
+                # old location and reporting its PR would be answering for a
+                # pane that may have moved on, or closed.
+                $resolvedCwd = Resolve-WmuxPaneCwd -CwdFile $cwdFile
+                if ($resolvedCwd) {
+                    # Vouch for the pane. The prompt rewrites this file, but a
+                    # pane can sit at an idle prompt for days, and the sweep in
+                    # Remove-StaleWmuxCwdFiles reads age as "is anyone still
+                    # here" — so a tick that just used the file says so, and a
+                    # live pane can never be swept out from under itself.
+                    try { (Get-Item -LiteralPath $cwdFile).LastWriteTime = Get-Date } catch {}
+                    Set-Location -LiteralPath $resolvedCwd
+                    $null = git rev-parse --git-dir 2>$null
+                    $inRepo = $LASTEXITCODE -eq 0
+                    $prJson = ""
+                    $ghExit = 1
+                    if ($inRepo) {
+                        $prJson = (gh pr view --json number,state,title 2>$null) -join "`n"
+                        $ghExit = $LASTEXITCODE
+                    }
+                    $msg = Get-WmuxPrMessage -SurfaceId $surfaceId -PrJson $prJson -ExitCode $ghExit `
+                        -InRepo $inRepo -Reported $reported
+                }
+            } catch {
+                # git or gh missing, or the location went away underneath us —
+                # all of which say nothing about the PR on the row.
+                $msg = ""
+            }
+            # The flag only moves if the send below actually lands — see
+            # Invoke-WmuxPrTick for why that ordering matters.
+            $reported = Invoke-WmuxPrTick -Message $msg -CurrentlyReported $reported -Send {
+                param($m)
+                try {
+                    $line = if ($pipeToken) { "auth $pipeToken $m" } else { $m }
                     $pipe = New-Object System.IO.Pipes.NamedPipeClientStream(".", $pipeName, [System.IO.Pipes.PipeDirection]::InOut)
                     $pipe.Connect(1000)
                     $writer = New-Object System.IO.StreamWriter($pipe)
                     $writer.AutoFlush = $true
-                    $writer.WriteLine($msg)
+                    $writer.WriteLine($line)
                     $pipe.Close()
+                    $true
+                } catch {
+                    $false
                 }
-            } catch { }
+            }
         }
-    } -ArgumentList $env:WMUX_SURFACE_ID, "wmux", $env:WMUX_PIPE_TOKEN
+    } -ArgumentList $env:WMUX_SURFACE_ID, "wmux", $env:WMUX_PIPE_TOKEN, $global:_wmux_cwd_file
 }
 
 # Quick-launch profile startup commands (issue #32).

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { DEFAULT_DEV_PORTS, mergeDevPorts, matchDevPorts, firstNewDevPort } from
 import { aggregateProgress } from './store/progress-slice';
 import { isDiffTabDismissed } from './store/surface-slice';
 import Sidebar from './components/Sidebar/Sidebar';
+import { applyPrCommand } from './pr-metadata';
 import Titlebar from './components/Titlebar/Titlebar';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import SettingsWindow from './components/Settings/SettingsWindow';
@@ -330,18 +331,15 @@ function handleSurfaceMetadata(cmd: any, ws: WorkspaceInfo, deps: MetaDeps): voi
     case 'clear_git_branch':
       deps.updateWorkspaceMetadata(ws.id, { gitBranch: undefined, gitDirty: undefined });
       break;
-    case 'report_pr': {
-      const [num, status, ...labelParts] = cmd.args || [];
-      deps.updateWorkspaceMetadata(ws.id, {
-        prNumber: num ? parseInt(num) : undefined,
-        prStatus: status as any,
-        prLabel: labelParts.join(' '),
-      });
+    case 'report_pr':
+    case 'clear_pr': {
+      // See pr-metadata.ts: `clear_pr` is gated on the surface that reported
+      // the PR still being the one asking to clear it, so one pane's poller
+      // can't wipe another pane's PR out of a shared workspace row.
+      const patch = applyPrCommand(cmd, ws);
+      if (patch) deps.updateWorkspaceMetadata(ws.id, patch);
       break;
     }
-    case 'clear_pr':
-      deps.updateWorkspaceMetadata(ws.id, { prNumber: undefined, prStatus: undefined, prLabel: undefined });
-      break;
     case 'report_shell_state':
       applyShellState(cmd, ws, deps);
       break;
@@ -378,7 +376,7 @@ function handleAgentLifecycleEvent(event: any, addNotification: StoreAction, t: 
  * (enforced in replaceSoleTerminalSurface), and not itself an agent surface.
  * Returns true when the spawn was handled via replacement.
  */
-function tryReplaceTabSpawn(event: any, ws: WorkspaceInfo, setAgentMeta: (surfaceId: any, meta: any) => void): boolean {
+export function tryReplaceTabSpawn(event: any, ws: WorkspaceInfo, setAgentMeta: (surfaceId: any, meta: any) => void): boolean {
   if (!event.replaceTab) return false;
   const state = useStore.getState();
   const leaf = findLeaf(ws.splitTree, event.paneId);
@@ -393,6 +391,13 @@ function tryReplaceTabSpawn(event: any, ws: WorkspaceInfo, setAgentMeta: (surfac
   // Intentionally not pushed onto the reopen-closed stack — the replaced
   // surface is an idle default shell, not user work.
   window.wmux?.pty?.kill(replacedSurfaceId);
+  // This kills the PTY directly instead of routing through closeSurface, so
+  // it must run the same ownership-gated PR-badge clear closeSurface would
+  // have run — otherwise a replaced tab that happened to hold the PR badge
+  // leaves `prSurfaceId` pointing at a surface that no longer exists, and
+  // since clear_pr is only honoured from its owner (see pr-metadata.ts), the
+  // badge becomes unclearable by anything, ever.
+  state.clearPrIfSurfaceOwner(event.workspaceId, [replacedSurfaceId]);
   return true;
 }
 

--- a/src/renderer/components/Sidebar/PrStatusIcon.tsx
+++ b/src/renderer/components/Sidebar/PrStatusIcon.tsx
@@ -1,12 +1,22 @@
 import React from 'react';
+import { normalizePrStatus, PrStatus } from './pr-status';
 
 interface PrStatusIconProps {
-  status: 'open' | 'merged' | 'closed';
+  status: PrStatus;
   size?: number;
 }
 
 export default function PrStatusIcon({ status, size = 12 }: PrStatusIconProps) {
-  switch (status) {
+  // Normalized here as well as at the `report_pr` handler (pr-metadata.ts):
+  // PR fields are never persisted across a save/restore (they're absent from
+  // both the auto-save and named-save snapshots in App.tsx, and from
+  // `replaceAllWorkspaces`), so a stale-casing value can't survive a restart.
+  // The guard earns its keep anyway as a second line of defense at the render
+  // boundary — any future caller that sets `prStatus` without going through
+  // the handler (a test fixture, a future direct-store write) gets the same
+  // protection this switch already needs to have, rather than a silently
+  // missing glyph.
+  switch (normalizePrStatus(status)) {
     case 'open':
       return (
         <svg width={size} height={size} viewBox="0 0 16 16" fill="#3fb950">
@@ -25,5 +35,10 @@ export default function PrStatusIcon({ status, size = 12 }: PrStatusIconProps) {
           <path d="M3.25 1A2.25 2.25 0 0 1 4 5.372v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 3.25 1Zm9.5 5.5a.75.75 0 0 1 .75.75v3.378a2.251 2.251 0 1 1-1.5 0V7.25a.75.75 0 0 1 .75-.75Zm-1.22-5.03a.75.75 0 0 1 1.06 0l1.5 1.5a.75.75 0 0 1-1.06 1.06l-1.5-1.5a.75.75 0 0 1 0-1.06Zm0 3.06a.75.75 0 0 1 0-1.06l1.5-1.5a.75.75 0 1 1 1.06 1.06l-1.5 1.5a.75.75 0 0 1-1.06 0Z" />
         </svg>
       );
+    default:
+      // Deliberately nothing, rather than falling off the end of the switch —
+      // an implicit `undefined` return is legal in React 19 and draws the same
+      // blank, which is how a missing glyph went unnoticed.
+      return null;
   }
 }

--- a/src/renderer/components/Sidebar/pr-status.ts
+++ b/src/renderer/components/Sidebar/pr-status.ts
@@ -1,0 +1,18 @@
+export type PrStatus = 'open' | 'merged' | 'closed';
+
+const PR_STATUSES: readonly PrStatus[] = ['open', 'merged', 'closed'];
+
+/**
+ * Fold a reported PR state onto the union the sidebar renders.
+ *
+ * `gh pr view --json state` answers `OPEN` / `MERGED` / `CLOSED`, and the V1
+ * `report_pr` command carries that string through untouched — so the value that
+ * reaches the store is in GitHub's casing, not the renderer's. Anything else is
+ * reported as absent: a state no icon knows would render as bare text beside a
+ * missing glyph, which reads as a stuck badge rather than an unknown one.
+ */
+export function normalizePrStatus(raw: string | undefined | null): PrStatus | undefined {
+  if (!raw) return undefined;
+  const lower = raw.trim().toLowerCase();
+  return PR_STATUSES.find((s) => s === lower);
+}

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -10,7 +10,7 @@ import { ProgressAddon } from '@xterm/addon-progress';
 import { useStore } from '../store';
 import { useT } from '../i18n';
 import { collectActiveTerminalSurfaceIds } from '../store/split-utils';
-import { SplitNode, ThemeConfig } from '../../shared/types';
+import { SplitNode, SurfaceId, ThemeConfig } from '../../shared/types';
 import { UserColorScheme } from '../store/settings-slice';
 import { activateTerminalLink, terminalLinkHandler } from '../utils/terminal-links';
 import {
@@ -816,6 +816,11 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
         // An exited process can't be making progress — drop any leftover
         // OSC 9;4 indicator (same stuck-badge reasoning as above).
         useStore.getState().setSurfaceProgress(id, null);
+        // Same reasoning again for the sidebar's PR badge: the shell that
+        // reported it is gone, and the tab it left behind can no longer
+        // retract its own claim. Ownership-gated inside, so this is a no-op
+        // for every pane that wasn't the one holding the badge.
+        useStore.getState().clearPrForSurface(id as SurfaceId);
         // Mouse modes belong to the application that asked for them, and it is
         // gone. Keeping them would replay tracking into the next terminal on
         // this surface — a plain shell that never requested it — and would also

--- a/src/renderer/pr-metadata.ts
+++ b/src/renderer/pr-metadata.ts
@@ -1,0 +1,48 @@
+import { SurfaceId, WorkspaceInfo } from '../shared/types';
+import { normalizePrStatus } from './components/Sidebar/pr-status';
+
+/**
+ * Pure decision logic for the `report_pr` / `clear_pr` V1 pipe commands
+ * (issue #4). Split out of `App.tsx`'s `handleSurfaceMetadata` so it can be
+ * exercised without pulling in the whole component tree — same reasoning as
+ * `pr-status.ts` next to `PrStatusIcon`.
+ *
+ * Every PowerShell pane in a workspace runs its own PR poller and they all
+ * write the SAME workspace-scoped fields, so a `clear_pr` from one pane can
+ * otherwise wipe a PR another pane just reported (two panes, two repos, one
+ * workspace). `ws.prSurfaceId` records who currently owns the row; a
+ * `clear_pr` is honoured only from that surface. When no owner is recorded
+ * — a fresh workspace, or one where the badge was already cleared — the
+ * comparison against `undefined` simply fails and the clear is dropped,
+ * which is correct: there is nothing to clear. In practice a workspace never
+ * has `prNumber` set without `prSurfaceId` alongside it, because PR metadata
+ * is never persisted across a restart (see `PrStatusIcon.tsx`) — the owner
+ * is always written in the same patch as the PR number.
+ *
+ * Returns the patch for `updateWorkspaceMetadata`, or `null` when the
+ * command is a no-op (an unowned/foreign `clear_pr`).
+ */
+export function applyPrCommand(
+  cmd: { command: string; surfaceId?: string; args?: string[] },
+  ws: Pick<WorkspaceInfo, 'prSurfaceId'>,
+): Partial<WorkspaceInfo> | null {
+  if (cmd.command === 'report_pr') {
+    const [num, status, ...labelParts] = cmd.args || [];
+    return {
+      prNumber: num ? parseInt(num) : undefined,
+      // gh reports OPEN/MERGED/CLOSED; the store and the icon speak the
+      // lowercase union. `SidebarMetadata.prStatus` is a plain string, so
+      // the casing difference had nothing to catch it on the way through.
+      prStatus: normalizePrStatus(status),
+      prLabel: labelParts.join(' '),
+      prSurfaceId: cmd.surfaceId as SurfaceId | undefined,
+    };
+  }
+
+  if (cmd.command === 'clear_pr') {
+    if (!cmd.surfaceId || cmd.surfaceId !== ws.prSurfaceId) return null;
+    return { prNumber: undefined, prStatus: undefined, prLabel: undefined, prSurfaceId: undefined };
+  }
+
+  return null;
+}

--- a/src/renderer/store/surface-slice.ts
+++ b/src/renderer/store/surface-slice.ts
@@ -5,6 +5,51 @@ import { findLeaf, removeLeaf, splitNode, getAllPaneIds } from './split-utils';
 import { killSurfacePty } from './pty-teardown';
 import { WorkspaceSlice } from './workspace-slice';
 
+// ─── PR badge teardown (issue #4, continued) ──────────────────────────────────
+//
+// Closing the pane/tab that reported a PR used to leave its sidebar badge up
+// forever. A killed PTY never runs a shell-side exit trap, so `clear_pr`
+// never arrives for a Ctrl+W, a tab-× click, or `wmux close-pane` — the store
+// has to notice the loss itself, at the SAME state transitions that already
+// reap the PTY (closeSurface, closePane, closeOtherSurfaces,
+// closeSurfacesToRight — everywhere `killSurfacePty` is called for a real
+// close). `ws.prSurfaceId` (see pr-metadata.ts) says who owns the row, so
+// this only clears when the surface actually leaving IS that owner.
+//
+// Deliberately NOT hooked on `moveSurface` / `splitAndMoveSurface`: the
+// surface — and the PR it owns — keeps existing, it's just relocated to
+// another pane. Both take a single `workspaceId` and move a surface within
+// that workspace's tree, so the owner never leaves the workspace whose row
+// carries the badge and the claim stays answerable.
+//
+// A shell that dies inside a still-open tab (the user types `exit`, or the
+// process falls over) reaches none of those transitions — nothing calls
+// closeSurface/closePane, the tab is still there — so it is answered from the
+// `pty:exit` handler in useTerminal.ts instead, through `clearPrForSurface`
+// below. That is the same place a stuck "Running" badge and a leftover
+// progress indicator are already healed, and it is a signal the renderer gets
+// whether the shell left gracefully or not.
+//
+// Exposed as a store action (rather than kept module-private) so callers
+// outside this slice — `App.tsx`'s `--replace-tab` spawn path, which
+// destroys the reporting surface directly via `pty.kill` instead of going
+// through `closeSurface` — can run the same ownership-gated clear instead of
+// re-deriving it.
+function clearPrIfOwner(
+  get: () => SliceState,
+  workspaceId: WorkspaceId,
+  closingSurfaceIds: readonly SurfaceId[],
+): void {
+  const ws = get().workspaces.find((w) => w.id === workspaceId);
+  if (!ws?.prSurfaceId || !closingSurfaceIds.includes(ws.prSurfaceId)) return;
+  get().updateWorkspaceMetadata(workspaceId, {
+    prNumber: undefined,
+    prStatus: undefined,
+    prLabel: undefined,
+    prSurfaceId: undefined,
+  });
+}
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface SurfaceSlice {
@@ -35,6 +80,29 @@ export interface SurfaceSlice {
 
   /** Close a surface; if it's the last one in the pane, the pane is removed */
   closeSurface: (workspaceId: WorkspaceId, paneId: PaneId, surfaceId: SurfaceId) => void;
+
+  /**
+   * Drop the workspace's PR badge iff `ws.prSurfaceId` is one of
+   * `destroyedSurfaceIds` — a no-op otherwise (unowned badge, or the owner
+   * isn't in the list). Every in-slice close path (closeSurface, closePane,
+   * closeOtherSurfaces, closeSurfacesToRight) already runs this at the same
+   * transition that reaps the PTY; this is the same check exposed for a
+   * caller OUTSIDE the slice that destroys a surface a different way (see
+   * `App.tsx`'s `--replace-tab` spawn path, which calls `pty.kill` directly
+   * rather than routing through `closeSurface`) — so that path doesn't have
+   * to re-derive the ownership rule to avoid leaving an unclearable badge.
+   */
+  clearPrIfSurfaceOwner: (workspaceId: WorkspaceId, destroyedSurfaceIds: readonly SurfaceId[]) => void;
+
+  /**
+   * Drop the PR badge owned by `surfaceId`, wherever it lives — the same
+   * ownership-gated clear, for a caller that knows only the surface. Used by
+   * the `pty:exit` handler in useTerminal.ts: a shell can die with its tab
+   * still open (the user types `exit`, or the process falls over), and there
+   * is no close transition for that at all, so nothing else would notice the
+   * pane that reported the PR is no longer able to speak for it.
+   */
+  clearPrForSurface: (surfaceId: SurfaceId) => void;
 
   /**
    * The path behind every USER close gesture for a tab (the tab ×, Ctrl+W).
@@ -225,6 +293,15 @@ function pushClosedSurface(workspaceId: WorkspaceId, surface: SurfaceRef): void 
 // ─── Slice creator ───────────────────────────────────────────────────────────
 
 export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> = (set, get) => ({
+  clearPrIfSurfaceOwner(workspaceId, destroyedSurfaceIds) {
+    clearPrIfOwner(get, workspaceId, destroyedSurfaceIds);
+  },
+
+  clearPrForSurface(surfaceId) {
+    const ws = get().workspaces.find((w) => w.prSurfaceId === surfaceId);
+    if (ws) clearPrIfOwner(get, ws.id, [surfaceId]);
+  },
+
   addSurface(workspaceId, paneId, type, options) {
     const surfaceId: SurfaceId = `surf-${uuid()}` as SurfaceId;
 
@@ -332,6 +409,7 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
     if (closing) {
       pushClosedSurface(workspaceId, closing);
       killSurfacePty(closing);
+      clearPrIfOwner(get, workspaceId, [closing.id]);
     }
 
     const newSurfaces = leaf.surfaces.filter((s) => s.id !== surfaceId);
@@ -385,6 +463,7 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
       if (surface.type === 'diff') diffTabDismissed.add(workspaceId);
       killSurfacePty(surface);
     }
+    clearPrIfOwner(get, workspaceId, leaf.surfaces.map((s) => s.id));
     updateSplitTree(workspaceId, newTree);
   },
 
@@ -402,11 +481,14 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
 
     // Reap the shells we're dropping and remember them for Ctrl+Shift+T,
     // mirroring the bookkeeping in closeSurface (issues #64, #65).
+    const dropped: SurfaceId[] = [];
     for (const s of leaf.surfaces) {
       if (s.id === keepSurfaceId) continue;
       pushClosedSurface(workspaceId, s);
       killSurfacePty(s);
+      dropped.push(s.id);
     }
+    clearPrIfOwner(get, workspaceId, dropped);
 
     const updatedTree = patchLeaf(ws.splitTree, paneId, {
       surfaces: [keep],
@@ -428,10 +510,12 @@ export const createSurfaceSlice: StateCreator<SliceState, [], [], SurfaceSlice> 
 
     // Reap the shells to the right and remember them for Ctrl+Shift+T,
     // mirroring the bookkeeping in closeSurface (issues #64, #65).
-    for (const s of leaf.surfaces.slice(idx + 1)) {
+    const dropped = leaf.surfaces.slice(idx + 1);
+    for (const s of dropped) {
       pushClosedSurface(workspaceId, s);
       killSurfacePty(s);
     }
+    clearPrIfOwner(get, workspaceId, dropped.map((s) => s.id));
 
     const newSurfaces = leaf.surfaces.slice(0, idx + 1);
     const newActiveIndex = Math.min(leaf.activeSurfaceIndex, newSurfaces.length - 1);

--- a/src/renderer/store/workspace-slice.ts
+++ b/src/renderer/store/workspace-slice.ts
@@ -74,6 +74,12 @@ export const createWorkspaceSlice: StateCreator<WorkspaceSlice> = (set, get) => 
       prNumber: options.prNumber,
       prStatus: options.prStatus,
       prLabel: options.prLabel,
+      // No current caller passes PR fields into createWorkspace, so this is
+      // latent — but a workspace created WITH a PR and no recorded owner
+      // would have a badge nothing could ever clear (clear_pr is only
+      // honoured from ws.prSurfaceId; see pr-metadata.ts). Copying it keeps
+      // the PR fields internally consistent regardless.
+      prSurfaceId: options.prSurfaceId,
       ports: options.ports,
       notificationText: options.notificationText,
       shellState: options.shellState,

--- a/src/renderer/styles/sidebar.css
+++ b/src/renderer/styles/sidebar.css
@@ -337,6 +337,9 @@
 
 .workspace-row__pr-status {
   opacity: 0.7;
+  /* The state is stored lowercase (the icon switches on it); the badge has
+     always read in gh's uppercase, so it keeps reading that way. */
+  text-transform: uppercase;
 }
 
 /* PR state is colour-coded (open/merged/draft) — same reasoning as __status. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -101,6 +101,13 @@ export interface WorkspaceInfo {
   prNumber?: number;
   prStatus?: 'open' | 'merged' | 'closed';
   prLabel?: string;
+  // Which surface reported the currently-shown PR (issue #4 continued). Every
+  // PowerShell pane in a workspace polls its own PR independently and all of
+  // them write these same workspace-scoped fields, so without an owner a
+  // `clear_pr` from one pane can wipe a PR a DIFFERENT pane just reported.
+  // Gates `clear_pr` in `applyPrCommand` (pr-metadata.ts) and the badge's
+  // teardown-on-close in `surface-slice.ts`.
+  prSurfaceId?: SurfaceId;
   ports?: number[];
   notificationText?: string;
   shellState?: 'idle' | 'running' | 'interrupted';
@@ -216,6 +223,7 @@ export interface SidebarMetadata {
   prNumber?: number;
   prStatus?: string;
   prLabel?: string;
+  prSurfaceId?: SurfaceId;
   ports?: number[];
   notificationText?: string;
   shellState?: 'idle' | 'running' | 'interrupted';

--- a/src/shell-integration/wmux-powershell-integration.ps1
+++ b/src/shell-integration/wmux-powershell-integration.ps1
@@ -41,6 +41,192 @@ function Report-Cwd {
     }
 }
 
+# Publish the live cwd for the PR poller.
+#
+# The poller runs in a child runspace, which takes the location it was created
+# in and keeps it, so it needs to be told where the pane has got to. An env var
+# cannot carry that: the job is already running by the time the pane moves.
+#
+# Nor can the pipe, which is the obvious candidate and the one to rule out
+# explicitly. It runs one direction — shell to wmux — and the consumer here is
+# another *shell* process, not wmux. The prompt already sends this exact value
+# over as report_pwd; routing the hand-off through the pipe would mean adding
+# currentCwd to the surface listing, a V2 method and a CLI verb to read it back,
+# then spawning node on every 45s tick, so that the shell can ask wmux for
+# something the shell itself just told it. This is a shell-to-shell hand-off, so
+# it stays between the shells.
+#
+# The directory is the one wmux-bash-integration.sh already uses for its own
+# hand-off, rather than a second scratch location.
+$global:_wmux_cwd_file = if ($env:WMUX_SURFACE_ID) {
+    $dir = Join-Path ([System.IO.Path]::GetTempPath()) "wmux"
+    try { $null = New-Item -ItemType Directory -Path $dir -Force -ErrorAction Stop } catch {}
+    Join-Path $dir "cwd-$($env:WMUX_SURFACE_ID).txt"
+} else { $null }
+
+function Update-WmuxCwdFile {
+    if (-not $global:_wmux_cwd_file) { return }
+    try {
+        Set-Content -LiteralPath $global:_wmux_cwd_file -Value $PWD.ProviderPath -Encoding UTF8 -ErrorAction Stop
+    } catch {
+        # Nothing to do — the poller just keeps its last known location.
+    }
+}
+
+# What the shell owes on the way out: its own hand-off file, so a pane that
+# closes leaves nothing behind. Parameterized so it can be driven directly in
+# a test instead of only through a real process exit.
+#
+# The PR badge is deliberately NOT this function's business. A shell that is
+# killed rather than asked to leave (Ctrl+W, `wmux close-pane`, closing the
+# workspace) runs no exit handler at all, and a last-gasp pipe write is
+# best-effort by nature — so the badge is dropped where the renderer already
+# learns the process is gone: the `pty:exit` handler in useTerminal.ts, which
+# heals the stuck "Running" badge and the leftover progress indicator for
+# exactly the same reason. That path covers the graceful `exit` too, so there
+# is nothing left here for it to do.
+function Invoke-WmuxExitCleanup {
+    param([string]$CwdFile)
+    if ($CwdFile) {
+        Remove-Item -LiteralPath $CwdFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Hand-off files outlive panes that were killed rather than closed: a kill
+# runs no exit handler, so nothing removes theirs and `<temp>\wmux` grows one
+# small file per pane, forever.
+#
+# Age is what separates the two, and a live pane keeps its own file young from
+# both ends: the prompt rewrites it on every command, and its poller touches it
+# on every tick — 45 seconds apart, whether or not anyone is typing. So a file
+# nothing has touched for a day belonged to a pane that is gone, and none of
+# this requires asking wmux which surfaces still exist.
+function Remove-StaleWmuxCwdFiles {
+    param(
+        [string]$Directory,
+        [datetime]$OlderThan
+    )
+    if (-not $Directory) { return }
+    try {
+        Get-ChildItem -LiteralPath $Directory -Filter 'cwd-*.txt' -File -ErrorAction Stop |
+            Where-Object { $_.LastWriteTime -lt $OlderThan } |
+            ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue }
+    } catch {
+        # The directory may not exist yet, or may be unreadable — either way
+        # there is nothing to prune and nothing worth reporting.
+    }
+}
+
+$null = Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PSEngineEvent]::Exiting) -Action {
+    Invoke-WmuxExitCleanup -CwdFile $global:_wmux_cwd_file
+}
+
+# What a poller tick should send. Pure so the decision can be tested without a
+# job, a pipe, or a GitHub repo. An empty result means "say nothing".
+function Get-WmuxPrMessage {
+    param(
+        [string]$SurfaceId,
+        [string]$PrJson,
+        [int]$ExitCode,
+        [bool]$InRepo,
+        [bool]$Reported
+    )
+    # A pane standing outside a repo knows nothing about anyone else's PR, so it
+    # must not speak for the workspace at large — but it does still answer for
+    # the claim it made itself. Leaving that claim up is how a badge outlives
+    # the repo it came from: `cd ~` clears the branch off the row and leaves the
+    # PR sitting next to it. The ownership gate on the renderer side
+    # (`applyPrCommand`) drops a clear from any pane that isn't the recorded
+    # owner, so retracting here can only ever take down this pane's own badge.
+    if (-not $InRepo) {
+        if ($Reported) { return "clear_pr $SurfaceId" }
+        return ""
+    }
+
+    if ($ExitCode -eq 0 -and $PrJson) {
+        try {
+            $pr = $PrJson | ConvertFrom-Json -ErrorAction Stop
+            if ($null -ne $pr -and $pr.number) {
+                return "report_pr $SurfaceId $($pr.number) $($pr.state) $($pr.title)"
+            }
+        } catch {
+            # Fall through: unreadable output tells us nothing about the PR, and
+            # whatever this pane last claimed may no longer hold.
+        }
+    }
+
+    # We are looking at a branch and gh found no PR on it. Only retract a claim
+    # this pane actually made: PR metadata is workspace-scoped and every pwsh
+    # pane polls, so a pane clearing unconditionally would speak for panes it
+    # knows nothing about — two panes in one workspace would take turns
+    # reporting and clearing every 45 seconds.
+    if ($Reported) { return "clear_pr $SurfaceId" }
+    return ""
+}
+
+# What the poller should trust as "the pane is here" this tick. Pure other
+# than reading the hand-off file, so it can be tested directly against real
+# files rather than only through the job.
+#
+# Anything that leaves genuine doubt about where the pane currently is — the
+# file missing, empty, unreadable, or naming a path that Set-Location would
+# reject outright (deleted since the write, or a non-filesystem provider
+# location such as `cd Env:` whose ProviderPath is not a directory at all) —
+# returns $null rather than a best guess. A caller that fell back to "wherever
+# the job runspace last was" would go on polling (and reporting on) a stale
+# repo, which is the frozen-cwd bug this file exists to fix — the exit handler
+# above deletes this same file when the shell closes, so this also stops a job
+# that briefly outlives its shell from reporting on it.
+function Resolve-WmuxPaneCwd {
+    param([string]$CwdFile)
+    if (-not $CwdFile) { return $null }
+    if (-not (Test-Path -LiteralPath $CwdFile -PathType Leaf)) { return $null }
+    try {
+        $live = Get-Content -LiteralPath $CwdFile -Raw -ErrorAction Stop
+    } catch {
+        return $null
+    }
+    if (-not $live) { return $null }
+    $live = $live.Trim()
+    if (-not $live) { return $null }
+    try {
+        if (-not (Test-Path -LiteralPath $live -PathType Container -ErrorAction Stop)) { return $null }
+    } catch {
+        return $null
+    }
+    return $live
+}
+
+# Carries out one tick's send and updates the "did I claim this PR" flag from
+# the outcome, not from the decision. The send is handed in as a scriptblock
+# so this can be exercised without a live pipe: production passes the real
+# named-pipe write, tests pass a stub that can be made to fail on demand.
+#
+# The flag must only advance on a send that actually landed. The earlier shape
+# flipped it right after deciding what to send, before attempting the write —
+# so a clear_pr that failed to go out (pipe not up yet, wmux busy, connect
+# timeout) still left the pane believing it had nothing left to retract, and
+# no later tick would ever try that clear again: the badge this file exists to
+# unstick would get stuck the same way, just on the send instead of the
+# decision. Leaving the flag where it was makes the next tick recompute the
+# same message and retry it.
+function Invoke-WmuxPrTick {
+    param(
+        [string]$Message,
+        [bool]$CurrentlyReported,
+        [scriptblock]$Send
+    )
+    if (-not $Message) { return $CurrentlyReported }
+    $ok = $false
+    try {
+        $ok = [bool](& $Send $Message)
+    } catch {
+        $ok = $false
+    }
+    if (-not $ok) { return $CurrentlyReported }
+    return $Message.StartsWith('report_pr')
+}
+
 # Report git branch
 function Report-GitBranch {
     $surfaceId = $env:WMUX_SURFACE_ID
@@ -84,6 +270,7 @@ if (Get-Module -Name PSReadLine -ErrorAction SilentlyContinue) {
 $_wmux_original_prompt = $function:prompt
 function prompt {
     Report-Cwd
+    Update-WmuxCwdFile
     Report-GitBranch
     # Detect if last command was interrupted (Ctrl+C → exit code -1073741510 on Windows)
     if ($LASTEXITCODE -eq -1073741510 -or $LASTEXITCODE -eq 130) {
@@ -111,26 +298,74 @@ $global:_wmux_pr_started = $false
 $null = Register-EngineEvent -SourceIdentifier ([System.Management.Automation.PSEngineEvent]::OnIdle) -Action {
     if ($global:_wmux_pr_started) { return }
     $global:_wmux_pr_started = $true
-    $global:_wmux_pr_job = Start-Job -ScriptBlock {
-        param($surfaceId, $pipeName, $pipeToken)
+    # Sweep hand-off files left behind by panes that were killed. Done here
+    # rather than during init for the same reason the job is: the first prompt
+    # should not wait on it.
+    if ($global:_wmux_cwd_file) {
+        Remove-StaleWmuxCwdFiles -Directory (Split-Path -Parent $global:_wmux_cwd_file) -OlderThan (Get-Date).AddDays(-1)
+    }
+    # A job runs in its own runspace and sees none of this session's functions,
+    # so the tick's decision functions are carried across as its initialization.
+    $_wmux_pr_init = [scriptblock]::Create("function Get-WmuxPrMessage {`n$(${function:Get-WmuxPrMessage})`n}`nfunction Resolve-WmuxPaneCwd {`n$(${function:Resolve-WmuxPaneCwd})`n}`nfunction Invoke-WmuxPrTick {`n$(${function:Invoke-WmuxPrTick})`n}")
+    $global:_wmux_pr_job = Start-Job -InitializationScript $_wmux_pr_init -ScriptBlock {
+        param($surfaceId, $pipeName, $pipeToken, $cwdFile)
+        # Whether the PR currently on the row is this pane's own claim.
+        $reported = $false
         while ($true) {
             Start-Sleep -Seconds 45
+            $msg = ""
             try {
-                $prJson = gh pr view --json number,state,title 2>$null
-                if ($LASTEXITCODE -eq 0 -and $prJson) {
-                    $pr = $prJson | ConvertFrom-Json
-                    $msg = "report_pr $surfaceId $($pr.number) $($pr.state) $($pr.title)"
-                    if ($pipeToken) { $msg = "auth $pipeToken $msg" }
+                # Follow the pane. This runspace's location is the one it was
+                # created in and never moves on its own, so a pane that has
+                # since cd'd into another repo would keep being answered for
+                # the first one — unless the hand-off can't be trusted this
+                # tick, in which case there is nothing to probe: staying on the
+                # old location and reporting its PR would be answering for a
+                # pane that may have moved on, or closed.
+                $resolvedCwd = Resolve-WmuxPaneCwd -CwdFile $cwdFile
+                if ($resolvedCwd) {
+                    # Vouch for the pane. The prompt rewrites this file, but a
+                    # pane can sit at an idle prompt for days, and the sweep in
+                    # Remove-StaleWmuxCwdFiles reads age as "is anyone still
+                    # here" — so a tick that just used the file says so, and a
+                    # live pane can never be swept out from under itself.
+                    try { (Get-Item -LiteralPath $cwdFile).LastWriteTime = Get-Date } catch {}
+                    Set-Location -LiteralPath $resolvedCwd
+                    $null = git rev-parse --git-dir 2>$null
+                    $inRepo = $LASTEXITCODE -eq 0
+                    $prJson = ""
+                    $ghExit = 1
+                    if ($inRepo) {
+                        $prJson = (gh pr view --json number,state,title 2>$null) -join "`n"
+                        $ghExit = $LASTEXITCODE
+                    }
+                    $msg = Get-WmuxPrMessage -SurfaceId $surfaceId -PrJson $prJson -ExitCode $ghExit `
+                        -InRepo $inRepo -Reported $reported
+                }
+            } catch {
+                # git or gh missing, or the location went away underneath us —
+                # all of which say nothing about the PR on the row.
+                $msg = ""
+            }
+            # The flag only moves if the send below actually lands — see
+            # Invoke-WmuxPrTick for why that ordering matters.
+            $reported = Invoke-WmuxPrTick -Message $msg -CurrentlyReported $reported -Send {
+                param($m)
+                try {
+                    $line = if ($pipeToken) { "auth $pipeToken $m" } else { $m }
                     $pipe = New-Object System.IO.Pipes.NamedPipeClientStream(".", $pipeName, [System.IO.Pipes.PipeDirection]::InOut)
                     $pipe.Connect(1000)
                     $writer = New-Object System.IO.StreamWriter($pipe)
                     $writer.AutoFlush = $true
-                    $writer.WriteLine($msg)
+                    $writer.WriteLine($line)
                     $pipe.Close()
+                    $true
+                } catch {
+                    $false
                 }
-            } catch { }
+            }
         }
-    } -ArgumentList $env:WMUX_SURFACE_ID, "wmux", $env:WMUX_PIPE_TOKEN
+    } -ArgumentList $env:WMUX_SURFACE_ID, "wmux", $env:WMUX_PIPE_TOKEN, $global:_wmux_cwd_file
 }
 
 # Quick-launch profile startup commands (issue #32).

--- a/tests/unit/app-replace-tab-pr.test.ts
+++ b/tests/unit/app-replace-tab-pr.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useStore } from '../../src/renderer/store';
+import { tryReplaceTabSpawn } from '../../src/renderer/App';
+import { WorkspaceId, PaneId, SurfaceId, WorkspaceInfo } from '../../src/shared/types';
+
+// Issue #4 (continued), blocker 1 from external review: `--replace-tab` agent
+// spawn (PR #85) destroys the pane's sole idle terminal directly via
+// `pty.kill`, bypassing `closeSurface` entirely — so the ownership-gated PR
+// badge clear that `closeSurface` runs never fires. If that terminal happened
+// to be the surface that reported the workspace's PR, `prSurfaceId` is left
+// naming a surface that no longer exists. Because `clear_pr` is only honoured
+// from its recorded owner (pr-metadata.ts), nothing — not even a fresh
+// `report_pr`/`clear_pr` pair from another pane — can ever clear it again.
+
+describe('tryReplaceTabSpawn PR badge teardown', () => {
+  let kill: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    kill = vi.fn();
+    (globalThis as any).window = { wmux: { pty: { kill } } };
+    useStore.setState({ workspaces: [], activeWorkspaceId: null, agentMeta: new Map() } as any);
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).window;
+  });
+
+  function setup() {
+    const workspaceId = useStore.getState().createWorkspace({ title: 'Test WS' });
+    const ws = useStore.getState().workspaces.find((w) => w.id === workspaceId) as WorkspaceInfo;
+    const paneId = (ws.splitTree as Extract<typeof ws.splitTree, { type: 'leaf' }>).paneId as PaneId;
+    const soleSurfaceId = (ws.splitTree as Extract<typeof ws.splitTree, { type: 'leaf' }>).surfaces[0].id;
+    return { workspaceId, paneId, soleSurfaceId };
+  }
+
+  function setAgentMeta(surfaceId: any, meta: any) {
+    useStore.setState((state) => {
+      const next = new Map(state.agentMeta);
+      next.set(surfaceId, meta);
+      return { agentMeta: next } as any;
+    });
+  }
+
+  it('clears the PR badge when the replaced sole terminal was the owner', () => {
+    const { workspaceId, paneId, soleSurfaceId } = setup();
+    useStore.getState().updateWorkspaceMetadata(workspaceId, {
+      prNumber: 7,
+      prStatus: 'open',
+      prLabel: 'Some PR',
+      prSurfaceId: soleSurfaceId,
+    });
+    const ws = useStore.getState().workspaces.find((w) => w.id === workspaceId) as WorkspaceInfo;
+
+    const event = {
+      type: 'spawned',
+      replaceTab: true,
+      surfaceId: 'surf-agent' as SurfaceId,
+      paneId,
+      workspaceId,
+      agentId: 'agent-1',
+      label: 'Agent',
+    };
+
+    const handled = tryReplaceTabSpawn(event, ws, setAgentMeta);
+
+    expect(handled).toBe(true);
+    expect(kill).toHaveBeenCalledWith(soleSurfaceId);
+    const updated = useStore.getState().workspaces.find((w) => w.id === workspaceId) as WorkspaceInfo;
+    expect(updated.prNumber).toBeUndefined();
+    expect(updated.prSurfaceId).toBeUndefined();
+  });
+
+  it('leaves the PR badge alone when a different surface owns it', () => {
+    const { workspaceId, paneId, soleSurfaceId } = setup();
+    const otherOwner = 'surf-other-owner' as SurfaceId;
+    useStore.getState().updateWorkspaceMetadata(workspaceId, {
+      prNumber: 7,
+      prStatus: 'open',
+      prLabel: 'Some PR',
+      prSurfaceId: otherOwner,
+    });
+    const ws = useStore.getState().workspaces.find((w) => w.id === workspaceId) as WorkspaceInfo;
+
+    const event = {
+      type: 'spawned',
+      replaceTab: true,
+      surfaceId: 'surf-agent-2' as SurfaceId,
+      paneId,
+      workspaceId,
+      agentId: 'agent-2',
+      label: 'Agent',
+    };
+
+    const handled = tryReplaceTabSpawn(event, ws, setAgentMeta);
+
+    expect(handled).toBe(true);
+    expect(kill).toHaveBeenCalledWith(soleSurfaceId);
+    const updated = useStore.getState().workspaces.find((w) => w.id === workspaceId) as WorkspaceInfo;
+    expect(updated.prNumber).toBe(7);
+    expect(updated.prSurfaceId).toBe(otherOwner);
+  });
+});

--- a/tests/unit/pr-metadata.test.ts
+++ b/tests/unit/pr-metadata.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+
+import { applyPrCommand } from '../../src/renderer/pr-metadata';
+import { SurfaceId } from '../../src/shared/types';
+
+const SURF_A = 'surf-aaaa' as SurfaceId;
+const SURF_B = 'surf-bbbb' as SurfaceId;
+
+/**
+ * Ownership gate for `clear_pr` (issue #4, Codex review follow-up).
+ *
+ * Every PowerShell pane in a workspace runs its own PR poller, so two panes
+ * on two different repos/branches both write the SAME workspace-scoped PR
+ * fields. Before this fix, `clear_pr` from either pane wiped the row
+ * unconditionally: pane A reports #1, pane B (different repo) reports #2 —
+ * the row now shows #2 — then pane A's branch loses its PR and pane A sends
+ * `clear_pr`, wiping pane B's #2 even though B's PR is still open. The
+ * PowerShell side can't fix this alone: it only knows whether IT reported,
+ * not whether something else has since overwritten the row.
+ */
+describe('applyPrCommand — report_pr', () => {
+  it('records the reporting surface as the owner alongside the PR fields', () => {
+    const patch = applyPrCommand(
+      { command: 'report_pr', surfaceId: SURF_A, args: ['42', 'OPEN', 'Fix', 'thing'] },
+      {},
+    );
+    expect(patch).toEqual({
+      prNumber: 42,
+      prStatus: 'open',
+      prLabel: 'Fix thing',
+      prSurfaceId: SURF_A,
+    });
+  });
+});
+
+describe('applyPrCommand — clear_pr ownership gate', () => {
+  it('clears the PR when it comes from the surface that reported it', () => {
+    const patch = applyPrCommand(
+      { command: 'clear_pr', surfaceId: SURF_A },
+      { prSurfaceId: SURF_A },
+    );
+    expect(patch).toEqual({
+      prNumber: undefined,
+      prStatus: undefined,
+      prLabel: undefined,
+      prSurfaceId: undefined,
+    });
+  });
+
+  it('is dropped as a no-op when it comes from a different surface than the owner', () => {
+    // Pane B owns the row (reported #2); pane A's clear must not touch it.
+    const patch = applyPrCommand(
+      { command: 'clear_pr', surfaceId: SURF_A },
+      { prSurfaceId: SURF_B },
+    );
+    expect(patch).toBeNull();
+  });
+
+  it('is dropped as a no-op when no owner is recorded yet', () => {
+    const patch = applyPrCommand(
+      { command: 'clear_pr', surfaceId: SURF_A },
+      {},
+    );
+    expect(patch).toBeNull();
+  });
+});

--- a/tests/unit/pr-poll.test.ts
+++ b/tests/unit/pr-poll.test.ts
@@ -1,0 +1,627 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+
+/**
+ * The PR poller in the PowerShell integration can raise a PR badge but never
+ * lower one (issue #4).
+ *
+ * Two things keep a merged or foreign PR pinned to a workspace row:
+ *
+ *  1. The tick reports only on success. `gh pr view` failing — no PR for this
+ *     branch, not a repo, gh not authed — sends nothing at all, so the last
+ *     value stands. `clear_pr` is handled in App.tsx but has no sender, unlike
+ *     `clear_git_branch`, whose clearing half is already wired up in both the
+ *     PowerShell and bash integrations.
+ *
+ *  2. `Start-Job` hands the child runspace the location captured at call time
+ *     and keeps it there. The poller is started on the shell's first idle (a
+ *     deliberate startup-cost fix), so every later `gh pr view` answers for the
+ *     directory the pane opened in — `cd` to another repo or worktree and the
+ *     row keeps showing the first one's PR.
+ *
+ * The per-tick decision is a pure function so it can be exercised here against
+ * a real PowerShell host rather than pattern-matched; the wiring around it is
+ * read back out of the script.
+ */
+
+const SCRIPT = path.join(__dirname, '..', '..', 'src', 'shell-integration', 'wmux-powershell-integration.ps1');
+// Normalized to LF: the script is CRLF on disk, and every offset below looks
+// for a brace on its own line.
+const source = fs.readFileSync(SCRIPT, 'utf8').replace(/\r\n/g, '\n');
+
+/**
+ * Lift a top-level `function Name { … }` out of the integration script.
+ * Terminated by a closing brace in column 0, which is how every function in
+ * this file is written.
+ */
+function extractFunction(name: string): string {
+  const start = source.indexOf(`function ${name} {`);
+  expect(start, `${name} is not defined in ${path.basename(SCRIPT)}`).toBeGreaterThan(-1);
+  const end = source.indexOf('\n}\n', start);
+  expect(end, `${name} has no column-0 closing brace`).toBeGreaterThan(start);
+  return source.slice(start, end + 2);
+}
+
+/**
+ * The job's script block — everything the poller runs on a tick. Anchored on
+ * the `Start-Job` *call*, not the first mention of the word: the comments above
+ * it discuss the job, and slicing from those swept in the functions in between.
+ */
+function pollerJobBlock(): string {
+  const start = source.indexOf('= Start-Job ');
+  expect(start, 'no Start-Job call in the integration script').toBeGreaterThan(-1);
+  return source.slice(start);
+}
+
+function findPowerShell(): string | null {
+  for (const exe of ['pwsh.exe', 'powershell.exe', 'pwsh']) {
+    try {
+      execFileSync(exe, ['-NoProfile', '-NonInteractive', '-Command', 'exit 0'], { stdio: 'ignore' });
+      return exe;
+    } catch {
+      // Not installed, or refused to run — try the next host.
+    }
+  }
+  return null;
+}
+
+const host = findPowerShell();
+
+/**
+ * Run `Get-WmuxPrMessage` in a real host. Written to a temp .ps1 and invoked
+ * with -File: the arguments carry JSON and quotes, and -Command would have them
+ * re-parsed by the host's own command-line splitter on the way in.
+ */
+function prMessage(args: {
+  surfaceId: string;
+  prJson: string;
+  exitCode: number;
+  inRepo?: boolean;
+  reported?: boolean;
+}): string {
+  // Single-quoted PowerShell literals: the payload is JSON, and a double-quoted
+  // string would have its `"` and `$` re-read by the parser.
+  const ps = (s: string) => `'${s.replace(/'/g, "''")}'`;
+  const script = [
+    extractFunction('Get-WmuxPrMessage'),
+    '',
+    `Get-WmuxPrMessage -SurfaceId ${ps(args.surfaceId)} ` +
+      `-PrJson ${ps(args.prJson)} -ExitCode ${args.exitCode} ` +
+      `-InRepo $${args.inRepo ?? true} -Reported $${args.reported ?? false}`,
+    '',
+  ].join('\n');
+
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-pr-')), 'probe.ps1');
+  fs.writeFileSync(file, script, 'utf8');
+  try {
+    return execFileSync(host as string, ['-NoProfile', '-NonInteractive', '-File', file], {
+      encoding: 'utf8',
+    }).trim();
+  } finally {
+    fs.rmSync(path.dirname(file), { recursive: true, force: true });
+  }
+}
+
+describe.skipIf(!host)('Get-WmuxPrMessage — what a poller tick decides to send', () => {
+  const surfaceId = 'surf-1111';
+
+  it('reports the PR when gh resolved one', () => {
+    const json = JSON.stringify({ number: 450, state: 'MERGED', title: 'Fix the thing' });
+    expect(prMessage({ surfaceId, prJson: json, exitCode: 0 })).toBe(
+      `report_pr ${surfaceId} 450 MERGED Fix the thing`,
+    );
+  });
+
+  it('keeps a multi-word title in one piece', () => {
+    // pipe-server.ts:139 rejoins everything past the state, so spaces survive
+    // the trip — the message just has to carry them.
+    const json = JSON.stringify({ number: 7, state: 'OPEN', title: 'a b c d' });
+    expect(prMessage({ surfaceId, prJson: json, exitCode: 0 })).toBe(`report_pr ${surfaceId} 7 OPEN a b c d`);
+  });
+
+  it('retracts its own report when the branch it reported has no PR', () => {
+    // The tick that used to send nothing and leave the previous PR up forever.
+    expect(prMessage({ surfaceId, prJson: '', exitCode: 1, reported: true })).toBe(`clear_pr ${surfaceId}`);
+  });
+
+  it('retracts when gh exits zero but says nothing', () => {
+    expect(prMessage({ surfaceId, prJson: '', exitCode: 0, reported: true })).toBe(`clear_pr ${surfaceId}`);
+  });
+
+  it('retracts rather than reporting unparseable output', () => {
+    expect(prMessage({ surfaceId, prJson: 'not json at all', exitCode: 0, reported: true })).toBe(
+      `clear_pr ${surfaceId}`,
+    );
+  });
+
+  // PR metadata is workspace-scoped but every pwsh pane polls, so a pane that
+  // clears unconditionally speaks for panes it knows nothing about. Two panes
+  // in one workspace — one on a branch with a PR, one not — would take turns
+  // reporting and clearing every 45s. A pane only ever retracts its own claim.
+  it('stays quiet when it never reported a PR in the first place', () => {
+    expect(prMessage({ surfaceId, prJson: '', exitCode: 1, reported: false })).toBe('');
+  });
+
+  // Walking out of a repo is the one way a badge could outlive what it
+  // describes: the prompt clears the branch off the row on the very next
+  // command, and a poller that stayed quiet here would leave the PR sitting
+  // beside a row that no longer has a repo behind it. The retraction is safe
+  // for the same reason as every other one — it names this pane, and the
+  // renderer honours a clear only from the pane that currently owns the badge.
+  it('retracts its own badge when the pane walks out of the repo', () => {
+    expect(prMessage({ surfaceId, prJson: '', exitCode: 1, inRepo: false, reported: true })).toBe(
+      `clear_pr ${surfaceId}`,
+    );
+  });
+
+  // Still nothing to say for a pane that never claimed the badge — the pane in
+  // ~ must not clear the PR its neighbour just reported.
+  it('stays quiet outside a repo when it never claimed the badge', () => {
+    expect(prMessage({ surfaceId, prJson: '', exitCode: 1, inRepo: false, reported: false })).toBe('');
+  });
+
+  it('reports nothing from outside a repo even if gh answered', () => {
+    const json = JSON.stringify({ number: 450, state: 'MERGED', title: 't' });
+    expect(prMessage({ surfaceId, prJson: json, exitCode: 0, inRepo: false })).toBe('');
+  });
+});
+
+describe.skipIf(!host)('the integration script itself', () => {
+  it('parses in a real PowerShell host', () => {
+    // Nothing else here would notice a syntax error: the tests above lift one
+    // function out of the file, and the ones below read it as text. A shell
+    // integration that fails to parse takes the whole pane's prompt, git
+    // branch and shell state down with it, silently.
+    const probe = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-parse-')), 'parse.ps1');
+    fs.writeFileSync(
+      probe,
+      [
+        '$errors = $null',
+        `$null = [System.Management.Automation.Language.Parser]::ParseFile('${SCRIPT.replace(/'/g, "''")}', [ref]$null, [ref]$errors)`,
+        'if ($errors) { $errors | ForEach-Object { "$($_.Extent.StartLineNumber): $($_.Message)" } }',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    try {
+      const out = execFileSync(host as string, ['-NoProfile', '-NonInteractive', '-File', probe], {
+        encoding: 'utf8',
+      }).trim();
+      expect(out, `parse errors in ${path.basename(SCRIPT)}`).toBe('');
+    } finally {
+      fs.rmSync(path.dirname(probe), { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * Run `Resolve-WmuxPaneCwd` in a real host against a real temp file. This is
+ * genuinely filesystem-shaped behavior (missing file, empty file, a path that
+ * no longer exists) so it's exercised with real files rather than mocked.
+ */
+function resolvePaneCwd(cwdFile: string | null): string {
+  const script = [extractFunction('Resolve-WmuxPaneCwd'), '', `$r = Resolve-WmuxPaneCwd -CwdFile ${cwdFile ? `'${cwdFile.replace(/'/g, "''")}'` : "''"}`, 'if ($null -eq $r) { "<null>" } else { $r }', ''].join('\n');
+  const file = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-resolve-')), 'probe.ps1');
+  fs.writeFileSync(file, script, 'utf8');
+  try {
+    return execFileSync(host as string, ['-NoProfile', '-NonInteractive', '-File', file], {
+      encoding: 'utf8',
+    }).trim();
+  } finally {
+    fs.rmSync(path.dirname(file), { recursive: true, force: true });
+  }
+}
+
+describe.skipIf(!host)('Resolve-WmuxPaneCwd — what the job trusts as "the pane is here"', () => {
+  it('resolves a file that names a real directory', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-realdir-'));
+    const cwdFile = path.join(dir, 'cwd.txt');
+    fs.writeFileSync(cwdFile, dir, 'utf8');
+    expect(resolvePaneCwd(cwdFile)).toBe(dir);
+  });
+
+  it('returns nothing when the hand-off file does not exist', () => {
+    const missing = path.join(os.tmpdir(), 'wmux-does-not-exist', 'cwd.txt');
+    expect(resolvePaneCwd(missing)).toBe('<null>');
+  });
+
+  it('returns nothing when the hand-off file is empty', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-empty-'));
+    const cwdFile = path.join(dir, 'cwd.txt');
+    fs.writeFileSync(cwdFile, '', 'utf8');
+    expect(resolvePaneCwd(cwdFile)).toBe('<null>');
+  });
+
+  it('returns nothing when the hand-off file is whitespace only', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-ws-'));
+    const cwdFile = path.join(dir, 'cwd.txt');
+    fs.writeFileSync(cwdFile, '   \n', 'utf8');
+    expect(resolvePaneCwd(cwdFile)).toBe('<null>');
+  });
+
+  it('returns nothing when the named path no longer exists (deleted since the write)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-stale-'));
+    const cwdFile = path.join(dir, 'cwd.txt');
+    const goneDir = path.join(dir, 'gone');
+    fs.mkdirSync(goneDir);
+    fs.writeFileSync(cwdFile, goneDir, 'utf8');
+    fs.rmdirSync(goneDir);
+    expect(resolvePaneCwd(cwdFile)).toBe('<null>');
+  });
+
+  it('returns nothing when no cwd file was ever configured', () => {
+    expect(resolvePaneCwd(null)).toBe('<null>');
+  });
+});
+
+/**
+ * Run `Invoke-WmuxPrTick` in a real host with a stubbed `-Send`, so the
+ * send-succeeded/send-failed branches can be driven without a live pipe. The
+ * stub records whether it ran (and with what) by writing to a marker file —
+ * PowerShell script blocks passed through `Start-Job`-adjacent plumbing can't
+ * hand a value back to the Node test process any other way.
+ */
+function invokeTick(args: {
+  message: string;
+  currentlyReported: boolean;
+  sendSucceeds: boolean;
+}): { reported: boolean; sendCalledWith: string | null } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-tick-'));
+  const marker = path.join(dir, 'sent.txt').replace(/\\/g, '\\\\');
+  const ps = (s: string) => `'${s.replace(/'/g, "''")}'`;
+  const script = [
+    extractFunction('Invoke-WmuxPrTick'),
+    '',
+    `$send = { param($m) Set-Content -LiteralPath '${marker}' -Value $m -Encoding UTF8; $${args.sendSucceeds} }`,
+    `$r = Invoke-WmuxPrTick -Message ${ps(args.message)} -CurrentlyReported $${args.currentlyReported} -Send $send`,
+    '"reported=$r"',
+    '',
+  ].join('\n');
+  const file = path.join(dir, 'probe.ps1');
+  fs.writeFileSync(file, script, 'utf8');
+  try {
+    const out = execFileSync(host as string, ['-NoProfile', '-NonInteractive', '-File', file], {
+      encoding: 'utf8',
+    }).trim();
+    const markerPath = path.join(dir, 'sent.txt');
+    const sendCalledWith = fs.existsSync(markerPath) ? fs.readFileSync(markerPath, 'utf8').trim() : null;
+    return { reported: out === 'reported=True', sendCalledWith };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe.skipIf(!host)('Invoke-WmuxPrTick — the flag only advances on a send that landed', () => {
+  it('flips reported to true after a report_pr send that succeeds', () => {
+    const { reported, sendCalledWith } = invokeTick({
+      message: 'report_pr surf-1 5 OPEN t',
+      currentlyReported: false,
+      sendSucceeds: true,
+    });
+    expect(sendCalledWith).toBe('report_pr surf-1 5 OPEN t');
+    expect(reported).toBe(true);
+  });
+
+  it('flips reported to false after a clear_pr send that succeeds', () => {
+    const { reported } = invokeTick({
+      message: 'clear_pr surf-1',
+      currentlyReported: true,
+      sendSucceeds: true,
+    });
+    expect(reported).toBe(false);
+  });
+
+  // This is defect 1: the old job set `$reported = $msg.StartsWith("report_pr")`
+  // BEFORE attempting the send, so a clear that failed to go out still made the
+  // pane believe it had nothing left to retract, and no later tick would ever
+  // try that clear again. The flag must stay put on a failed send so the next
+  // tick computes the same clear_pr and retries it.
+  it('leaves reported=true alone when a clear_pr send fails, so the clear is retried', () => {
+    const { reported, sendCalledWith } = invokeTick({
+      message: 'clear_pr surf-1',
+      currentlyReported: true,
+      sendSucceeds: false,
+    });
+    expect(sendCalledWith).toBe('clear_pr surf-1'); // the send was attempted
+    expect(reported).toBe(true); // but the flag didn't move, so it'll retry
+  });
+
+  it('leaves reported=false alone when a report_pr send fails, so the report is retried', () => {
+    const { reported } = invokeTick({
+      message: 'report_pr surf-1 5 OPEN t',
+      currentlyReported: false,
+      sendSucceeds: false,
+    });
+    expect(reported).toBe(false);
+  });
+
+  it('never calls Send when the tick has nothing to say, and leaves the flag untouched', () => {
+    const { reported, sendCalledWith } = invokeTick({
+      message: '',
+      currentlyReported: true,
+      sendSucceeds: true,
+    });
+    expect(sendCalledWith).toBeNull();
+    expect(reported).toBe(true);
+  });
+});
+
+/**
+ * Run `Invoke-WmuxExitCleanup` in a real host, so the shell's own way out can
+ * be exercised without a real process exit.
+ */
+function invokeExitCleanup(cwdFile: string | null): { cwdFileRemoved: boolean } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-exit-'));
+  const ps = (v: string | null) => (v === null ? '$null' : `'${v.replace(/'/g, "''")}'`);
+  const script = [extractFunction('Invoke-WmuxExitCleanup'), '', `Invoke-WmuxExitCleanup -CwdFile ${ps(cwdFile)}`, ''].join('\n');
+  const file = path.join(dir, 'probe.ps1');
+  fs.writeFileSync(file, script, 'utf8');
+  try {
+    execFileSync(host as string, ['-NoProfile', '-NonInteractive', '-File', file], { encoding: 'utf8' });
+    return { cwdFileRemoved: cwdFile ? !fs.existsSync(cwdFile) : true };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// The shell's exit handler owes exactly one thing: its own hand-off file. The
+// badge is dropped from the renderer's `pty:exit` handler instead, which sees
+// a shell that was killed just as well as one that left on its own.
+describe.skipIf(!host)('Invoke-WmuxExitCleanup — what a shell owes on the way out', () => {
+  it('removes the cwd hand-off file when one was configured', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-exit-cwd-'));
+    const cwdFile = path.join(dir, 'cwd.txt');
+    fs.writeFileSync(cwdFile, dir, 'utf8');
+    try {
+      expect(invokeExitCleanup(cwdFile).cwdFileRemoved).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does nothing, quietly, when the pane has no hand-off file', () => {
+    expect(() => invokeExitCleanup(null)).not.toThrow();
+  });
+
+  it('does not throw when the file is already gone', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-exit-missing-'));
+    const cwdFile = path.join(dir, 'never-written.txt');
+    try {
+      expect(invokeExitCleanup(cwdFile).cwdFileRemoved).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+/**
+ * Drive `Remove-StaleWmuxCwdFiles` over a real directory in a real host.
+ * Returns the file names still standing afterwards.
+ */
+function pruneCwdFiles(dir: string, olderThanDays: number): string[] {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-prune-'));
+  const script = [
+    extractFunction('Remove-StaleWmuxCwdFiles'),
+    '',
+    `Remove-StaleWmuxCwdFiles -Directory '${dir.replace(/'/g, "''")}' -OlderThan (Get-Date).AddDays(-${olderThanDays})`,
+    '',
+  ].join('\n');
+  const file = path.join(probeDir, 'probe.ps1');
+  fs.writeFileSync(file, script, 'utf8');
+  try {
+    execFileSync(host as string, ['-NoProfile', '-NonInteractive', '-File', file], { encoding: 'utf8' });
+    return fs.existsSync(dir) ? fs.readdirSync(dir).sort() : [];
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+}
+
+// A pane that is killed rather than closed runs no exit handler, so nothing
+// removes its hand-off file — without a sweep the directory grows one small
+// file per pane for the life of the machine.
+describe.skipIf(!host)('Remove-StaleWmuxCwdFiles — the sweep for panes that were killed', () => {
+  const age = (file: string, days: number) => {
+    const when = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    fs.utimesSync(file, when, when);
+  };
+
+  it('drops a hand-off file nothing has touched for longer than the cutoff', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-stale-'));
+    try {
+      const stale = path.join(dir, 'cwd-surf-old.txt');
+      fs.writeFileSync(stale, dir, 'utf8');
+      age(stale, 3);
+      expect(pruneCwdFiles(dir, 1)).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves a live pane alone — its file is rewritten on every prompt', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-live-'));
+    try {
+      const live = path.join(dir, 'cwd-surf-live.txt');
+      const stale = path.join(dir, 'cwd-surf-dead.txt');
+      fs.writeFileSync(live, dir, 'utf8');
+      fs.writeFileSync(stale, dir, 'utf8');
+      age(stale, 3);
+      expect(pruneCwdFiles(dir, 1)).toEqual(['cwd-surf-live.txt']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('touches nothing else in the directory, however old', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-other-'));
+    try {
+      const other = path.join(dir, 'screenshot-1.png');
+      fs.writeFileSync(other, 'x', 'utf8');
+      age(other, 30);
+      expect(pruneCwdFiles(dir, 1)).toEqual(['screenshot-1.png']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('says nothing about a directory that does not exist', () => {
+    const dir = path.join(os.tmpdir(), 'wmux-absent-dir-that-was-never-made');
+    expect(() => pruneCwdFiles(dir, 1)).not.toThrow();
+  });
+});
+
+describe.skipIf(!host)('the poller job', () => {
+  it('can call Get-WmuxPrMessage inside the job runspace', () => {
+    // A job is a separate runspace and inherits none of the session's
+    // functions, so the tick's decision function is handed over as the job's
+    // initialization script. If that hand-off ever stopped working the tick
+    // would throw on every pass and clear the badge forever — the same symptom
+    // as the bug, from the other direction.
+    const initLine = source.split('\n').find((l) => l.includes('[scriptblock]::Create('));
+    expect(initLine, 'no initialization script built for the job').toBeTruthy();
+
+    const probe = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-job-')), 'job.ps1');
+    fs.writeFileSync(
+      probe,
+      [
+        extractFunction('Get-WmuxPrMessage'),
+        '',
+        (initLine as string).trim(),
+        '$j = Start-Job -InitializationScript $_wmux_pr_init -ScriptBlock {',
+        "  Get-WmuxPrMessage -SurfaceId 'surf-1' -PrJson '{\"number\":450,\"state\":\"MERGED\",\"title\":\"t\"}' " +
+          '-ExitCode 0 -InRepo $true -Reported $false',
+        '}',
+        '$null = Wait-Job $j -Timeout 30',
+        'Receive-Job $j',
+        'Remove-Job $j -Force',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    try {
+      const out = execFileSync(host as string, ['-NoProfile', '-NonInteractive', '-File', probe], {
+        encoding: 'utf8',
+      }).trim();
+      expect(out).toBe('report_pr surf-1 450 MERGED t');
+    } finally {
+      fs.rmSync(path.dirname(probe), { recursive: true, force: true });
+    }
+  });
+
+  it('can call Resolve-WmuxPaneCwd and Invoke-WmuxPrTick inside the job runspace', () => {
+    // Same hand-off mechanism as above, for the two functions added to fix
+    // defects #1 and #2 — if either were left out of the initialization
+    // script the job would throw the moment it tried to call them.
+    const initLine = source.split('\n').find((l) => l.includes('[scriptblock]::Create('));
+    expect(initLine, 'no initialization script built for the job').toBeTruthy();
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wmux-job2-'));
+    const cwdFile = path.join(dir, 'cwd.txt');
+    fs.writeFileSync(cwdFile, dir, 'utf8');
+    const probe = path.join(dir, 'job.ps1');
+    fs.writeFileSync(
+      probe,
+      [
+        extractFunction('Get-WmuxPrMessage'),
+        extractFunction('Resolve-WmuxPaneCwd'),
+        extractFunction('Invoke-WmuxPrTick'),
+        '',
+        (initLine as string).trim(),
+        `$cwdFile = '${cwdFile.replace(/'/g, "''")}'`,
+        '$j = Start-Job -InitializationScript $_wmux_pr_init -ScriptBlock {',
+        '  param($cwdFile)',
+        '  $resolved = Resolve-WmuxPaneCwd -CwdFile $cwdFile',
+        "  $sent = Invoke-WmuxPrTick -Message 'clear_pr surf-1' -CurrentlyReported $true -Send { param($m) $false }",
+        '  "resolved=$resolved sent=$sent"',
+        '} -ArgumentList $cwdFile',
+        '$null = Wait-Job $j -Timeout 30',
+        'Receive-Job $j',
+        'Remove-Job $j -Force',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    try {
+      const out = execFileSync(host as string, ['-NoProfile', '-NonInteractive', '-File', probe], {
+        encoding: 'utf8',
+      }).trim();
+      // Resolve-WmuxPaneCwd found the real dir; Invoke-WmuxPrTick kept the
+      // flag true because the stubbed send returned $false (the retry path).
+      expect(out).toBe(`resolved=${dir} sent=True`);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('PR poller wiring', () => {
+  it('sends whatever the tick decided, not only the success case', () => {
+    const job = pollerJobBlock();
+    expect(job).toContain('Get-WmuxPrMessage');
+    // The old shape: a lone `if` around the send, with no else.
+    expect(job).not.toMatch(/if\s*\(\s*\$LASTEXITCODE\s*-eq\s*0\s*-and\s*\$prJson\s*\)/);
+  });
+
+  it('re-reads the pane cwd on every tick instead of trusting Start-Job', () => {
+    const job = pollerJobBlock();
+    expect(job).toContain('Set-Location');
+  });
+
+  it('asks whether the pane is in a repo before deciding anything', () => {
+    // Distinguishes "on a branch with no PR" (the pane's own claim to retract)
+    // from "not looking at a repo at all" (nothing to say about the badge).
+    expect(pollerJobBlock()).toMatch(/git\s+rev-parse/);
+  });
+
+  it('remembers whether it was the one that reported', () => {
+    const job = pollerJobBlock();
+    expect(job).toContain('-Reported');
+  });
+
+  it('touches the hand-off file each tick, so a live pane is never swept', () => {
+    // The sweep reads age as "is anyone still here", and the prompt is the
+    // only other writer — so a pane parked at an idle prompt for a day would
+    // otherwise have its own file deleted by the next shell to start, and
+    // stop being polled until someone typed in it.
+    expect(pollerJobBlock()).toMatch(/LastWriteTime\s*=\s*Get-Date/);
+  });
+
+  it('routes the send through Invoke-WmuxPrTick instead of flipping the flag inline', () => {
+    // The bug this guards: `$reported = $msg.StartsWith("report_pr")` executed
+    // BEFORE the pipe write, so a failed send still lost the pane's memory of
+    // having reported. Send-then-flip has to happen in one place the tests can
+    // drive with a stubbed send (see the Invoke-WmuxPrTick describe block
+    // below) rather than inline in the job where only a live pipe reaches it.
+    const job = pollerJobBlock();
+    expect(job).toContain('Invoke-WmuxPrTick');
+    expect(job).not.toMatch(/\$reported\s*=\s*\$msg\.StartsWith/);
+  });
+
+  it('treats an unresolvable cwd as no information, not as "stay put"', () => {
+    // The old shape skipped Set-Location on a bad hand-off and fell through to
+    // probing git/gh from wherever the job runspace last was — reporting a
+    // stale repo's PR as if it were current. Resolve-WmuxPaneCwd centralizes
+    // "can we even tell where the pane is" so the job can skip the probe
+    // entirely rather than guess.
+    const job = pollerJobBlock();
+    expect(job).toContain('Resolve-WmuxPaneCwd');
+  });
+
+  it('keeps the cwd hand-off in the temp directory the integrations already use', () => {
+    // wmux-bash-integration.sh writes under <temp>\wmux; sharing it keeps this
+    // from becoming a second scratch location, and makes the leftovers easy to
+    // find if the exit handler ever misses one.
+    expect(source).toMatch(/Join-Path \(\[System\.IO\.Path\]::GetTempPath\(\)\) "wmux"/);
+    expect(source).toContain('PSEngineEvent]::Exiting');
+  });
+
+  it('publishes the pane cwd from the prompt, which is where it is known', () => {
+    // The job is a separate process: an env var set after it started is
+    // invisible to it, so the live location has to be handed over out-of-band.
+    expect(source).toContain('Update-WmuxCwdFile');
+    const prompt = source.slice(source.indexOf('function prompt {'));
+    expect(prompt.slice(0, prompt.indexOf('\n}\n'))).toContain('Update-WmuxCwdFile');
+  });
+});

--- a/tests/unit/pr-status.test.ts
+++ b/tests/unit/pr-status.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+
+import { normalizePrStatus } from '../../src/renderer/components/Sidebar/pr-status';
+import PrStatusIcon from '../../src/renderer/components/Sidebar/PrStatusIcon';
+
+/**
+ * The sidebar's PR badge renders its number and state but never its icon
+ * (issue #4).
+ *
+ * `gh pr view --json state` answers in GitHub's own casing — `OPEN`, `MERGED`,
+ * `CLOSED` — and that string travels the V1 pipe verbatim into
+ * `updateWorkspaceMetadata`. `WorkspaceMetadata.prStatus` is typed `string`
+ * (types.ts:217) while `Workspace.prStatus` is the narrow lowercase union
+ * (types.ts:102), so the `as any` at the `report_pr` handler is accepted and
+ * the uppercase value lands in the store unchallenged.
+ *
+ * `PrStatusIcon` then switches on the lowercase union with no default arm, so
+ * every real report falls off the end and the component returns `undefined`.
+ * React 19 renders that as nothing rather than throwing, which is why the badge
+ * degrades quietly to a bare `#450 MERGED` instead of failing loudly.
+ *
+ * Two guards: normalize on the way in at the `report_pr` handler, and let the
+ * icon accept whatever casing reaches it anyway. PR fields aren't persisted
+ * across a save/restore, so the second guard isn't recovering from a stale
+ * session — it's a cheap defense at the render boundary against anything
+ * else that might set `prStatus` without going through the handler.
+ */
+describe('normalizePrStatus', () => {
+  it("accepts gh's own casing", () => {
+    // Exactly what `gh pr view --json state` emits.
+    expect(normalizePrStatus('OPEN')).toBe('open');
+    expect(normalizePrStatus('MERGED')).toBe('merged');
+    expect(normalizePrStatus('CLOSED')).toBe('closed');
+  });
+
+  it('passes an already-lowercase state through unchanged', () => {
+    expect(normalizePrStatus('open')).toBe('open');
+    expect(normalizePrStatus('merged')).toBe('merged');
+    expect(normalizePrStatus('closed')).toBe('closed');
+  });
+
+  it('reports an unrecognized state as absent rather than storing it', () => {
+    // A state nothing downstream can render is worse than no state at all: the
+    // row would print the raw word next to a missing glyph.
+    expect(normalizePrStatus('DRAFT')).toBeUndefined();
+    expect(normalizePrStatus('')).toBeUndefined();
+    expect(normalizePrStatus(undefined)).toBeUndefined();
+  });
+});
+
+describe('PrStatusIcon', () => {
+  // Called as a plain function — these tests need the return value, not a DOM.
+  const render = (status: string) => PrStatusIcon({ status: status as never, size: 12 });
+
+  it('renders an icon for each state gh can report, in gh casing', () => {
+    for (const status of ['OPEN', 'MERGED', 'CLOSED']) {
+      expect(render(status), `no icon for ${status}`).not.toBeNull();
+      expect(React.isValidElement(render(status))).toBe(true);
+    }
+  });
+
+  it('still renders an icon for the lowercase union it was written against', () => {
+    for (const status of ['open', 'merged', 'closed']) {
+      expect(React.isValidElement(render(status))).toBe(true);
+    }
+  });
+
+  it('returns null — never undefined — for a state it does not know', () => {
+    // `undefined` from a component is legal in React 19 but is exactly how the
+    // missing glyph hid: the switch simply ran off the end. An explicit null
+    // says "nothing to draw here" on purpose.
+    expect(render('DRAFT')).toBeNull();
+  });
+});

--- a/tests/unit/surface-slice.test.ts
+++ b/tests/unit/surface-slice.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 import { create } from 'zustand';
 import { createWorkspaceSlice, WorkspaceSlice } from '../../src/renderer/store/workspace-slice';
 import { createSurfaceSlice, isDiffTabDismissed, SurfaceSlice } from '../../src/renderer/store/surface-slice';
+import { getAllPaneIds, splitNode } from '../../src/renderer/store/split-utils';
 import { WorkspaceId, PaneId, SurfaceId, SplitNode } from '../../src/shared/types';
 
 type TestStore = WorkspaceSlice & SurfaceSlice;
@@ -111,6 +114,195 @@ describe('surface-slice', () => {
       const leaf = currentLeaf();
       expect(leaf.surfaces).toHaveLength(1);
       expect(leaf.activeSurfaceIndex).toBe(0);
+    });
+  });
+
+  // Issue #4 (continued): closing the pane/tab that reported a PR used to
+  // leave its badge on the sidebar row forever. A killed PTY never runs a
+  // shell-side exit trap, so `clear_pr` never arrives for a Ctrl+W or `wmux
+  // close-pane` — the store has to notice the loss itself, at the same state
+  // transition that already reaps the PTY (see pty-teardown.ts).
+  describe('PR badge teardown on close', () => {
+    function workspace() {
+      return useStore.getState().workspaces.find((w) => w.id === workspaceId)!;
+    }
+
+    function reportPr(surfaceId: SurfaceId) {
+      useStore.getState().updateWorkspaceMetadata(workspaceId, {
+        prNumber: 42,
+        prStatus: 'open',
+        prLabel: 'Fix thing',
+        prSurfaceId: surfaceId,
+      });
+    }
+
+    it('closeSurface clears the badge when the closed surface is the one that reported it', () => {
+      // Two tabs so this exercises closeSurface's own branch, not the
+      // last-tab delegation to closePane.
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      const owner = currentLeaf().surfaces[0].id;
+      reportPr(owner);
+
+      useStore.getState().closeSurface(workspaceId, paneId, owner);
+
+      expect(workspace().prNumber).toBeUndefined();
+      expect(workspace().prSurfaceId).toBeUndefined();
+    });
+
+    it('closeSurface leaves the badge alone when a different surface is closed', () => {
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      const owner = currentLeaf().surfaces[0].id;
+      const other = currentLeaf().surfaces[1].id;
+      reportPr(owner);
+
+      useStore.getState().closeSurface(workspaceId, paneId, other);
+
+      expect(workspace().prNumber).toBe(42);
+      expect(workspace().prSurfaceId).toBe(owner);
+    });
+
+    it('closePane clears the badge when the reporting surface lives in that pane', () => {
+      // Two panes so the workspace survives the close and can be inspected.
+      const secondPaneId = `pane-test-2` as PaneId;
+      useStore.getState().updateSplitTree(
+        workspaceId,
+        splitNode(workspace().splitTree, paneId, secondPaneId, 'terminal', 'horizontal'),
+      );
+      const owner = currentLeaf().surfaces[0].id;
+      reportPr(owner);
+
+      useStore.getState().closePane(workspaceId, paneId);
+
+      expect(getAllPaneIds(workspace().splitTree)).toEqual([secondPaneId]);
+      expect(workspace().prNumber).toBeUndefined();
+      expect(workspace().prSurfaceId).toBeUndefined();
+    });
+
+    it('closeOtherSurfaces clears the badge when the reporting surface is among the ones dropped', () => {
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      const owner = currentLeaf().surfaces[0].id;
+      const keep = currentLeaf().surfaces[1].id;
+      reportPr(owner);
+
+      useStore.getState().closeOtherSurfaces(workspaceId, paneId, keep);
+
+      expect(workspace().prNumber).toBeUndefined();
+      expect(workspace().prSurfaceId).toBeUndefined();
+    });
+
+    it('closeSurfacesToRight clears the badge when the reporting surface is among the ones dropped', () => {
+      const first = currentLeaf().surfaces[0].id;
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      const owner = currentLeaf().surfaces[1].id;
+      reportPr(owner);
+
+      useStore.getState().closeSurfacesToRight(workspaceId, paneId, first);
+
+      expect(workspace().prNumber).toBeUndefined();
+      expect(workspace().prSurfaceId).toBeUndefined();
+    });
+
+    it('closePane leaves the badge alone when the owner lives in a different pane', () => {
+      const secondPaneId = `pane-test-2` as PaneId;
+      useStore.getState().updateSplitTree(
+        workspaceId,
+        splitNode(workspace().splitTree, paneId, secondPaneId, 'terminal', 'horizontal'),
+      );
+      const owner = currentLeaf().surfaces[0].id;
+      reportPr(owner);
+
+      // Close the OTHER pane — the owner's pane is untouched.
+      useStore.getState().closePane(workspaceId, secondPaneId);
+
+      expect(workspace().prNumber).toBe(42);
+      expect(workspace().prSurfaceId).toBe(owner);
+    });
+
+    it('closeOtherSurfaces leaves the badge alone when the owner is the tab being kept', () => {
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      const owner = currentLeaf().surfaces[0].id;
+      reportPr(owner);
+
+      useStore.getState().closeOtherSurfaces(workspaceId, paneId, owner);
+
+      expect(workspace().prNumber).toBe(42);
+      expect(workspace().prSurfaceId).toBe(owner);
+    });
+
+    it('closeSurfacesToRight leaves the badge alone when the owner is left of the cut', () => {
+      const owner = currentLeaf().surfaces[0].id;
+      reportPr(owner);
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      const second = currentLeaf().surfaces[1].id;
+
+      // Cut after `second`, which is right of `owner` — owner is never dropped.
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      useStore.getState().closeSurfacesToRight(workspaceId, paneId, second);
+
+      expect(workspace().prNumber).toBe(42);
+      expect(workspace().prSurfaceId).toBe(owner);
+    });
+
+    it('moveSurface does NOT clear the badge — the surface still exists, just under a different pane', () => {
+      const secondPaneId = `pane-test-2` as PaneId;
+      useStore.getState().updateSplitTree(
+        workspaceId,
+        splitNode(workspace().splitTree, paneId, secondPaneId, 'terminal', 'horizontal'),
+      );
+      const owner = currentLeaf().surfaces[0].id;
+      reportPr(owner);
+
+      useStore.getState().moveSurface(workspaceId, paneId, owner, secondPaneId);
+
+      expect(workspace().prNumber).toBe(42);
+      expect(workspace().prSurfaceId).toBe(owner);
+    });
+
+    // The shell dying inside a still-open tab reaches none of the close
+    // transitions above, so the renderer's `pty:exit` handler answers for it
+    // through clearPrForSurface — which has only a surface id to go on.
+    it('clearPrForSurface clears the badge owned by an exited surface, wherever it lives', () => {
+      const owner = currentLeaf().surfaces[0].id;
+      reportPr(owner);
+
+      useStore.getState().clearPrForSurface(owner);
+
+      expect(workspace().prNumber).toBeUndefined();
+      expect(workspace().prSurfaceId).toBeUndefined();
+    });
+
+    it('clearPrForSurface leaves a badge belonging to another surface alone', () => {
+      useStore.getState().addSurface(workspaceId, paneId, 'terminal');
+      const owner = currentLeaf().surfaces[0].id;
+      const other = currentLeaf().surfaces[1].id;
+      reportPr(owner);
+
+      useStore.getState().clearPrForSurface(other);
+
+      expect(workspace().prNumber).toBe(42);
+      expect(workspace().prSurfaceId).toBe(owner);
+    });
+
+    it('clearPrForSurface is a no-op when no workspace owns a badge at all', () => {
+      const orphan = currentLeaf().surfaces[0].id;
+
+      expect(() => useStore.getState().clearPrForSurface(orphan)).not.toThrow();
+      expect(workspace().prNumber).toBeUndefined();
+    });
+
+    // The action above is only useful if the exit handler actually calls it,
+    // and that handler lives inside a hook that needs a real xterm instance to
+    // exercise. Reading the wiring back out of the source is the cheap half of
+    // that: it cannot prove the handler runs, but it does catch the call being
+    // dropped in a later edit, which would put the badge straight back to
+    // outliving its shell.
+    it('is wired into the pty:exit handler, alongside the other stuck-badge heals', () => {
+      const hook = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'src', 'renderer', 'hooks', 'useTerminal.ts'),
+        'utf8',
+      );
+      const exitHandler = hook.slice(hook.indexOf('window.wmux.pty.onExit('));
+      expect(exitHandler).toMatch(/clearPrForSurface\(id/);
     });
   });
 

--- a/tests/unit/workspace-create-pr-fields.test.ts
+++ b/tests/unit/workspace-create-pr-fields.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { create } from 'zustand';
+import { createWorkspaceSlice, WorkspaceSlice } from '../../src/renderer/store/workspace-slice';
+import { SurfaceId } from '../../src/shared/types';
+
+// Issue #4, small consistency gap flagged by external review: createWorkspace
+// copied prNumber/prStatus/prLabel from options but not prSurfaceId. No
+// current caller passes PR fields into createWorkspace, so this was latent —
+// but a workspace created WITH a PR and no recorded owner would carry a badge
+// nothing could ever clear, since `clear_pr` is only honoured from the
+// surface named in `ws.prSurfaceId` (see pr-metadata.ts). Keeping all four PR
+// fields copied together (or none of them) keeps that invariant true no
+// matter how a workspace gets created.
+
+function makeStore() {
+  return create<WorkspaceSlice>()((...args) => ({ ...createWorkspaceSlice(...args) }));
+}
+
+describe('createWorkspace PR field consistency', () => {
+  it('copies prSurfaceId alongside the other PR fields when options provide one', () => {
+    const store = makeStore();
+    const owner = 'surf-owner-1' as SurfaceId;
+    const id = store.getState().createWorkspace({
+      prNumber: 99,
+      prStatus: 'open',
+      prLabel: 'Some PR',
+      prSurfaceId: owner,
+    });
+    const ws = store.getState().workspaces.find((w) => w.id === id)!;
+    expect(ws.prNumber).toBe(99);
+    expect(ws.prSurfaceId).toBe(owner);
+  });
+
+  it('leaves prSurfaceId unset when no PR fields are given at all', () => {
+    const store = makeStore();
+    const id = store.getState().createWorkspace({ title: 'Plain' });
+    const ws = store.getState().workspaces.find((w) => w.id === id)!;
+    expect(ws.prNumber).toBeUndefined();
+    expect(ws.prSurfaceId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The PR badge on a workspace row can be raised but never lowered, and its icon
doesn't reach the screen. Three commits, each standing on its own.

### 1. The icon never renders

`gh pr view --json state` answers in GitHub's casing — `OPEN` / `MERGED` /
`CLOSED` — and `report_pr` carries that string through untouched.
`SidebarMetadata.prStatus` is a plain `string` while `WorkspaceInfo.prStatus` is
the lowercase union, so the casing difference has nothing to catch it on the way
into the store.

`PrStatusIcon` switches on the lowercase union, so every real report falls past
all three arms and the component returns `undefined`. React 19 renders that as
nothing rather than throwing, so the row degrades quietly to a bare
`#450 MERGED` with a missing glyph — which reads more like a stuck badge than a
merged one.

The fold onto the union lives next to the icon as a small pure function, so the
render boundary is safe whatever a caller passes, and the switch gains an
explicit `null` default. Badge text keeps its uppercase appearance via
`text-transform`, so nothing about the row changes except the icon appearing.

### 2. A badge belongs to the pane that reported it

PR metadata is workspace-scoped while every PowerShell pane in the workspace
runs its own poller, and they all write the same row. Two things follow.

A `clear_pr` from one pane could take down a PR another pane had just reported —
two panes, two repos, one workspace. The reporting surface is now recorded
alongside the PR (`prSurfaceId`) and a `clear_pr` is honoured only from that
surface. Tracking it shell-side wouldn't be enough on its own: a poller job
can't know another pane has since overwritten the row.

And closing the reporting pane left the badge up — the case the report opens
with. That can't be answered from the shell, since a killed PTY runs no exit
handler, so the badge is dropped where the surface itself goes away: the same
close chokepoints that already reap the PTY. A surface merely moved between
panes keeps its badge; only a real close drops it.

A shell that dies inside a still-open tab reaches none of those transitions, so
that one is answered from the `pty:exit` handler in `useTerminal.ts` — already
where a stuck "Running" badge and a leftover progress indicator are healed for
the same reason, and a signal that arrives whether the shell left gracefully or
was killed.

### 3. The poller can lower a badge, and follows the pane

`clear_pr` is handled in `App.tsx` but has no sender, unlike `clear_git_branch`,
whose clearing half is wired up in both integrations. The tick reports only on
the success path, so a `gh pr view` that finds nothing sends nothing.

The job's location is the other half. `Start-Job` hands the child runspace the
location captured at call time and keeps it there. Starting the poller on the
shell's first idle is what keeps several hundred ms of runspace startup off the
first prompt and is worth keeping — but it does mean a pane that cd's into
another repo or worktree keeps being answered for the first one.

The tick now decides through one pure function and the prompt publishes the
pane's live location for the job to read back each tick:

| Pane state | Sends |
|---|---|
| In a repo, gh resolves a PR | `report_pr` |
| In a repo, gh finds nothing, this pane had reported | `clear_pr` |
| In a repo, gh finds nothing, this pane never reported | nothing |
| Not in a repo, this pane had reported | `clear_pr` |
| Not in a repo, never reported | nothing |

Retracting only its own claim is what keeps a pane from speaking for panes it
knows nothing about — one workspace with a pane on a PR branch and a pane in `~`
would otherwise take turns reporting and clearing every 45s — and it means the
pipe goes quiet once a badge is down. The renderer honours a clear only from the
surface that owns the row, so a retraction can never reach past its own claim.

Three edges came with it: the "did I claim this" flag now advances only on a
send that actually landed (a `clear_pr` that failed to go out used to leave the
pane believing it had nothing left to retract); an unreadable cwd hand-off is
treated as no information rather than "stay put", which would have gone on
polling a stale repo; and the hand-off files of panes that were killed rather
than closed are swept by age, since a kill runs no exit handler. A live pane
keeps its own file young from both ends — the prompt rewrites it on every
command and the poller touches it on every tick — so a pane parked at an idle
prompt for days can't be swept out from under itself.

## Calls that felt like yours to make, not mine

**Should a merged PR display at all?** Left exactly as it is. `gh pr view`
resolves a PR from its branch after it's merged, so a pane sitting on a merged
branch legitimately keeps reporting `MERGED` — refreshed, not stale. Now that
the icon renders, that may well be the useful behaviour; if you'd rather a
merged PR cleared itself, that's a one-line change and I'm glad to make it.

**When a pane walks out of a repo.** It retracts its own badge, on the reasoning
that the prompt drops the branch off the row on the very next command and a PR
sitting beside a row with no repo behind it reads as stuck. Happy to make that
row of the table silent instead if you'd read it the other way.

## Why the cwd hand-off is a file and not the pipe

Worth stating outright, since the pipe is the obvious candidate. It runs one
direction — shell to wmux — and the consumer here is another *shell* process.
The prompt already sends this exact value across as `report_pwd`; routing the
hand-off through the pipe would mean adding `currentCwd` to the surface listing,
a V2 method and a CLI verb to read it back, and a `node` spawn on every 45s
tick, so that the shell could ask wmux for something the shell itself had just
told it.

The file lives in `<temp>\wmux` — the directory `wmux-bash-integration.sh`
already uses for its own hand-off — is removed on shell exit, and panes that
were killed rather than closed are swept by age on a later shell's first idle,
so the directory can't grow one file per pane forever.

## Known edge

If `gh` is unauthenticated while the pane *is* in a repo, `gh pr view` fails the
same way "no PR on this branch" does, so a pane that had reported retracts once.
It re-reports as soon as auth is restored. Separating the two means parsing gh's
stderr text, which doesn't hold across gh versions — the single spurious clear
seemed the better trade, but say the word if you'd rather gate on
`gh auth status`.

## Verification

- `npx vitest run` — **1225 passed / 100 files** (master @ v1.5.1: 1159 / 95).
- `npm run lint` — unchanged; the errors in touched files are pre-existing on
  master (confirmed by stashing).
- Real PowerShell host, both **7** and **Windows PowerShell 5.1**, including the
  decision functions run inside an actual `Start-Job -InitializationScript` —
  a job runspace inherits none of the session's functions, and a silent failure
  there would look exactly like the bug.
- A parse gate on the whole integration script: it caught a bad
  `$($function:…)` reference while this was being written, and nothing else in
  the suite would notice a script that fails to parse — the cost of one is the
  pane's whole prompt, git branch and shell state going quiet.
- Both copies of the shell integration move together, as the mirror check
  requires.

## Notes

- No version bump.
