### PR TITLE
fix(hooks): emit commands PowerShell can run, not 2>/dev/null

### DIFF
--- a/src/main/claude-context.ts
+++ b/src/main/claude-context.ts
@@ -287,8 +287,17 @@ export function applyWmuxHooks(settings: any, hookScript: string): any {
 
   // PostToolUse passes the tool name as a positional arg; Notification/Stop
   // pass an --event flag so the helper reports an event type instead.
-  const makeToolCmd = (tool: string) => `node "${hookScript}" ${tool} 2>/dev/null || true`;
-  const makeEventCmd = (event: string) => `node "${hookScript}" --event ${event} 2>/dev/null || true`;
+  //
+  // Bare `node …` — not `2>/dev/null || true`. The helper already exits 0
+  // when the pipe is absent, so the shell wrapper never kept a downed wmux
+  // from blocking the agent. It DID break every consumer that is not bash:
+  // Grok (and anything else that honours ~/.claude/settings.json) runs these
+  // commands in PowerShell on Windows, where `>/dev/null` is Out-File of
+  // `C:\dev\null` and every hook fails with exit 1. Claude Code on Windows
+  // may still use Git Bash, so a PowerShell-only spelling (`2>$null`) is
+  // equally wrong. No redirect is valid in bash, cmd and pwsh.
+  const makeToolCmd = (tool: string) => `node "${hookScript}" ${tool}`;
+  const makeEventCmd = (event: string) => `node "${hookScript}" --event ${event}`;
 
   // The per-tool-call hooks run in the BACKGROUND. Every wmux hook is a pure
   // observer: it reports to the pipe and never blocks a tool or injects

--- a/tests/unit/claude-hooks.test.ts
+++ b/tests/unit/claude-hooks.test.ts
@@ -17,11 +17,27 @@ describe('applyWmuxHooks (issue #53)', () => {
 
     // Notification + Stop: pass an --event flag.
     expect(wmuxCmds(out.hooks.Notification)).toEqual([
-      `node "${HOOK}" --event Notification 2>/dev/null || true`,
+      `node "${HOOK}" --event Notification`,
     ]);
     expect(wmuxCmds(out.hooks.Stop)).toEqual([
-      `node "${HOOK}" --event Stop 2>/dev/null || true`,
+      `node "${HOOK}" --event Stop`,
     ]);
+  });
+
+  // Grok (and other agents that load ~/.claude/settings.json) run these
+  // commands in PowerShell on Windows. `2>/dev/null` becomes Out-File of
+  // `C:\dev\null` and every hook fails; a PowerShell-only `2>$null` would
+  // equally break Claude Code under Git Bash. No redirect is the portable form.
+  it('emits hook commands that bash, cmd and PowerShell can all run', () => {
+    const out = applyWmuxHooks({}, HOOK);
+    const all = Object.values(out.hooks).flatMap((entries: any) => wmuxCmds(entries));
+    expect(all.length).toBeGreaterThan(0);
+    for (const cmd of all) {
+      expect(cmd).toMatch(/^node "/);
+      expect(cmd).not.toMatch(/\/dev\/null/);
+      expect(cmd).not.toMatch(/\|\|/);
+      expect(cmd).not.toMatch(/2>\$null/);
+    }
   });
 
   it('preserves existing user hooks in every array', () => {
@@ -96,5 +112,6 @@ describe('applyWmuxHooks (issue #53)', () => {
     const out = applyWmuxHooks(legacy, HOOK);
     expect(out.hooks.PreToolUse).toHaveLength(1);
     expect(out.hooks.PreToolUse[0].hooks[0].async).toBe(true);
+    expect(out.hooks.PreToolUse[0].hooks[0].command).toBe(`node "${HOOK}" --event PreToolUse`);
   });
 });


### PR DESCRIPTION
## Summary

wmux writes Claude Code hooks as `node "…/wmux-hook.js" … 2>/dev/null || true`. That is bash. Grok — and anything else that honours `~/.claude/settings.json` — runs those commands in PowerShell on Windows, where `>/dev/null` is `Out-File` of `C:\dev\null`. Every hook then fails with exit 1 (`Could not find a part of the path 'C:\dev\null'`), so the sidebar never sees Grok activity.

This is not a one-machine quirk and not Grok-only. It hits any Windows agent that executes the injected commands outside bash. Claude Code itself often still uses Git Bash on Windows, which is why the wrapper survived.

## Why not skip rewriting existing hooks

`applyWmuxHooks` replacing wmux-owned entries on launch is how new events (`SessionStart` / `PreToolUse` / …) and `async: true` reach existing installs. Skipping the rewrite would preserve a local PowerShell patch until the next start — and would also freeze users on a stale hook set. User hooks are already left alone (issue #53). The durable fix is what we *write*, not whether we write.

A PowerShell-only spelling (`2>$null`) is equally wrong: it would break Claude Code under Git Bash. The helper already exits 0 when the pipe is absent, so the shell wrapper was never what kept a downed wmux from blocking the agent.

Bare `node "…"` is valid in bash, cmd and pwsh. Existing installs pick it up on the next wmux launch; no settings migration.

## Tests

- `tests/unit/claude-hooks.test.ts` — expected commands no longer carry the redirect; new assertion that no generated command contains `/dev/null`, `||`, or `2>$null`; legacy rewrite still upgrades an old `2>/dev/null` entry.
- `tests/unit/agent-integration.test.ts` — unchanged, still passes.

`npx vitest run tests/unit/claude-hooks.test.ts tests/unit/agent-integration.test.ts` — 36 passed.
