### PR TITLE
feat(explorer): hidden-file visibility persists with the rest of the panel

### DIFF
--- a/src/main/session-persistence.ts
+++ b/src/main/session-persistence.ts
@@ -37,6 +37,7 @@ export interface SessionData {
       explorerOpen?: boolean;
       explorerWidth?: number;
       explorerExpanded?: Record<string, string[]>;
+      explorerShowHidden?: boolean;
     }>;
   }>;
 }
@@ -131,6 +132,7 @@ function backupAutoSession(previousVersion: string): void {
         explorerOpen: w.explorerOpen,
         explorerWidth: w.explorerWidth,
         explorerExpanded: w.explorerExpanded,
+        explorerShowHidden: w.explorerShowHidden,
       })),
       sidebarWidth: windows[0]?.sidebarWidth ?? 260,
     };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -935,6 +935,7 @@ export default function App() {
             explorerOpen: ws.explorerOpen,
             explorerWidth: ws.explorerWidth,
             explorerExpanded: ws.explorerExpanded,
+            explorerShowHidden: ws.explorerShowHidden,
           })),
         }],
       };
@@ -1079,6 +1080,7 @@ export default function App() {
         explorerOpen: ws.explorerOpen,
         explorerWidth: ws.explorerWidth,
         explorerExpanded: ws.explorerExpanded,
+        explorerShowHidden: ws.explorerShowHidden,
       })),
       sidebarWidth: sidebarWidthRef.current,
       terminalPrefs: { ...state.terminalPrefs },

--- a/src/renderer/components/Explorer/ExplorerPanel.tsx
+++ b/src/renderer/components/Explorer/ExplorerPanel.tsx
@@ -93,7 +93,6 @@ export function ExplorerPanel({ onClose, focusedPaneId }: ExplorerPanelProps): R
   const [truncated, setTruncated] = useState(false);
   const [loading, setLoading] = useState(false);
   const [selected, setSelected] = useState<string | null>(null);
-  const [showHidden, setShowHidden] = useState(false);
   // The absolute, realpath'd root main actually listed, taken from the root
   // reply. Main already knows it; before this landed the renderer threw it away
   // and concatenated paths onto the reported cwd instead, which under Git Bash
@@ -102,6 +101,17 @@ export function ExplorerPanel({ onClose, focusedPaneId }: ExplorerPanelProps): R
   const [resolvedRoot, setResolvedRoot] = useState<string | null>(null);
 
   const absRoot = pathRoot(resolvedRoot, root);
+
+  // Hidden-file visibility persists per workspace, for the same reason the
+  // expansion does: it is part of the view the user arranged, and a remount —
+  // a pane switch, a workspace reload — must not silently re-hide files they
+  // asked to see. It reads straight off the workspace rather than mirroring
+  // into local state, so there is one value and no resync effect.
+  const showHidden = !!workspace?.explorerShowHidden;
+  const toggleHidden = useCallback(() => {
+    if (!activeWorkspaceId) return;
+    updateWorkspaceMetadata(activeWorkspaceId, { explorerShowHidden: !showHidden });
+  }, [activeWorkspaceId, showHidden, updateWorkspaceMetadata]);
 
   // ─── The loaded tree, cached per root ──────────────────────────────────────
   // `tree` used to be torn down and refetched on every pane switch while
@@ -418,7 +428,7 @@ export function ExplorerPanel({ onClose, focusedPaneId }: ExplorerPanelProps): R
           title={showHidden
             ? t('explorer.hideHidden', 'Hide hidden files')
             : t('explorer.showHidden', 'Show hidden files')}
-          onClick={() => setShowHidden((v) => !v)}
+          onClick={toggleHidden}
         >{showHidden ? '◉' : '○'}</button>
         <button
           className="explorer-panel__action"

--- a/src/renderer/store/workspace-slice.ts
+++ b/src/renderer/store/workspace-slice.ts
@@ -238,6 +238,7 @@ export const createWorkspaceSlice: StateCreator<WorkspaceSlice> = (set, get) => 
       explorerOpen: config.explorerOpen,
       explorerWidth: config.explorerWidth,
       explorerExpanded: config.explorerExpanded,
+      explorerShowHidden: config.explorerShowHidden,
     }));
 
     // IDs are regenerated above, so a saved activeWorkspaceId is meaningless —

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -351,6 +351,13 @@ export interface WorkspaceInfo {
   explorerWidth?: number;
   /** Expanded dirs by root path, POSIX separators. Capped at 8 roots, LRU. */
   explorerExpanded?: Record<string, string[]>;
+  /**
+   * Whether the explorer lists dotfiles and filtered names. Per-workspace, the
+   * same scope as `explorerOpen` and `explorerWidth` — the panel is a view onto
+   * one workspace's tree, so a repo where `.github/` matters does not drag a
+   * repo where it is noise along with it.
+   */
+  explorerShowHidden?: boolean;
 }
 
 // Surface
@@ -490,6 +497,7 @@ export interface SavedSession {
     explorerOpen?: boolean;
     explorerWidth?: number;
     explorerExpanded?: Record<string, string[]>;
+    explorerShowHidden?: boolean;
     pinned?: boolean;
   }>;
   sidebarWidth: number;

--- a/tests/unit/explorer-show-hidden.test.ts
+++ b/tests/unit/explorer-show-hidden.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { create } from 'zustand';
+import { createWorkspaceSlice, WorkspaceSlice } from '../../src/renderer/store/workspace-slice';
+import { treeCacheKey } from '../../src/renderer/components/Explorer/explorer-state';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hidden-file visibility is workspace state, not component state.
+//
+// It shipped in #210 as a `useState(false)` inside ExplorerPanel, which made it
+// the one piece of panel state that did not survive a remount — the width and
+// the expansion both persisted, so the toggle silently reverted on a pane
+// switch or a session restore while everything beside it held.
+//
+// The restore path is the half that fails quietly: `replaceAllWorkspaces` names
+// every field it carries, so a field it does not name is dropped with no error
+// and no type complaint (its input is a Partial). That is #145 exactly, and it
+// is why this is tested rather than eyeballed.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeStore() {
+  return create<WorkspaceSlice>()((...args) => ({ ...createWorkspaceSlice(...args) }));
+}
+
+describe('explorerShowHidden survives a restore', () => {
+  it('is carried through replaceAllWorkspaces', () => {
+    const store = makeStore();
+    store.getState().replaceAllWorkspaces([
+      { title: 'repo', shell: 'pwsh', cwd: 'C:\\repo', explorerShowHidden: true },
+    ]);
+    expect(store.getState().workspaces[0].explorerShowHidden).toBe(true);
+  });
+
+  it('stays undefined for a session saved before the field existed', () => {
+    // Read as `!!workspace?.explorerShowHidden` in the panel, so absent means
+    // hidden — the behaviour those sessions already had.
+    const store = makeStore();
+    store.getState().replaceAllWorkspaces([{ title: 'repo', shell: 'pwsh', cwd: 'C:\\repo' }]);
+    expect(store.getState().workspaces[0].explorerShowHidden).toBeUndefined();
+  });
+
+  it('is per workspace, so one repo showing dotfiles does not drag the next one along', () => {
+    const store = makeStore();
+    store.getState().replaceAllWorkspaces([
+      { title: 'a', shell: 'pwsh', explorerShowHidden: true },
+      { title: 'b', shell: 'pwsh' },
+    ]);
+    const [a, b] = store.getState().workspaces;
+    expect(a.explorerShowHidden).toBe(true);
+    expect(b.explorerShowHidden).toBeUndefined();
+  });
+
+  it('the toggle writes it through updateWorkspaceMetadata', () => {
+    const store = makeStore();
+    store.getState().replaceAllWorkspaces([{ title: 'repo', shell: 'pwsh' }]);
+    const id = store.getState().workspaces[0].id;
+    store.getState().updateWorkspaceMetadata(id, { explorerShowHidden: true });
+    expect(store.getState().workspaces[0].explorerShowHidden).toBe(true);
+    store.getState().updateWorkspaceMetadata(id, { explorerShowHidden: false });
+    expect(store.getState().workspaces[0].explorerShowHidden).toBe(false);
+  });
+
+  it('still keys the tree cache, so a toggle cannot serve a filtered tree unfiltered', () => {
+    // The value moved out of useState; the cache identity it feeds did not.
+    expect(treeCacheKey('C:\\repo', true)).not.toBe(treeCacheKey('C:\\repo', false));
+  });
+});

--- a/tests/unit/session-persistence.test.ts
+++ b/tests/unit/session-persistence.test.ts
@@ -290,7 +290,7 @@ describe('explorer panel state persistence', () => {
     fs.rmSync(APPDATA_OVERRIDE, { recursive: true, force: true });
   });
 
-  it('round-trips explorerOpen, explorerWidth and explorerExpanded', () => {
+  it('round-trips explorerOpen, explorerWidth, explorerExpanded and explorerShowHidden', () => {
     const data: any = {
       version: 1,
       windows: [{
@@ -303,6 +303,7 @@ describe('explorer panel state persistence', () => {
           explorerOpen: true,
           explorerWidth: 280,
           explorerExpanded: { 'C:/repo': ['docs', 'docs/nested'] },
+          explorerShowHidden: true,
         }],
       }],
     };
@@ -311,6 +312,7 @@ describe('explorer panel state persistence', () => {
     expect(ws.explorerOpen).toBe(true);
     expect(ws.explorerWidth).toBe(280);
     expect(ws.explorerExpanded).toEqual({ 'C:/repo': ['docs', 'docs/nested'] });
+    expect(ws.explorerShowHidden).toBe(true);
   });
 
   it('carries the explorer fields through the version-change auto-backup', () => {
@@ -324,6 +326,7 @@ describe('explorer panel state persistence', () => {
         workspaces: [{
           id: 'ws-1', title: 'ws', pinned: false, shell: 'pwsh', cwd: 'C:\\repo', splitTree: leaf,
           explorerOpen: true, explorerWidth: 280, explorerExpanded: { 'C:/repo': ['docs'] },
+          explorerShowHidden: true,
         }],
       }],
     } as any);
@@ -335,5 +338,6 @@ describe('explorer panel state persistence', () => {
     expect(ws.explorerOpen).toBe(true);
     expect(ws.explorerWidth).toBe(280);
     expect(ws.explorerExpanded).toEqual({ 'C:/repo': ['docs'] });
+    expect(ws.explorerShowHidden).toBe(true);
   });
 });


### PR DESCRIPTION
The explorer's width and its per-root expansion both persist per workspace.
`showHidden` was a `useState(false)` inside `ExplorerPanel`, so it was the one
piece of panel state that reverted on a remount — a pane switch or a session
restore silently re-hid files the user had asked to see, while everything beside
it held.

It now lives in workspace metadata alongside `explorerExpanded`, read straight
off the workspace rather than mirrored into local state, so there is one value
and no resync effect.

**Per workspace, not global**, matching `explorerOpen` and `explorerWidth`: the
panel is a view onto one workspace's tree, so a repo where `.github/` matters
does not drag a repo where it is noise along with it.

**Absent stays falsy**, so sessions saved before this field come back hiding
hidden files, exactly as they did.

### The half that fails quietly

`replaceAllWorkspaces` names every field it carries and takes a `Partial`, so a
field the restore does not name is dropped with no error and no type complaint —
the shape of #145. The field is therefore declared in both `WorkspaceInfo` and
the `SavedSession` workspace entry and carried explicitly through all four
paths: `replaceAllWorkspaces`, the auto-save and the named-session save in
`App.tsx`, and `backupAutoSession` in `session-persistence.ts`. The round-trip
and the restore are tested rather than eyeballed.

The tree cache key already included the visibility flag (`treeCacheKey(root,
showHidden)`); a test pins that, since the value moved out of `useState` and the
cache identity it feeds must not follow it.

### Testing

- `tests/unit/explorer-show-hidden.test.ts` (new) — restore carries the field,
  absent stays `undefined`, per-workspace isolation, the toggle writes through
  `updateWorkspaceMetadata`, and the cache key still splits on visibility.
- `tests/unit/session-persistence.test.ts` — extended to round-trip the field
  and carry it through the version-change auto-backup.
- Full suite: 2592 passed / 166 files. `tsc --noEmit` clean on both projects.
- Manually: toggle hidden files on, switch panes, restart wmux — the toggle
  holds, and a second workspace keeps its own setting.
