### PR TITLE
perf: cut typing latency when many panes stream concurrently

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { promises as fsp } from 'fs';
 import { IPC_CHANNELS, SurfaceId, WindowId, WorkspaceId, AgentId, type InsertionResult, type ExplorerListError } from '../shared/types';
 import { observePtyData, clearActivity } from './claude-observer';
+import { createPtyDataBatcher } from './pty-data-batcher';
 import { clearAgentState, noteHumanInput, listAgentStates } from './agent-state';
 import { PtyManager } from './pty-manager';
 import { PtyLedger, reapOrphans } from './pty-ledger';
@@ -544,14 +545,24 @@ export function registerIpcHandlers(windowManager: WindowManager, cdpProxyInstan
         return created;
       }
       const window = BrowserWindow.fromWebContents(_event.sender);
-      const unsubData = ptyManager.onData(id, (data) => {
+      // Batch the per-chunk stream before it crosses IPC: one send per ~4ms
+      // window per pane instead of one per ConPTY chunk, which is what kept
+      // keystroke echo waiting behind other panes' output under load. The
+      // observer reads the same batched bytes — identical lines in identical
+      // order — so its ANSI-strip/regex pass drops to the same cadence.
+      const batcher = createPtyDataBatcher((data) => {
         if (window && !window.isDestroyed()) {
           window.webContents.send(IPC_CHANNELS.PTY_DATA, id, data);
         }
         // Feed Claude Code observer for sidebar activity display
         try { observePtyData(id, data); } catch {}
       });
+      const unsubData = ptyManager.onData(id, (data) => batcher.push(data));
       const unsubExit = ptyManager.onExit(id, (code) => {
+        // Trailing output must land before the exit notification, or the
+        // renderer paints the exit over bytes still sitting in the window.
+        batcher.flush();
+        batcher.dispose();
         if (window && !window.isDestroyed()) {
           window.webContents.send(IPC_CHANNELS.PTY_EXIT, id, code);
         }
@@ -1429,12 +1440,17 @@ export function registerIpcHandlers(windowManager: WindowManager, cdpProxyInstan
 
 export function setupAgentPtyForwarding(surfaceId: string, window: BrowserWindow): void {
   ownSurface(surfaceId as SurfaceId, window.webContents);
-  const unsubData = ptyManager.onData(surfaceId as SurfaceId, (data) => {
+  // Same batching as the PTY_CREATE forwarder — agent panes are the panes most
+  // likely to stream hard, so they need it most.
+  const batcher = createPtyDataBatcher((data) => {
     if (window && !window.isDestroyed()) {
       window.webContents.send(IPC_CHANNELS.PTY_DATA, surfaceId, data);
     }
   });
+  const unsubData = ptyManager.onData(surfaceId as SurfaceId, (data) => batcher.push(data));
   const unsubExit = ptyManager.onExit(surfaceId as SurfaceId, (code) => {
+    batcher.flush();
+    batcher.dispose();
     if (window && !window.isDestroyed()) {
       window.webContents.send(IPC_CHANNELS.PTY_EXIT, surfaceId, code);
     }

--- a/src/main/pty-data-batcher.ts
+++ b/src/main/pty-data-batcher.ts
@@ -1,0 +1,87 @@
+/**
+ * Coalesces the per-chunk PTY output stream into batched deliveries.
+ *
+ * ConPTY hands node-pty many small chunks in bursts, and each chunk used to be
+ * its own `webContents.send` — one structured-clone + IPC message per chunk,
+ * all serialized through the single main→renderer channel that also carries
+ * every other pane's output and the observer's regex pass. Under many
+ * concurrently-streaming panes that channel is what the user feels as typing
+ * latency: the echo of a keystroke queues behind the flood.
+ *
+ * Shape: leading-edge immediate delivery, then a short trailing window. The
+ * FIRST chunk after an idle period is delivered synchronously — a lone
+ * keystroke echo never waits — and opens a WINDOW_MS window during which
+ * subsequent chunks accumulate into one string, delivered when the window
+ * closes. Sustained output therefore settles at ~1000/WINDOW_MS deliveries
+ * per second per pane instead of one per chunk, while interactive latency
+ * stays at zero for the byte the user is waiting on.
+ */
+export interface PtyDataBatcher {
+  /** Queue a chunk (or deliver it now, when idle). */
+  push(data: string): void;
+  /**
+   * Deliver anything buffered right now. Call before sending PTY_EXIT so a
+   * process's trailing output lands ahead of its exit notification.
+   */
+  flush(): void;
+  /** Drop buffered data and cancel the pending timer. */
+  dispose(): void;
+}
+
+const WINDOW_MS = 4;
+
+// Force a delivery mid-window past this much buffered text, so one pane
+// cat-ing a huge file cannot grow an unbounded string in main.
+const MAX_BUFFERED_CHARS = 256 * 1024;
+
+export function createPtyDataBatcher(deliver: (data: string) => void): PtyDataBatcher {
+  let buffered = '';
+  let timer: NodeJS.Timeout | null = null;
+  let disposed = false;
+
+  const closeWindow = () => {
+    if (disposed) return;
+    if (!buffered) {
+      // Quiet window: go idle, so the next chunk takes the immediate path.
+      timer = null;
+      return;
+    }
+    const out = buffered;
+    buffered = '';
+    // Re-arm BEFORE delivering: sustained output keeps batching instead of
+    // alternating immediate/batched on every expiry.
+    timer = setTimeout(closeWindow, WINDOW_MS);
+    deliver(out);
+  };
+
+  return {
+    push(data: string): void {
+      if (disposed) return;
+      if (timer === null) {
+        timer = setTimeout(closeWindow, WINDOW_MS);
+        deliver(data);
+        return;
+      }
+      buffered += data;
+      if (buffered.length >= MAX_BUFFERED_CHARS) {
+        const out = buffered;
+        buffered = '';
+        deliver(out);
+      }
+    },
+    flush(): void {
+      if (disposed || !buffered) return;
+      const out = buffered;
+      buffered = '';
+      deliver(out);
+    },
+    dispose(): void {
+      disposed = true;
+      buffered = '';
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useStore } from './store';
 import { PaneId, SurfaceId, SurfaceRef, WorkspaceId, WorkspaceInfo, SplitNode } from '../shared/types';
 import { cwdReportPatch } from '../shared/paths';
@@ -462,6 +463,14 @@ export function tryReplaceTabSpawn(event: any, ws: WorkspaceInfo, setAgentMeta: 
 }
 
 export default function App() {
+  // Field-scoped store subscription. A bare `useStore()` subscribes App to the
+  // WHOLE store, so every set() anywhere — one pane's OSC 9;4 progress, an
+  // agent verdict, a settings write — re-rendered App and with it the sidebar
+  // and every workspace's split container. That is #141's shape one level up:
+  // the per-chunk paths stay out of the store, but any store write that DID
+  // land still cost a full-App render. useShallow pins the subscription to the
+  // fields App actually reads; the actions are identity-stable, so App now
+  // re-renders only when workspaces/active/sidebar/shortcuts/notifications move.
   const {
     workspaces,
     activeWorkspaceId,
@@ -481,7 +490,26 @@ export default function App() {
     setAgentMeta,
     addNotification,
     toggleSidebar,
-  } = useStore();
+  } = useStore(useShallow((s) => ({
+    workspaces: s.workspaces,
+    activeWorkspaceId: s.activeWorkspaceId,
+    createWorkspace: s.createWorkspace,
+    requestCloseWorkspace: s.requestCloseWorkspace,
+    selectWorkspace: s.selectWorkspace,
+    renameWorkspace: s.renameWorkspace,
+    reorderWorkspaces: s.reorderWorkspaces,
+    updateWorkspaceMetadata: s.updateWorkspaceMetadata,
+    updateSplitTree: s.updateSplitTree,
+    sidebarVisible: s.sidebarVisible,
+    shortcuts: s.shortcuts,
+    notifications: s.notifications,
+    markRead: s.markRead,
+    markAllRead: s.markAllRead,
+    selectSurface: s.selectSurface,
+    setAgentMeta: s.setAgentMeta,
+    addNotification: s.addNotification,
+    toggleSidebar: s.toggleSidebar,
+  })));
 
   useUiTheme();
   useUiMode();

--- a/src/renderer/components/Sidebar/WorkspaceRow.tsx
+++ b/src/renderer/components/Sidebar/WorkspaceRow.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useMemo, useEffect } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { WorkspaceInfo, SplitNode, PaneId } from '../../../shared/types';
 import { useStore } from '../../store';
 import { useT } from '../../i18n';
@@ -142,12 +143,18 @@ export default function WorkspaceRow({
   const activeTabIndicator = useStore((state) => state.sidebarPrefs.activeTabIndicator);
   const uiMode = useStore((state) => state.appearancePrefs.uiMode);
 
-  const surfaceProgress = useStore((state) => state.surfaceProgress);
-  const wsProgress = useMemo(() => {
+  // Select only THIS workspace's progress entries, shallow-compared. The slice
+  // replaces the whole surfaceProgress object on any accepted update, so a bare
+  // `state.surfaceProgress` subscription re-rendered EVERY sidebar row for one
+  // pane's OSC 9;4 tick (#141's fan-out, one hop downstream of the slice's own
+  // change-gate). Per-surface entries are identity-stable while unchanged, so
+  // another workspace's progress leaves this array shallow-equal and this row
+  // untouched.
+  const wsProgressEntries = useStore(useShallow((state) => {
     const ids = getAllSurfaceIds(workspace.splitTree);
-    const entries = ids.map((id) => surfaceProgress[id]).filter(Boolean);
-    return aggregateProgress(entries);
-  }, [surfaceProgress, workspace.splitTree]);
+    return ids.map((id) => state.surfaceProgress[id]).filter(Boolean);
+  }));
+  const wsProgress = useMemo(() => aggregateProgress(wsProgressEntries), [wsProgressEntries]);
 
   // Find Claude activity for this workspace's surfaces (from PTY observer)
   const wsActivity = useMemo(() => {

--- a/tests/unit/pty-data-batcher.test.ts
+++ b/tests/unit/pty-data-batcher.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createPtyDataBatcher } from '../../src/main/pty-data-batcher';
+
+// The contract under test: leading-edge immediate delivery (a lone keystroke
+// echo never waits), then a trailing ~4ms window that coalesces the flood into
+// one string per window. flush() exists so trailing output can be delivered
+// ahead of PTY_EXIT; dispose() must silence everything after teardown.
+describe('pty-data-batcher', () => {
+  let delivered: string[];
+  let deliver: (data: string) => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    delivered = [];
+    deliver = (data) => delivered.push(data);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('delivers the first chunk after idle immediately', () => {
+    const b = createPtyDataBatcher(deliver);
+    b.push('a');
+    expect(delivered).toEqual(['a']);
+  });
+
+  it('coalesces chunks inside the window into one delivery', () => {
+    const b = createPtyDataBatcher(deliver);
+    b.push('lead');
+    b.push('x');
+    b.push('y');
+    b.push('z');
+    expect(delivered).toEqual(['lead']);
+    vi.advanceTimersByTime(5);
+    expect(delivered).toEqual(['lead', 'xyz']);
+  });
+
+  it('keeps batching across windows under sustained output', () => {
+    const b = createPtyDataBatcher(deliver);
+    b.push('1');            // immediate
+    b.push('2');
+    vi.advanceTimersByTime(5);   // window closes → '2', window re-armed
+    b.push('3');            // inside the re-armed window → buffered, NOT immediate
+    vi.advanceTimersByTime(5);
+    expect(delivered).toEqual(['1', '2', '3']);
+  });
+
+  it('returns to the immediate path after a quiet window', () => {
+    const b = createPtyDataBatcher(deliver);
+    b.push('1');
+    vi.advanceTimersByTime(5);   // quiet window, nothing buffered → idle
+    b.push('2');
+    expect(delivered).toEqual(['1', '2']);   // '2' immediate again
+  });
+
+  it('forces a mid-window delivery when the buffer grows past the cap', () => {
+    const b = createPtyDataBatcher(deliver);
+    b.push('lead');
+    const big = 'x'.repeat(256 * 1024);
+    b.push(big);
+    expect(delivered).toEqual(['lead', big]);
+  });
+
+  it('flush() delivers buffered data on demand and is a no-op when empty', () => {
+    const b = createPtyDataBatcher(deliver);
+    b.push('lead');
+    b.push('tail');
+    b.flush();
+    expect(delivered).toEqual(['lead', 'tail']);
+    b.flush();
+    expect(delivered).toEqual(['lead', 'tail']);
+  });
+
+  it('preserves byte order between buffered chunks', () => {
+    const b = createPtyDataBatcher(deliver);
+    b.push('a');
+    b.push('b');
+    b.push('c');
+    b.push('d');
+    vi.advanceTimersByTime(5);
+    expect(delivered.join('')).toBe('abcd');
+  });
+
+  it('dispose() drops buffered data and ignores later pushes', () => {
+    const b = createPtyDataBatcher(deliver);
+    b.push('lead');
+    b.push('doomed');
+    b.dispose();
+    vi.advanceTimersByTime(10);
+    b.push('after');
+    b.flush();
+    expect(delivered).toEqual(['lead']);
+  });
+});


### PR DESCRIPTION
## Problem

With several agent sessions streaming output at once, typing in any pane gets visibly laggy. Traced it to four compounding costs — none of them the keyboard path itself, which is already lean:

1. **One IPC message per ConPTY chunk.** Every `pty.onData` chunk was its own `webContents.send`, so N busy panes flood the single main→renderer channel that keystrokes also cross. Under load, echo queues behind other panes' output.
2. **`observePtyData` on every chunk of every surface**, on the main-process event loop that forwards keystrokes: ANSI-strip (two whole-chunk regex passes) plus up to 9 per-line handlers, ungated.
3. **`App.tsx` subscribed to the whole store** (bare `useStore()`), so any accepted store write re-rendered the entire tree — sidebar plus every workspace's split container. This is #141's shape one level up: the per-chunk paths stay out of the store, but each write that does land paid a full-App render.
4. **Every `WorkspaceRow` subscribed to the whole `surfaceProgress` object**, so one pane's OSC 9;4 tick re-rendered every sidebar row.

## Fix

- **`src/main/pty-data-batcher.ts` (new):** per-pane coalescing of PTY output before IPC. Leading edge is immediate — the first chunk after idle ships synchronously, so a lone keystroke echo never waits — then a 4ms trailing window batches the flood into one send per window. 256KB cap forces a mid-window delivery so a `cat bigfile` can't grow an unbounded string in main; `flush()` runs ahead of `PTY_EXIT` so trailing output still precedes the exit notification. Wired into both forwarders in `ipc-handlers.ts` (PTY_CREATE and `setupAgentPtyForwarding`). Sustained output settles at ~250 sends/s per pane instead of one per chunk.
- The observer now reads the batched bytes — identical lines, identical order, so parsing semantics are unchanged — which drops its regex cadence by the same factor.
- **`App.tsx`:** field-scoped `useShallow` selector over the 18 fields it actually reads. Actions are identity-stable, so App now re-renders only when workspaces/active/sidebar/shortcuts/notifications move.
- **`WorkspaceRow.tsx`:** each row selects only its own workspace's progress entries, shallow-compared; entries are identity-stable while unchanged, so other workspaces' progress no longer touches the row.

## Testing

- `tests/unit/pty-data-batcher.test.ts` (new, 8 cases, fake timers): immediate leading edge, window coalescing, sustained batching across windows, return-to-idle, cap-forced delivery, `flush()` semantics, byte-order preservation, `dispose()`.
- `npm run typecheck` clean; `npm test` 2708 passed (the one failure on my machine is the pre-existing `resolveExistingShellPath` pwsh test — this box has no PowerShell 7; it fails identically on a clean checkout of master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfhwse76gqxU7voD3iGCvt