### PR TITLE
fix(terminal): keep xterm and ConPTY agreeing about the cursor row

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -35,6 +35,11 @@ contextBridge.exposeInMainWorld('wmux', {
     // rather than an IPC round-trip because the markdown path chip (issue #116)
     // needs it during render to shorten `C:\Users\me\notes.md` → `~\notes.md`.
     homeDir: os.homedir(),
+    // `os.release()` verbatim (e.g. '10.0.26200'), read once at preload time.
+    // The renderer needs the Windows build number to hand xterm its ConPTY
+    // compatibility block at Terminal-construction time — an async IPC answer
+    // would arrive after the terminal already existed. See utils/windows-pty.ts.
+    osRelease: os.release(),
     getShells: () => ipcRenderer.invoke(IPC_CHANNELS.SYSTEM_GET_SHELLS),
     getFonts: () => ipcRenderer.invoke(IPC_CHANNELS.SYSTEM_GET_FONTS) as Promise<string[]>,
     openExternal: (url: string) => ipcRenderer.send(IPC_CHANNELS.SYSTEM_OPEN_EXTERNAL, url),

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -24,6 +24,8 @@ import {
 } from '../utils/mouse-modes';
 import { attachVisibleRenderer, RendererHandle } from '../utils/terminal-renderer';
 import { resetTerminalModes } from '../utils/terminal-reset';
+import { windowsPtyCompat } from '../utils/windows-pty';
+import { ReplayHold } from '../utils/replay-hold';
 import { trimTrailingWhitespace } from '../utils/copy-text';
 import { handleShiftEnter, isShiftEnter } from './terminal-keys';
 import { applyKeyRemap } from '../key-remaps';
@@ -110,16 +112,26 @@ function clearStuckRunningState(surfaceId: string): void {
 // can replay it (issue #49). Normal buffer only, so a TUI's own SIGWINCH
 // redraw owns the alt screen after remount. Bounded LRU so a genuine pane
 // close (no remount to consume it) can't grow the cache.
-function snapshotSurfaceBuffer(surfaceId: string | undefined, serializeAddon: SerializeAddon): void {
+function snapshotSurfaceBuffer(
+  surfaceId: string | undefined,
+  serializeAddon: SerializeAddon,
+  terminal: Terminal,
+): void {
   if (!surfaceId) return;
   try {
-    const snapshot = serializeAddon.serialize({ excludeAltBuffer: true });
-    if (!snapshot) return;
+    const text = serializeAddon.serialize({ excludeAltBuffer: true });
+    if (!text) return;
     if (surfaceBufferCache.size >= MAX_BUFFER_CACHE) {
       const oldest = surfaceBufferCache.keys().next().value;
       if (oldest !== undefined) surfaceBufferCache.delete(oldest);
     }
-    surfaceBufferCache.set(surfaceId, snapshot);
+    // The dimensions travel with the text because the replay only reproduces
+    // the original screen at the original size: SerializeAddon restores the
+    // cursor to its VIEWPORT row, and the PTY on the other side is still the
+    // size we last told it. Replaying into a differently-sized buffer therefore
+    // lands the cursor a different number of rows from the bottom than ConPTY
+    // has it, and nothing afterwards corrects that. See restoreSurfaceBuffer.
+    surfaceBufferCache.set(surfaceId, { text, cols: terminal.cols, rows: terminal.rows });
   } catch {
     // Serialization failure is non-fatal — just lose the snapshot.
   }
@@ -295,7 +307,15 @@ function mouseModesFor(surfaceId: string): MouseModeState {
 // different depth/parent), disposing and recreating the terminal — which would
 // otherwise wipe the scrollback (issue #49). We snapshot on unmount and replay
 // on the next mount. Bounded so genuine pane closes can't leak the cache.
-const surfaceBufferCache = new Map<string, string>();
+interface BufferSnapshot {
+  /** SerializeAddon output — the normal buffer only. */
+  text: string;
+  /** The size the terminal (and so the PTY) had when it was taken. */
+  cols: number;
+  rows: number;
+}
+
+const surfaceBufferCache = new Map<string, BufferSnapshot>();
 const MAX_BUFFER_CACHE = 32;
 
 // Live xterm instances keyed by surfaceId, so the pipe bridge can read screen
@@ -503,15 +523,22 @@ function scheduleInitialResize(
   fit: () => void,
   fitAddon: FitAddon,
   ptyIdRef: { current: string | null },
+  replayHold: ReplayHold,
   attempt = 0,
 ): void {
+  // This is the resize that was measured taking the snapshot replay from 28
+  // rows to 60 before it had been parsed: it runs from the PTY-attach
+  // continuation, which is asynchronous and therefore races xterm's write
+  // buffer. `fit()` refuses on its own while held; the PTY must be left alone
+  // too, or the sides simply diverge from the other direction.
+  if (replayHold.isHolding) return;
   fit();
   const dims = fitAddon.proposeDimensions();
   if (dims) {
     window.wmux.pty.resize(ptyId, dims.cols, dims.rows);
   } else if (attempt < 8) {
     requestAnimationFrame(() => {
-      if (ptyIdRef.current === ptyId) scheduleInitialResize(ptyId, fit, fitAddon, ptyIdRef, attempt + 1);
+      if (ptyIdRef.current === ptyId) scheduleInitialResize(ptyId, fit, fitAddon, ptyIdRef, replayHold, attempt + 1);
     });
   }
 }
@@ -557,6 +584,13 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
   const terminalRef = useRef<HTMLDivElement | null>(null);
   const xtermRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  /**
+   * Pins the terminal to a snapshot's size while that snapshot is being
+   * replayed. A ref because `fit()` and every effect that resizes have to see
+   * the SAME latch as the mount effect that set it; it is replaced per mount so
+   * a hold can never survive the terminal it belonged to.
+   */
+  const replayHoldRef = useRef<ReplayHold>(new ReplayHold());
   const searchAddonRef = useRef<SearchAddon | null>(null);
   const ptyIdRef = useRef<string | null>(null);
   const cleanupFnsRef = useRef<Array<() => void>>([]);
@@ -607,6 +641,13 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
   };
 
   const fit = () => {
+    // A snapshot replay pins the terminal to the size the snapshot was taken
+    // at until it has actually been PARSED — `terminal.write()` is async, so
+    // resizing before that lays the replay out at the wrong height and strands
+    // the restored cursor. Gated here rather than at each caller because
+    // fit() is reached from the ResizeObserver, the PTY attach, the visibility
+    // effect and the theme effect, and one ungated path is enough to lose it.
+    if (!replayHoldRef.current.request()) return;
     if (fitAddonRef.current) {
       try {
         fitAddonRef.current.fit();
@@ -641,6 +682,12 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
       allowProposedApi: true,
       linkHandler: terminalLinkHandler,
       scrollback: prefs.scrollbackLines || 10000,
+      // Every wmux PTY is ConPTY, and xterm grows rows differently for one.
+      // Without this a pane that gets TALLER (an adjacent pane closed, the
+      // window resized) leaves xterm and ConPTY disagreeing about which row the
+      // cursor is on, and the prompt strands itself in the middle of old output.
+      // See utils/windows-pty.ts for the mechanism.
+      windowsPty: windowsPtyCompat(window.wmux?.system?.osRelease ?? ''),
     });
 
     xtermRef.current = terminal;
@@ -705,6 +752,20 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
     // Open terminal in the DOM
     terminal.open(terminalRef.current);
 
+    // Size the buffer to the pane BEFORE anything is written into it. xterm
+    // starts every terminal at 80x24, so a remount that replays a snapshot
+    // (below) used to lay ~200 lines of scrollback into a 24-row buffer and only
+    // reach the rAF fit() further down afterwards — a single ~20-row growth on
+    // an already-full buffer, which is the largest possible dose of the ConPTY
+    // row-growth mismatch windowsPty above exists to prevent. Safe to run
+    // synchronously here: proposeDimensions only needs the element laid out,
+    // which it is once open() has attached to it. The rAF fit() stays as the
+    // safety net for a pane that is not measurable yet (a hidden tab).
+    fit();
+
+    const replayHold = new ReplayHold();
+    replayHoldRef.current = replayHold;
+
     if (surfaceId) surfaceTerminalRegistry.set(surfaceId, terminal);
 
     const titleDisposable = recordTitleChanges(terminal, surfaceId);
@@ -718,7 +779,32 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
       const snapshot = surfaceBufferCache.get(surfaceId);
       if (snapshot) {
         surfaceBufferCache.delete(surfaceId);
-        terminal.write(snapshot);
+        // Replay at the size the snapshot was taken at, undoing the fit()
+        // above — and HELD there, not merely set there. SerializeAddon restores
+        // the cursor to its VIEWPORT row, so the replayed screen agrees with
+        // ConPTY's about where the cursor is only at the size ConPTY still has;
+        // and `terminal.write()` is asynchronous, so a bare resize pins only the
+        // size the bytes are QUEUED at. A remount is triggered by a split-tree
+        // change — exactly when the pane's size changed — so the PTY attach, the
+        // ResizeObserver and the visibility effect are all racing the parse. The
+        // hold is what keeps them out of it; see utils/replay-hold.ts for the
+        // measurement. Growing to the pane's real size then happens once, in the
+        // write callback, applied to BOTH sides in step — which with windowsPty
+        // set moves the cursor the same way on each.
+        replayHold.hold();
+        terminal.resize(snapshot.cols, snapshot.rows);
+        terminal.write(snapshot.text, () => {
+          // Parsed at last. Release, and pay back the one size sync that was
+          // refused while we held — the pane's real size, applied to xterm and
+          // the PTY together, which is the single in-step growth `windowsPty`
+          // makes correct on both sides.
+          if (!replayHold.release()) return;
+          fit();
+          const dims = fitAddonRef.current?.proposeDimensions();
+          if (dims && ptyIdRef.current) {
+            window.wmux.pty.resize(ptyIdRef.current, dims.cols, dims.rows);
+          }
+        });
       }
 
       // Put the replacement terminal back into the mouse modes the STILL-RUNNING
@@ -1055,12 +1141,12 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
       cleanupFnsRef.current.push(unsubData, unsubExit);
 
       // Flush any resize that arrived before this PTY was ready
-      if (pendingResizeDims) {
+      if (pendingResizeDims && !replayHold.isHolding) {
         window.wmux.pty.resize(id, pendingResizeDims.cols, pendingResizeDims.rows);
         pendingResizeDims = null;
       } else {
         // Initial resize, retried until the renderer has laid out (see helper).
-        scheduleInitialResize(id, fit, fitAddon, ptyIdRef);
+        scheduleInitialResize(id, fit, fitAddon, ptyIdRef, replayHold);
       }
 
       // Deferred visual safety-net (see scheduleDeferredRepaint).
@@ -1180,7 +1266,7 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
       resizeRaf = requestAnimationFrame(() => {
         resizeRaf = null;
         fit();
-        const dims = fitAddon.proposeDimensions();
+        const dims = replayHoldRef.current.isHolding ? null : fitAddon.proposeDimensions();
         if (dims) {
           if (ptyIdRef.current) {
             window.wmux.pty.resize(ptyIdRef.current, dims.cols, dims.rows);
@@ -1239,7 +1325,7 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
 
       // Snapshot the buffer before disposal so a remount can replay it
       // (see snapshotSurfaceBuffer).
-      snapshotSurfaceBuffer(surfaceId, serializeAddon);
+      snapshotSurfaceBuffer(surfaceId, serializeAddon, terminal);
 
       // Drop the read-screen registry entry — but only if it still points at
       // THIS terminal (StrictMode re-setup may already have registered the
@@ -1408,7 +1494,7 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
       raf = requestAnimationFrame(() => {
         if (!xtermRef.current) return;
         fit();
-        const dims = fitAddonRef.current?.proposeDimensions();
+        const dims = replayHoldRef.current.isHolding ? null : fitAddonRef.current?.proposeDimensions();
         if (dims && ptyIdRef.current) {
           window.wmux.pty.resize(ptyIdRef.current, dims.cols, dims.rows);
         }
@@ -1448,7 +1534,7 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
           // The terminal may have been disposed between scheduling and firing.
           if (!xtermRef.current) return;
           fit();
-          const dims = fitAddonRef.current?.proposeDimensions();
+          const dims = replayHoldRef.current.isHolding ? null : fitAddonRef.current?.proposeDimensions();
           if (dims && ptyIdRef.current) {
             window.wmux.pty.resize(ptyIdRef.current, dims.cols, dims.rows);
           }

--- a/src/renderer/utils/replay-hold.ts
+++ b/src/renderer/utils/replay-hold.ts
@@ -1,0 +1,73 @@
+/**
+ * Holds a terminal at the size a buffer snapshot was taken at, for as long as
+ * it takes that snapshot to actually be parsed.
+ *
+ * ## Why a latch and not just an ordered pair of calls
+ *
+ * `terminal.write()` is asynchronous. It queues into xterm's write buffer and
+ * is parsed on a later task, so `resize(snap.cols, snap.rows)` immediately
+ * followed by `write(snap.text)` does NOT replay the snapshot at the snapshot's
+ * size — it only guarantees the size at the moment the bytes are *queued*.
+ *
+ * That gap is not theoretical. A remount is triggered by a split-tree change,
+ * which is exactly when the pane's size changed, so the PTY attach continuation
+ * (`scheduleInitialResize`), the ResizeObserver's first callback and the
+ * visibility effect are all racing the parse — and any one of them re-fits the
+ * terminal to the pane's NEW height first. Measured on a real pane close: the
+ * snapshot was taken at 28 rows, the replay drained at 60, and because
+ * SerializeAddon restores the cursor to its VIEWPORT row the cursor landed on
+ * row 59 of 60 while ConPTY still had it on row 27 of 28. Nothing resyncs that
+ * — from ConPTY's side nothing happened — so the prompt stayed stranded 32 rows
+ * up, exactly the number of rows the pane had grown, until a `clear`.
+ *
+ * So the size has to be *held*, not merely set. While a replay is in flight
+ * every size sync asks permission and is refused; the refusal is remembered, so
+ * releasing performs the one sync that was owed. The pane then grows once, on
+ * both sides in step, which is the case `windowsPty` makes correct.
+ *
+ * Deliberately knows nothing about terminals: this is the ordering rule, and it
+ * is the part worth testing without a DOM.
+ */
+export class ReplayHold {
+  private held = false;
+  private owed = false;
+
+  /** Begin holding. Called immediately before the snapshot write is queued. */
+  hold(): void {
+    this.held = true;
+    this.owed = false;
+  }
+
+  get isHolding(): boolean {
+    return this.held;
+  }
+
+  /**
+   * May the caller sync sizes now? `false` means a replay is in flight and the
+   * request has been recorded — the caller must do nothing at all, including
+   * resizing the PTY, or the two sides end up at different heights.
+   */
+  request(): boolean {
+    if (this.held) {
+      this.owed = true;
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Stop holding. Returns true when at least one sync was refused while held
+   * and therefore still has to happen.
+   *
+   * Safe to call when not holding (a mount with no snapshot, a second call
+   * after a write callback has already fired): it answers false and changes
+   * nothing.
+   */
+  release(): boolean {
+    if (!this.held) return false;
+    this.held = false;
+    const owed = this.owed;
+    this.owed = false;
+    return owed;
+  }
+}

--- a/src/renderer/utils/windows-pty.ts
+++ b/src/renderer/utils/windows-pty.ts
@@ -1,0 +1,38 @@
+import type { ITerminalOptions } from '@xterm/xterm';
+
+/**
+ * The `windowsPty` compatibility block xterm needs when its PTY is ConPTY.
+ *
+ * Without it xterm grows rows the POSIX way: it pulls scrollback back DOWN into
+ * the viewport (`ybase--`) and keeps the cursor pinned to the same absolute
+ * buffer line. ConPTY does the opposite — it appends blank rows at the bottom
+ * and leaves the cursor on the same VIEWPORT row. So after a pane grows by K
+ * rows the two sides disagree about the cursor's row by exactly K, and every
+ * repaint ConPTY sends afterwards lands K rows above the content it belongs to:
+ * the prompt appears stranded in the middle of old output, and typing overwrites
+ * whatever was there. `clear` looks like a fix only because it resyncs both
+ * sides. This is the case xterm's own typings describe — "ConPTY … makes empty
+ * rows at [the bottom] of the viewport. Not having this behavior can result in
+ * missing data as the rows get replaced."
+ *
+ * The build number is not decoration: xterm gates reflow on
+ * `backend === 'conpty' && buildNumber >= 21376`. Below that it also turns on
+ * the "line is wrapped if it does not end in whitespace" heuristic — correct
+ * for those older ConPTYs, and what every other xterm-based Windows terminal
+ * ships. An UNPARSEABLE release deliberately yields a block with no
+ * `buildNumber` rather than a guessed one: `backend` alone is enough to fix the
+ * resize behaviour, and an absent build number leaves reflow ON, which is the
+ * safer half of the trade to lose.
+ *
+ * node-pty is spawned with `useConpty: true` (`pty-manager.ts`), and its only
+ * fallback is `useConptyDll: false` — still ConPTY — so the backend is never
+ * winpty.
+ *
+ * @param release `os.release()`, e.g. `'10.0.26200'`.
+ */
+export function windowsPtyCompat(release: string): NonNullable<ITerminalOptions['windowsPty']> {
+  const build = Number((release ?? '').split('.')[2]);
+  return Number.isInteger(build) && build > 0
+    ? { backend: 'conpty', buildNumber: build }
+    : { backend: 'conpty' };
+}

--- a/tests/unit/replay-hold.test.ts
+++ b/tests/unit/replay-hold.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { ReplayHold } from '../../src/renderer/utils/replay-hold';
+
+/**
+ * The second half of the stranded-prompt bug (the first is `windows-pty.test.ts`).
+ *
+ * Replaying a snapshot at the size it was taken at is not achieved by resizing
+ * and then writing: `terminal.write()` is asynchronous, so that only fixes the
+ * size the bytes are QUEUED at. Instrumenting a real pane close showed the
+ * snapshot taken at 28 rows and the same replay draining at 60, with the
+ * restored cursor on row 59 of 60 against ConPTY's row 27 of 28 — a 32-row
+ * strand, matching the rows the pane had just grown by.
+ */
+const USE_TERMINAL = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'src', 'renderer', 'hooks', 'useTerminal.ts'),
+  'utf8',
+);
+
+describe('ReplayHold', () => {
+  it('allows size syncs when no replay is in flight', () => {
+    const hold = new ReplayHold();
+    expect(hold.isHolding).toBe(false);
+    expect(hold.request()).toBe(true);
+    expect(hold.request()).toBe(true);
+  });
+
+  it('refuses every size sync while holding', () => {
+    const hold = new ReplayHold();
+    hold.hold();
+    expect(hold.isHolding).toBe(true);
+    expect(hold.request()).toBe(false);
+    expect(hold.request()).toBe(false);
+  });
+
+  it('reports that a sync is owed when one was refused', () => {
+    const hold = new ReplayHold();
+    hold.hold();
+    hold.request();
+    expect(hold.release()).toBe(true);
+    expect(hold.isHolding).toBe(false);
+  });
+
+  it('reports nothing owed when the replay finished before anything asked', () => {
+    // The common case on a mount that is not racing a resize: the pane is
+    // already the right size and re-fitting it would be a no-op.
+    const hold = new ReplayHold();
+    hold.hold();
+    expect(hold.release()).toBe(false);
+  });
+
+  it('is inert when released without holding, and on a second release', () => {
+    // A mount with no snapshot never holds, and a write callback can fire after
+    // teardown has already released. Neither may report work that is not owed.
+    const hold = new ReplayHold();
+    expect(hold.release()).toBe(false);
+    hold.hold();
+    hold.request();
+    expect(hold.release()).toBe(true);
+    expect(hold.release()).toBe(false);
+  });
+
+  it('does not carry an owed sync across a second replay', () => {
+    const hold = new ReplayHold();
+    hold.hold();
+    hold.request();
+    expect(hold.release()).toBe(true);
+    hold.hold();
+    expect(hold.release()).toBe(false);
+  });
+});
+
+describe('useTerminal replay wiring', () => {
+  it('holds across the snapshot write and releases in its callback', () => {
+    const hold = USE_TERMINAL.indexOf('replayHold.hold()');
+    const write = USE_TERMINAL.indexOf('terminal.write(snapshot.text');
+    const release = USE_TERMINAL.indexOf('replayHold.release()');
+    expect(hold).toBeGreaterThan(-1);
+    expect(write).toBeGreaterThan(hold);
+    // The release has to be INSIDE the write callback: releasing on the next
+    // line would restore exactly the race this class exists to close.
+    expect(release).toBeGreaterThan(write);
+    expect(USE_TERMINAL).toMatch(/terminal\.write\(snapshot\.text,\s*\(\)\s*=>\s*\{/);
+  });
+
+  it('gates fit() itself, so every resize path is covered', () => {
+    // fit() is called from the ResizeObserver, the PTY attach continuation, the
+    // visibility effect and the theme effect. Gating the shared helper is what
+    // makes the hold hold; gating one caller would leave the others racing.
+    expect(USE_TERMINAL).toMatch(/const fit = \(\)[^}]*replayHoldRef\.current\.request\(\)/s);
+  });
+
+  it('never resizes the PTY while the replay is held', () => {
+    // A PTY resize that lands while xterm is pinned to the snapshot size puts
+    // the two at different heights — the same divergence, from the other side.
+    for (const call of USE_TERMINAL.matchAll(/window\.wmux\.pty\.resize\(/g)) {
+      const line = USE_TERMINAL.lastIndexOf('\n', call.index);
+      const context = USE_TERMINAL.slice(Math.max(0, line - 400), call.index);
+      expect(context).toMatch(/replayHold|isHolding|dims/);
+    }
+  });
+});

--- a/tests/unit/windows-pty.test.ts
+++ b/tests/unit/windows-pty.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { windowsPtyCompat } from '../../src/renderer/utils/windows-pty';
+
+/**
+ * The prompt that strands itself in the middle of the screen after a pane is
+ * closed.
+ *
+ * Two facts have to hold together, and neither is checkable from the other's
+ * side:
+ *
+ * 1. xterm must be told its PTY is ConPTY. Without `windowsPty` it grows rows
+ *    the POSIX way — pulls scrollback back down into the viewport and keeps the
+ *    cursor on the same ABSOLUTE buffer line — while ConPTY appends blank rows
+ *    at the bottom and keeps the cursor on the same VIEWPORT row. Grow by K
+ *    rows and every repaint ConPTY sends afterwards lands K rows too high.
+ * 2. A remount must replay its snapshot at the size the snapshot was taken at,
+ *    because SerializeAddon restores the cursor to its VIEWPORT row and that is
+ *    the size ConPTY still has. Setting the size is necessary and not
+ *    sufficient — `terminal.write()` is asynchronous, so it has to be HELD for
+ *    the duration of the parse; `replay-hold.test.ts` covers that half.
+ *
+ * Both live in a file that needs a DOM to run, so the wiring is pinned at the
+ * source level (the shape used by `resources-sync.test.ts`). Losing either one
+ * reintroduces the bug in full.
+ */
+const USE_TERMINAL = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'src', 'renderer', 'hooks', 'useTerminal.ts'),
+  'utf8',
+);
+
+describe('windowsPtyCompat', () => {
+  it('reports the ConPTY backend and the build number from os.release()', () => {
+    expect(windowsPtyCompat('10.0.26200')).toEqual({ backend: 'conpty', buildNumber: 26200 });
+  });
+
+  it('keeps a pre-21376 build number, which is what turns on the wrapping heuristics', () => {
+    expect(windowsPtyCompat('10.0.19045')).toEqual({ backend: 'conpty', buildNumber: 19045 });
+  });
+
+  it('still declares the backend when the release is unparseable', () => {
+    // `backend` alone is enough to fix the row-growth behaviour, and omitting
+    // the build number leaves reflow ON — the safer half of the trade to lose.
+    for (const release of ['', 'nonsense', '10.0', '10.0.x']) {
+      expect(windowsPtyCompat(release)).toEqual({ backend: 'conpty' });
+    }
+  });
+});
+
+describe('useTerminal wiring', () => {
+  it('constructs every terminal with the ConPTY compatibility block', () => {
+    expect(USE_TERMINAL).toMatch(/windowsPty:\s*windowsPtyCompat\(/);
+  });
+
+  it('fits the buffer to the pane before anything is written into it', () => {
+    const open = USE_TERMINAL.indexOf('terminal.open(terminalRef.current)');
+    const fit = USE_TERMINAL.indexOf('\n    fit();', open);
+    const replay = USE_TERMINAL.indexOf('surfaceBufferCache.get(surfaceId)');
+    expect(open).toBeGreaterThan(-1);
+    expect(fit).toBeGreaterThan(open);
+    expect(fit).toBeLessThan(replay);
+  });
+
+  it('replays a snapshot at the size it was taken at, before writing it', () => {
+    const resize = USE_TERMINAL.indexOf('terminal.resize(snapshot.cols, snapshot.rows)');
+    // Note the trailing comma: the write carries a callback now, because
+    // resizing before the write is not enough on its own — see
+    // `replay-hold.test.ts` for the race that fact closes.
+    const write = USE_TERMINAL.indexOf('terminal.write(snapshot.text,');
+    expect(resize).toBeGreaterThan(-1);
+    expect(write).toBeGreaterThan(resize);
+  });
+
+  it('captures the dimensions alongside the snapshot text', () => {
+    expect(USE_TERMINAL).toMatch(/cols:\s*terminal\.cols,\s*rows:\s*terminal\.rows/);
+  });
+});


### PR DESCRIPTION
Growing a pane — closing the pane below it, resizing the window — can leave the
prompt stranded in the middle of old output, with typing overwriting whatever
was on that row. `clear` looks like a fix only because it resyncs both sides.

Two independent halves, either of which reproduces it on its own.

## xterm is not told its PTY is ConPTY

Without `windowsPty`, xterm grows rows the POSIX way: it pulls scrollback back
DOWN into the viewport (`ybase--`) and keeps the cursor on the same ABSOLUTE
buffer line. ConPTY does the opposite. Verified against a live one — it appends
blank rows at the bottom, re-homes to `ESC[H`, repaints its whole viewport and
issues one absolute CUP that keeps the cursor on the same row *from the top*:

```
ESC[8;40;100t ESC[H line 42…ESC[K CRLF …40 rows… ESC[20;35H
```

Grow by K rows and the two sides disagree about the cursor row by exactly K, and
every repaint ConPTY sends afterwards lands K rows above the content it belongs
to. This is the case xterm's own typings describe; the option exists for it.

The build number is not decoration. xterm gates reflow on `buildNumber >=
21376`, and below that also turns on the "wrapped unless the line ends in
whitespace" heuristic — correct for those older ConPTYs, and what every other
xterm-based Windows terminal ships. An unparseable `os.release()` deliberately
yields a block with **no** build number rather than a guessed one: `backend`
alone fixes the resize behaviour, and an absent build number leaves reflow ON,
which is the safer half of the trade to lose.

## A remount must replay its snapshot at the snapshot's size — and hold it

A split-tree restructure disposes and recreates the terminal, and the buffer
snapshot (#49) was replayed into xterm's 80x24 default before the rAF `fit()`
ran. The snapshot now carries the size it was taken at: `SerializeAddon`
restores the cursor to its **viewport** row, so that is the size at which the
replayed screen and ConPTY's screen agree about where the cursor is.

Setting the size is necessary and **not sufficient**, and this is the part worth
writing down rather than rediscovering. `terminal.write()` is asynchronous, so a
resize immediately before it pins only the size the bytes are *queued* at — and
a remount is triggered by a split-tree change, i.e. precisely when the pane's
size changed, so the PTY-attach continuation, the `ResizeObserver` and the
visibility effect are all racing xterm's write buffer to re-fit first.

That is not theoretical. Instrumenting a real pane close caught it:

```
snapshot-taken  rows=28 len=249 baseY=221 cursorY=27 cursorAbs=248
replay-resized  rows=28
replay-drained  rows=60 len=249 baseY=189 cursorY=59 cursorAbs=248
```

`scheduleInitialResize`'s `fit()` reached the terminal before the parse did, so
the replay was laid out at 60 rows and the restored cursor landed on row 59 of
60 while ConPTY still had it on row 27 of 28 — stranded by exactly the 32 rows
the pane had grown.

## The failure mode that would otherwise be silent

Nothing resyncs that divergence. ConPTY re-asserts its whole screen only on a
resize *it* is told about, and here it was never told anything — from its side
nothing happened. So the two sides sit at different cursor rows indefinitely,
and the only feedback the user gets is that typing appears in the wrong place.
That is why the fix is a *hold* rather than an ordered pair of calls: any single
ungated resize path silently restores the bug, with no test failing and no error
anywhere.

`ReplayHold` is that latch. It is gated inside `fit()` rather than at each
caller, because `fit()` is reached from four independent effects and one ungated
path loses the whole property. The PTY is refused alongside it — a resize
landing while xterm is pinned produces the same divergence from the other
direction. Whatever asked while held is paid back once, in the write callback: a
single growth applied to both sides in step, which is the case `windowsPty`
makes correct.

## Scope and compatibility

- No behaviour change on a pane that does not grow, and none for the shrink path.
- `os.release()` is exposed on the preload's `system` block as a plain string
  rather than an IPC round-trip, because the value is needed at Terminal
  *construction* time — an async answer arrives after the terminal already
  exists. Same shape as the existing `homeDir`.
- **One visible change**: a pane that grows now shows blank rows at the bottom
  instead of pulling old scrollback down into view. That is ConPTY's own
  behaviour and what Windows Terminal does, but it is a change worth knowing
  about before merging.
- Windows 10 builds below 21376 now get reflow disabled and the whitespace
  wrapping heuristic. That is what xterm intends for those ConPTYs, and it is
  a behaviour change for anyone on e.g. 19045.

## Verification

- `tsc --noEmit` clean on both `tsconfig.json` and `tsconfig.node.json`.
- `vitest run`: 2707 tests, 173 files. `pipe-client-latency` and
  `orchestration-status-vocab` fail only under full parallel load (subprocess
  timing budgets) and pass in isolation; neither touches the renderer.
- Verified live on Windows 11 26200 by reproducing the original case — split
  horizontally, fill the top pane, close the bottom — before and after.

The latch is pure and unit-tested. The hook needs a DOM the node-env suite does
not have, so its wiring is pinned at the source level, the shape
`resources-sync.test.ts` uses: losing either half reintroduces the bug in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BjbqmJNha7mDaDbB2oSsy
