### PR TITLE
fix(session): keep the requested shell spec through a remount

### DIFF
--- a/src/renderer/components/SplitPane/surface-label.ts
+++ b/src/renderer/components/SplitPane/surface-label.ts
@@ -37,7 +37,11 @@ export function getSurfaceLabel(
     case 'terminal': {
       const folder = surface.currentCwd ? cwdFolderName(surface.currentCwd) : null;
       if (folder) return folder;
-      return getShellLabel(surface.shell || workspaceShell) || t('surfaceLabel.terminal', 'Terminal');
+      // resolvedShell first: it is the concrete executable, so it labels a
+      // pane started with no spec at all. `shell` may be a whole command line
+      // (`ssh user@host`), which getShellLabel would render as a mouthful.
+      return getShellLabel(surface.resolvedShell || surface.shell || workspaceShell)
+        || t('surfaceLabel.terminal', 'Terminal');
     }
     case 'browser':
       return t('surfaceLabel.browser', 'Browser');

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -117,6 +117,15 @@ function snapshotSurfaceBuffer(surfaceId: string | undefined, serializeAddon: Se
   }
 }
 
+/**
+ * Record what the PTY actually spawned, for the tab caption.
+ *
+ * Writes `resolvedShell`, NOT `shell`. It used to write `shell`, which is also
+ * the surface's respawn spec: `ssh user@host` was replaced by a bare
+ * `…\ssh.exe`, persisted that way, and a restored ssh workspace then started
+ * an ssh with no destination, printed usage and exited. The label only ever
+ * needed a name to show, so it gets its own field and the spec stays intact.
+ */
 function setResolvedShellForSurface(surfaceId: string | undefined, resolvedShell: string): void {
   if (!surfaceId || !resolvedShell) return;
   const state = useStore.getState();
@@ -124,7 +133,7 @@ function setResolvedShellForSurface(surfaceId: string | undefined, resolvedShell
   if (!workspace) return;
   const location = findSurfaceLocation(workspace.splitTree, surfaceId);
   if (!location) return;
-  state.updateSurface(workspace.id, location.paneId as any, surfaceId as any, { shell: resolvedShell });
+  state.updateSurface(workspace.id, location.paneId as any, surfaceId as any, { resolvedShell });
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -15,7 +15,20 @@ export interface SurfaceRef {
   id: SurfaceId;
   type: SurfaceType;
   customTitle?: string;
+  /**
+   * How this surface was ASKED to start: a bare executable, or a whole command
+   * line such as `ssh user@host` (issue #78). Immutable once set — it is what
+   * respawns the surface after a restart, so anything that overwrites it with
+   * a resolved executable silently breaks restore for every spec that carries
+   * arguments. The tab label wants the resolved value; that is `resolvedShell`.
+   */
   shell?: string;
+  /**
+   * The executable `shell` actually resolved to, reported back by the PTY.
+   * Display only — the tab caption uses it so a pane started with no spec at
+   * all can still say "PowerShell" rather than "Terminal".
+   */
+  resolvedShell?: string;
   /** Per-surface color scheme override (bundled theme name or user-defined scheme name). */
   colorScheme?: string;
   /** Per-surface working directory override (quick-launch profiles — issue #32). */

--- a/tests/unit/surface-label.test.ts
+++ b/tests/unit/surface-label.test.ts
@@ -11,6 +11,29 @@ function surface(id: string, patch: Partial<SurfaceRef> = {}): SurfaceRef {
 }
 
 describe('surface labels', () => {
+  it('labels from resolvedShell, so a spec with arguments stays readable', () => {
+    // `shell` is the requested spec and may be a whole command line. Rendering
+    // that as a tab caption produced "Ssh Fortuna@honoured Accident"; the
+    // resolved executable is what the label wants.
+    expect(
+      getSurfaceLabel(surface('surf-1', {
+        shell: 'ssh fortuna@honoured-accident',
+        resolvedShell: 'C:\\Windows\\System32\\OpenSSH\\ssh.exe',
+      })),
+    ).toBe('Ssh');
+  });
+
+  it('labels a pane started with no spec at all', () => {
+    // The regression e5ec559 existed to prevent: with no requested spec there
+    // is nothing to name the tab after except what actually spawned.
+    expect(getSurfaceLabel(surface('surf-1', { resolvedShell: 'pwsh.exe' }))).toBe('PowerShell');
+  });
+
+  it('still falls back to the requested spec, then the workspace shell', () => {
+    expect(getSurfaceLabel(surface('surf-1', { shell: 'cmd.exe' }))).toBe('Command Prompt');
+    expect(getSurfaceLabel(surface('surf-1'), undefined, 'bash.exe')).toBe('Bash');
+  });
+
   it('prefers custom titles over agent and shell labels', () => {
     expect(
       getSurfaceLabel(


### PR DESCRIPTION
## Summary

- preserve `SurfaceRef.shell` as the requested respawn/session-restore specification
- store the actual spawned executable separately as `resolvedShell`
- use the resolved value only for the terminal label
- keep persisted sessions without the new optional field compatible

This prevents a shell such as `ssh user@host` from becoming a destination-less `ssh.exe` after a remount or restore.

## Validation

- 14 focused unit tests passed
- `npm run typecheck`

Closes #194
