### PR TITLE
fix(pty): prefer Windows OpenSSH for a bare ssh spec

### DIFF
--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -11,6 +11,7 @@ import { attachErrorSink, installPtyCrashGuard } from './pty-crash-guard';
 import { powerShellShimDir } from './powershell-shim';
 import { getCliBinPath } from './cli-paths';
 import { getNodeRuntime } from './node-runtime';
+import { opensshPath } from './system32';
 
 // Applied once, at load, before any PTY can exist — the exit callback it guards
 // is registered by node-pty inside pty.spawn(), so a later install would leave
@@ -163,8 +164,39 @@ export function resolveExistingShellPath(shell: string): string | undefined {
   return resolved;
 }
 
+/**
+ * Windows' own `ssh`/`scp`, for a spec that named one without a path.
+ *
+ * A machine with Git for Windows installed usually has `C:\Program Files\Git\
+ * usr\bin` ahead of `System32` on PATH, so a bare `ssh` resolves to Git's MSYS2
+ * build. The two are not interchangeable: MSYS2 ssh looks for an agent on
+ * `$SSH_AUTH_SOCK`, while the Windows agent — the one 1Password, KeePassXC and
+ * the ssh-agent service all register with — is the named pipe
+ * `\\.\pipe\openssh-ssh-agent`. On a machine whose keys live only in an agent
+ * (no `~/.ssh/id_*` on disk), Git's ssh therefore sees no keys at all and the
+ * pane dies on "Permission denied (publickey)" while the user's own `ssh`
+ * works fine.
+ *
+ * Only reached for a spec wmux is spawning itself — `wmux ssh user@host`, or a
+ * workspace shell set to `ssh …`. A command the user types at a prompt is
+ * resolved by the shell inside the PTY and never comes through here, so panes
+ * keep behaving like every other terminal. Users with on-disk keys notice
+ * nothing: System32 OpenSSH reads the same `~/.ssh/config` and `~/.ssh/id_*`.
+ */
+function nativeOpenSshPath(shell: string): string | undefined {
+  if (process.platform !== 'win32') return undefined;
+  const base = path.basename(shell).toLowerCase().replace(/\.exe$/, '');
+  if (base !== 'ssh' && base !== 'scp') return undefined;
+  const native = opensshPath(base);
+  return fs.existsSync(native) ? native : undefined;
+}
+
 function resolveExistingShellPathUncached(shell: string): string | undefined {
   if (path.isAbsolute(shell) && fs.existsSync(shell)) return shell;
+  // Before PATH: an absolute path the user wrote still wins (checked above),
+  // but a bare `ssh` should be the platform's, not whatever is first on PATH.
+  const native = nativeOpenSshPath(shell);
+  if (native) return native;
   const onPath = shellProbe.onPath(shell);
   if (onPath) return onPath;
   // Bare alias with no real PATH hit. A Store-only PowerShell — stable or

--- a/src/main/system32.ts
+++ b/src/main/system32.ts
@@ -1,0 +1,38 @@
+/**
+ * Absolute paths to Windows-owned tools that must not be shadowed by a
+ * user-writable PATH entry.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+function systemRoot(): string {
+  return process.env.SystemRoot || process.env.windir || 'C:\\Windows';
+}
+
+/** `system32('OpenSSH', 'ssh.exe')` -> the in-box Windows OpenSSH client. */
+export function system32(...parts: string[]): string {
+  return path.join(systemRoot(), 'System32', ...parts);
+}
+
+/** Windows PowerShell 5.1, present on every supported Windows release. */
+export function powershellPath(): string {
+  return system32('WindowsPowerShell', 'v1.0', 'powershell.exe');
+}
+
+/**
+ * The Windows OpenSSH installation wmux should use for a bare managed spec.
+ *
+ * Microsoft's standalone upgrade is installed under Program Files and should
+ * win over the older in-box copy when both exist. System32 is the stable
+ * fallback. Keeping this decision in one helper also lets uploads select the
+ * sibling `scp.exe` from the same authentication stack.
+ */
+export function opensshPath(
+  tool: 'ssh' | 'scp',
+  exists: (candidate: string) => boolean = fs.existsSync,
+): string {
+  const file = `${tool}.exe`;
+  const standalone = path.join(process.env.ProgramFiles || 'C:\\Program Files', 'OpenSSH', file);
+  if (exists(standalone)) return standalone;
+  return system32('OpenSSH', file);
+}

--- a/tests/unit/pty-manager.test.ts
+++ b/tests/unit/pty-manager.test.ts
@@ -293,6 +293,46 @@ describe('resolveExistingShellPath', () => {
  * These tests pin the memoization by counting probes rather than timing, so
  * they mean the same thing on a fast machine and in CI.
  */
+/**
+ * A machine with Git for Windows installed usually has its `usr\bin` ahead of
+ * System32 on PATH, so a bare `ssh` resolved to Git's MSYS2 build. That build
+ * looks for an agent on $SSH_AUTH_SOCK instead of the Windows named pipe
+ * `\\.\pipe\openssh-ssh-agent`, so on a machine whose keys live only in an
+ * agent (1Password, KeePassXC, the ssh-agent service) it sees no keys at all:
+ * `wmux ssh user@host` died on "Permission denied (publickey)" while the
+ * user's own `ssh` in the same pane worked.
+ *
+ * Only shell SPECS come through here — a command typed at a prompt is resolved
+ * by the shell inside the PTY — so this changes what wmux launches, never what
+ * the user launches.
+ */
+describe('a bare ssh spec resolves to Windows OpenSSH, not PATH', () => {
+  beforeEach(() => {
+    resetShellPathCache();
+    vi.spyOn(shellProbe, 'onPath').mockImplementation(
+      (name: string) => (name === 'ssh' ? 'C:\\Program Files\\Git\\usr\\bin\\ssh.exe' : undefined),
+    );
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetShellPathCache();
+  });
+
+  it('prefers Windows OpenSSH over the PATH hit', () => {
+    if (process.platform !== 'win32') return;
+    const resolved = resolveExistingShellPath('ssh');
+    expect(resolved?.replace(/\\/g, '/')).toMatch(/\/(?:Program Files|System32)\/OpenSSH\/ssh\.exe$/i);
+    expect(resolved).not.toMatch(/Git/i);
+    // The PATH probe must not even be consulted for it.
+    expect(vi.mocked(shellProbe.onPath)).not.toHaveBeenCalledWith('ssh');
+  });
+
+  it('leaves every other shell to PATH', () => {
+    resolveExistingShellPath('fake-shell.exe');
+    expect(vi.mocked(shellProbe.onPath)).toHaveBeenCalledWith('fake-shell.exe');
+  });
+});
+
 describe('shell path resolution is memoized (issue #176)', () => {
   let probes: string[];
 


### PR DESCRIPTION
## Summary

- prefer an explicit SSH executable when one was requested
- otherwise prefer a complete OpenSSH `ssh.exe`/`scp.exe` pair under Program Files
- fall back to Windows System32 OpenSSH before consulting `PATH`
- keep the resolver memoized and cover the Windows precedence cases

This avoids accidentally selecting Git's or another package's PATH-provided SSH client on Windows and gives later consumers a deterministic matching tool pair.

## Validation

- 44 focused unit tests passed
- `npm run typecheck`

Closes #193
