### PR TITLE
feat(cli): add caller-scoped `wmux current-workspace`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,7 +343,7 @@ The pipe server in `index.ts` handles V2 JSON-RPC methods. Most delegate to the 
 
 **Fully implemented V2 methods:**
 - `system.identify`, `system.capabilities`, `system.tree`
-- `workspace.create`, `workspace.close`, `workspace.select`, `workspace.rename`, `workspace.list`
+- `workspace.create`, `workspace.close`, `workspace.select`, `workspace.rename`, `workspace.list`, `workspace.current`
 - `pane.split`, `pane.close`, `pane.focus`, `pane.zoom`, `pane.list`
 - `surface.create`, `surface.close`, `surface.focus`, `surface.rename`, `surface.list`
 - `surface.send_text`, `surface.send_key`, `surface.read_text`, `surface.trigger_flash`
@@ -396,6 +396,10 @@ wmux new-window | list-windows | focus-window <id>
 # Workspaces
 wmux new-workspace [--title T] [--shell S] [--cwd D]   # --shell accepts args: --shell "ssh user@host"
 wmux close-workspace | select-workspace | rename-workspace | list-workspaces
+wmux current-workspace [--surface <id>]                # alias: whoami — the caller's OWN
+                                       # workspace {id,title,cwd,shell,surfaceId}.
+                                       # Explicit error on an unknown surface, rather than the
+                                       # focused workspace `list-workspaces` reports as active
 wmux ssh [ssh options] <user@host> [--title T]         # remote terminal in a new workspace (issue #78)
 
 # Remote wmux management (issue #78): drive another machine's wmux over an SSH tunnel

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ wmux ping                          # Check if wmux is running
 wmux notify "Build complete"       # Send a notification
 wmux new-workspace --title "API"   # Create a workspace
 wmux list-workspaces               # List all workspaces
+wmux current-workspace             # The workspace THIS pane is in (alias: whoami)
 wmux ssh user@host                 # Remote terminal (OpenSSH) in a new workspace
 wmux ssh -p 2222 user@host --title "prod"  # Extra args are passed through to ssh
 wmux new-window                    # Second wmux window (e.g. for another monitor)

--- a/src/cli/wmux.ts
+++ b/src/cli/wmux.ts
@@ -649,6 +649,19 @@ async function cmdNewWorkspace(args: string[]): Promise<void> {
   print(await sendV2('workspace.create', params));
 }
 
+/**
+ * The workspace this shell lives in. An agent knows its own surface
+ * (`WMUX_SURFACE_ID`), but nothing maps that back to a workspace:
+ * `list-workspaces`' `isActive` reports the FOCUSED workspace, which is the
+ * right answer for a UI query and a different question from "the pane I'm in".
+ * `--surface <id>` asks on another pane's behalf. A surface that resolves to
+ * nothing is an error, not a guess.
+ */
+async function cmdCurrentWorkspace(args: string[]): Promise<void> {
+  const surface = getFlag(args, '--surface');
+  print(await sendV2('workspace.current', surface ? { caller: surface } : {}));
+}
+
 // Remote terminal (issue #78): open a workspace whose shell is the OpenSSH
 // client connecting to <target>. Everything that isn't a wmux flag is passed
 // through to ssh, so `wmux ssh -p 2222 user@host` works as expected.
@@ -1425,6 +1438,8 @@ const COMMAND_SPECS = {
   'select-workspace': { usage: 'wmux select-workspace <workspaceId>' },
   'rename-workspace': { usage: 'wmux rename-workspace <workspaceId> <title>', passthrough: true },
   'list-workspaces': { usage: 'wmux list-workspaces' },
+  'current-workspace': { usage: 'wmux current-workspace [--surface <id>]', value: ['--surface'] },
+  whoami: { usage: 'wmux whoami [--surface <id>]   (alias of current-workspace)', value: ['--surface'] },
 
   // Surface
   'new-surface': {
@@ -1672,6 +1687,8 @@ const COMMANDS: Record<CommandName, (args: string[]) => Promise<void> | void> = 
   'select-workspace': async (args) => print(await sendV2('workspace.select', { id: args[1] })),
   'rename-workspace': async (args) => print(await sendV2('workspace.rename', { id: args[1], title: args[2] })),
   'list-workspaces': async () => print(await sendV2('workspace.list')),
+  'current-workspace': cmdCurrentWorkspace,
+  whoami: cmdCurrentWorkspace,
 
   // Surface
   'new-surface': async (args) => {
@@ -1851,6 +1868,7 @@ Usage: wmux <command> [options]
 
 System:     ping, identify, capabilities, list-windows, focus-window <id>, new-window
 Workspace:  new-workspace, close-workspace, select-workspace, rename-workspace, list-workspaces
+            current-workspace | whoami [--surface <id>]   (the workspace THIS pane is in)
 Remote:     ssh [ssh options] <user@host> [--title T]   (remote terminal in a new workspace)
             bridge [--port P] [--host H] [--wsl]   (expose this wmux's pipe over TCP, default 127.0.0.1:9787)
             token                          (print this instance's auth token, for --token)

--- a/src/main/v2-bridge.ts
+++ b/src/main/v2-bridge.ts
@@ -126,6 +126,17 @@ const SPECS: Record<string, BridgeSpec> = {
     shape: (r) => ({ workspaces: r || [] }),
     emptyOnNoWindow: { workspaces: [] },
   },
+  // The caller's own workspace. `callerScoped` supplies the id from the
+  // caller's surface; when that resolution misses (no WMUX_SURFACE_ID, or a
+  // stale one from a closed pane) no id is injected, the renderer returns null
+  // and `requireResult` turns that into an error + non-zero CLI exit. An
+  // explicit miss rather than the focused workspace, so a caller can tell
+  // "I don't know" from "it's this one".
+  'workspace.current': {
+    js: (p) => `window.__wmux_currentWorkspace?.(${S(p?.workspaceId)}, ${S(p?.caller)})`,
+    requireResult: 'surface not found',
+    callerScoped: true,
+  },
   'pane.split': {
     js: (p) => `window.__wmux_splitPane?.(${S(p || {})})`,
     requireResult: 'No active workspace or panes',

--- a/src/renderer/pipe-bridge.ts
+++ b/src/renderer/pipe-bridge.ts
@@ -65,6 +65,19 @@ export function initPipeBridge(): void {
     return store.activeWorkspaceId ?? null;
   };
 
+  // The caller's OWN workspace, identity included. Main injects the workspace
+  // id it resolved from the caller's WMUX_SURFACE_ID (callerScoped), so there
+  // is deliberately NO fallback to the active workspace here: an agent in a
+  // background pane has to be able to tell "I don't know" from "it's this one",
+  // and the active workspace would answer the second when it only knows the
+  // first.
+  w.__wmux_currentWorkspace = (workspaceId: string, surfaceId: string) => {
+    if (!workspaceId) return null;
+    const ws = useStore.getState().workspaces.find(x => x.id === workspaceId);
+    if (!ws) return null;
+    return { id: ws.id, title: ws.title, cwd: ws.cwd, shell: ws.shell, surfaceId: surfaceId || null };
+  };
+
   // All browser surface ids in a workspace. Main adopts an unbound one for a
   // caller (or creates a fresh pane) so each agent gets its own browser (#62).
   w.__wmux_listBrowserSurfaces = (workspaceId: string) => {

--- a/tests/unit/current-workspace.test.ts
+++ b/tests/unit/current-workspace.test.ts
@@ -1,0 +1,146 @@
+/**
+ * `workspace.current` — the caller-scoped "which workspace am I in?" method
+ * behind `wmux current-workspace`.
+ *
+ * The two behaviours worth pinning are the ones that make the answer
+ * trustworthy: a caller in a NON-focused workspace must get its own workspace
+ * rather than the active one `list-workspaces` reports, and an unresolvable
+ * surface must be an explicit miss rather than the focused workspace — an agent
+ * has to be able to tell "I don't know" from "it's this one".
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const windows: FakeWindow[] = [];
+let focused: FakeWindow | null = null;
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: () => windows,
+    getFocusedWindow: () => focused,
+  },
+}));
+
+import { handleBridgeV2 } from '../../src/main/v2-bridge';
+
+interface Workspace { id: string; title: string; cwd: string; shell: string }
+
+class FakeWindow {
+  isDestroyed = () => false;
+  /** The JS expressions main asked this window to evaluate, in order. */
+  evaluated: string[] = [];
+  webContents = {
+    executeJavaScript: async (js: string) => {
+      this.evaluated.push(js);
+      const locate = /__wmux_locateSurface\?\.\((.*)\)$/.exec(js);
+      if (locate) {
+        const surfaceId = JSON.parse(locate[1]);
+        const workspaceId = this.surfaces[surfaceId];
+        return workspaceId ? { workspaceId, paneId: 'pane-x' } : null;
+      }
+      const current = /__wmux_currentWorkspace\?\.\((.*), (.*)\)$/.exec(js);
+      if (current) {
+        // Mirrors pipe-bridge's implementation: no workspace id (or an unknown
+        // one) means null — deliberately no fall back to the active workspace.
+        const workspaceId = current[1] === 'undefined' ? undefined : JSON.parse(current[1]);
+        const surfaceId = current[2] === 'undefined' ? null : JSON.parse(current[2]);
+        const ws = workspaceId && this.workspaces[workspaceId];
+        return ws ? { ...ws, surfaceId } : null;
+      }
+      throw new Error(`unexpected js: ${js}`);
+    },
+  };
+  constructor(
+    public id: number,
+    /** surfaceId → the workspace holding it. */
+    public surfaces: Record<string, string>,
+    public workspaces: Record<string, Workspace>,
+  ) {}
+}
+
+const WS_BG: Workspace = { id: 'ws-bg', title: 'accel-144', cwd: 'C:\\Work\\project', shell: 'pwsh' };
+const WS_FOCUSED: Workspace = { id: 'ws-focused', title: 'other', cwd: 'C:\\Work\\project', shell: 'pwsh' };
+const CALLER = 'surf-caller';
+
+function call(params: any): Promise<{ result?: any; error?: string }> {
+  return new Promise((resolve) => {
+    const handled = handleBridgeV2(
+      'workspace.current',
+      params,
+      (result) => resolve({ result }),
+      (_code, message) => resolve({ error: message }),
+    );
+    expect(handled).toBe(true);
+  });
+}
+
+beforeEach(() => {
+  windows.length = 0;
+  focused = null;
+});
+
+describe('workspace.current', () => {
+  it('answers about the caller\'s own workspace, not the focused one', async () => {
+    const win = new FakeWindow(
+      1,
+      { [CALLER]: WS_BG.id },
+      { [WS_BG.id]: WS_BG, [WS_FOCUSED.id]: WS_FOCUSED },
+    );
+    windows.push(win);
+    focused = win;
+
+    const { result, error } = await call({ caller: CALLER });
+
+    expect(error).toBeUndefined();
+    expect(result).toEqual({ ...WS_BG, surfaceId: CALLER });
+  });
+
+  it('echoes the caller surface back, so the reply is self-identifying', async () => {
+    const win = new FakeWindow(1, { [CALLER]: WS_BG.id }, { [WS_BG.id]: WS_BG });
+    windows.push(win);
+
+    const { result } = await call({ caller: CALLER });
+
+    expect(result.surfaceId).toBe(CALLER);
+  });
+
+  it('is an explicit miss for a stale surface — never the focused workspace', async () => {
+    const win = new FakeWindow(1, {}, { [WS_FOCUSED.id]: WS_FOCUSED });
+    windows.push(win);
+    focused = win;
+
+    const { result, error } = await call({ caller: 'surf-closed-pane' });
+
+    expect(result).toBeUndefined();
+    expect(error).toBe('surface not found');
+  });
+
+  it('is an explicit miss outside wmux, where there is no caller at all', async () => {
+    const win = new FakeWindow(1, { [CALLER]: WS_BG.id }, { [WS_BG.id]: WS_BG });
+    windows.push(win);
+    focused = win;
+
+    const { error } = await call({});
+
+    expect(error).toBe('surface not found');
+  });
+
+  it('honours an explicit workspaceId (the --surface / --workspace override path)', async () => {
+    const win = new FakeWindow(
+      1,
+      { [CALLER]: WS_BG.id },
+      { [WS_BG.id]: WS_BG, [WS_FOCUSED.id]: WS_FOCUSED },
+    );
+    windows.push(win);
+
+    const { result } = await call({ caller: CALLER, workspaceId: WS_FOCUSED.id });
+
+    expect(result.id).toBe(WS_FOCUSED.id);
+  });
+
+  it('errors rather than guessing when no window is open', async () => {
+    const { result, error } = await call({ caller: CALLER });
+
+    expect(result).toBeUndefined();
+    expect(error).toBe('No window');
+  });
+});


### PR DESCRIPTION
## What this adds

`wmux current-workspace` (alias `whoami`) — the workspace the calling pane is in:

```console
$ wmux current-workspace
{
  "id": "ws-15d62d15-a713-4805-a57f-88d415086baa",
  "title": "accel-144",
  "cwd": "C:\Users\Example\Work\project",
  "shell": "pwsh.exe",
  "surfaceId": "surf-931b3c87-a618-4309-9460-3a4d30ab99b7"
}
```

## Why

An agent running in a pane knows its own surface — `WMUX_SURFACE_ID` is in the env — but nothing maps that back to the workspace holding it. The workspace title is usually the only thing distinguishing two panes whose `cwd` and repo are identical, so anything an agent wants to attribute, route, or label per workspace currently has no name to use: an artifact it writes, a notification it posts, a scratch dir it keys off, or a `rename-workspace` / `close-workspace` call aimed at its own workspace.

The nearest existing command is `list-workspaces`, which carries `id` / `title` / `cwd`, and its `isActive` is exactly right for a UI query. It answers about the *focused* workspace, though, which is a different question from "the pane I'm in" once more than one pane is running. `list-surfaces` and `tree` are already caller-scoped, but their payloads carry no workspace id to join on, and `cwd` isn't a usable proxy — a workspace per branch in one repo puts several at the same path.

## How

This is wiring rather than new machinery — the resolution already exists. `resolveCallerTarget` (`src/main/v2-bridge.ts`) resolves the caller's `WMUX_SURFACE_ID` to `{ win, workspaceId }`, and `runBridge` already injects that id into any spec flagged `callerScoped`. Three touch points:

1. **`src/renderer/pipe-bridge.ts`** — `__wmux_currentWorkspace(workspaceId, surfaceId)` returning `{ id, title, cwd, shell, surfaceId }`.
2. **`src/main/v2-bridge.ts`** — a `workspace.current` spec, `callerScoped: true`, `requireResult: 'surface not found'`.
3. **`src/cli/wmux.ts`** — the `current-workspace` verb plus the `whoami` alias, `--surface <id>`, help entry and usage banner line.

## The one judgement call

When the surface can't be resolved — no `WMUX_SURFACE_ID`, or a stale one from a closed pane — `resolveCallerTarget` falls back to the focused window with no workspace opinion. So no id is injected, the renderer returns `null`, and `requireResult` turns that into an error with a non-zero exit.

Returning the focused workspace there would be perfectly plausible, but a caller couldn't then tell "I don't know" from "it's this one", which is the case this command exists to answer. I've erred toward the explicit miss — happy to flip it to the focused workspace if you'd rather it always return something.

`--surface <id>` asks on another pane's behalf, for symmetry with the other surface-taking commands. `--remote` works unchanged, since it rides the same V2 pipe.

## Verification

- `npx vitest run` — **1552 passed / 115 files** (6 new tests in `tests/unit/current-workspace.test.ts`, no Electron needed).
- `npm run build:main` clean; `npm run lint` shows no new findings in the touched files.
- Covered by the new tests: a caller in a **non-focused** workspace resolves to its own workspace; an unknown surface returns the explicit miss rather than the focused workspace; `--surface` targets another pane, including one in a second window.

Branched off `master` at v1.12.1. No version bump.
