### PR TITLE
feat(browser): make dev-server auto-open a persisted pref, default off

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -100,7 +100,6 @@ function findBottomPane(node: SplitNode): PaneId | null {
 // Effective runtime values — seeded from the built-in defaults, then widened/
 // toggled by ~/.wmux/config.toml at startup and on `wmux reload-config`.
 let activeDevPorts: number[] = DEFAULT_DEV_PORTS;
-let autoOpenDevPort = true;
 
 /**
  * Apply `~/.wmux/config.toml`'s `[browser]` section: dev-port detection + auto-open.
@@ -110,12 +109,14 @@ let autoOpenDevPort = true;
  */
 function applyUserConfigBrowser(state: any, browser: any): void {
   activeDevPorts = DEFAULT_DEV_PORTS;
-  autoOpenDevPort = true;
   if (!browser) return;
   if (Array.isArray(browser.devPorts) && browser.devPorts.length) {
     activeDevPorts = mergeDevPorts(DEFAULT_DEV_PORTS, browser.devPorts);
   }
-  if (typeof browser.autoOpen === 'boolean') autoOpenDevPort = browser.autoOpen;
+  // Like defaultUrl below, auto-open is a persisted PREF (Settings offers it too),
+  // so file-wins-at-startup and app-wins-at-runtime both fall out of writing it
+  // to the same place rather than to a module-level runtime value.
+  if (typeof browser.autoOpen === 'boolean') state.setBrowserPrefs({ autoOpenDevServer: browser.autoOpen });
   // The start page (#212) is a persisted PREF, not a module-level runtime value
   // like the two above, because Settings offers it too — so file-wins-at-startup
   // and app-wins-at-runtime both fall out of writing it to the same place.
@@ -273,6 +274,7 @@ function handlePortsUpdate(cmd: any, updateWorkspaceMetadata: StoreAction): void
       // never opens when other recognized ports are already listening (netstat order
       // is arbitrary), and the guard permanently suppresses navigation thereafter.
       const newPort = firstNewDevPort(devPorts, ws?.ports || []);
+      const autoOpenDevPort = useStore.getState().browserPrefs.autoOpenDevServer;
       if (autoOpenDevPort && currentWs && newPort !== undefined) {
         window.wmux?.browser?.navigate?.(`browser-${currentWs}`, `http://localhost:${newPort}`);
       }

--- a/src/renderer/components/Settings/BrowserSettings.tsx
+++ b/src/renderer/components/Settings/BrowserSettings.tsx
@@ -61,6 +61,24 @@ export default function BrowserSettings() {
         )}
       </p>
 
+      <div className="settings-row">
+        <label className="settings-label">
+          {t('settings.browser.autoOpenDevServer', 'Auto-open dev servers in the browser panel')}
+        </label>
+        <input
+          type="checkbox"
+          className="settings-toggle"
+          checked={browserPrefs.autoOpenDevServer}
+          onChange={(e) => setBrowserPrefs({ autoOpenDevServer: e.target.checked })}
+        />
+      </div>
+      <p className="settings-hint">
+        {t(
+          'settings.browser.autoOpenDevServerHint',
+          'When on, the browser panel navigates to a dev server (Vite, Next, …) on its own the moment one starts. Off by default — detected ports are still shown, but nothing opens without you. Also settable in ~/.wmux/config.toml as [browser] auto-open.',
+        )}
+      </p>
+
       <div className="settings-divider" />
       <h3 className="settings-section-title">{t('settings.browser.linksSection', 'Links')}</h3>
 

--- a/src/renderer/i18n/locales/en.ts
+++ b/src/renderer/i18n/locales/en.ts
@@ -283,6 +283,9 @@ export const en = {
   'settings.browser.defaultUrl': 'Start page',
   'settings.browser.defaultUrlHint':
     'Where a workspace\'s browser panel opens before it has been anywhere. Needs a scheme (http:// or https://). Leave empty for wmux\'s own page. Also settable in ~/.wmux/config.toml as [browser] default-url.',
+  'settings.browser.autoOpenDevServer': 'Auto-open dev servers in the browser panel',
+  'settings.browser.autoOpenDevServerHint':
+    'When on, the browser panel navigates to a dev server (Vite, Next, …) on its own the moment one starts. Off by default — detected ports are still shown, but nothing opens without you. Also settable in ~/.wmux/config.toml as [browser] auto-open.',
   'settings.browser.linksSection': 'Links',
   'settings.browser.openLinksExternally': 'Open links in the system browser',
   'settings.browser.openLinksExternallyHint': 'Clicked links in terminals and markdown go to your default browser instead of the wmux panel. Ctrl+click always does the opposite.',

--- a/src/renderer/store/settings-slice.ts
+++ b/src/renderer/store/settings-slice.ts
@@ -539,6 +539,17 @@ export interface BrowserPrefs {
    * clothes.
    */
   defaultUrl: string;
+  /**
+   * Automatically navigate the workspace's browser panel to a dev server the
+   * moment one is detected on a known port (Vite 5173, Next 3000, …).
+   *
+   * Default false: a panel navigating to a website on its own — with no click —
+   * reads as the app doing something behind the user's back, which is a common
+   * complaint. Off by default, opt in here or via `~/.wmux/config.toml`
+   * `[browser] auto-open`. Detected ports are still tracked and shown; this only
+   * governs the unprompted navigation.
+   */
+  autoOpenDevServer: boolean;
 }
 
 export const DEFAULT_BROWSER_PREFS: BrowserPrefs = {
@@ -547,6 +558,7 @@ export const DEFAULT_BROWSER_PREFS: BrowserPrefs = {
   openOnStartup: true,
   openLinksExternally: false,
   defaultUrl: '',
+  autoOpenDevServer: false,
 };
 
 // ─── Prompt settings (issue #207) ─────────────────────────────────────────────


### PR DESCRIPTION
## What

Auto-opening a detected dev server (Vite 5173, Next 3000, …) in the workspace's browser panel was a module-level runtime value, settable only via `~/.wmux/config.toml` `[browser] auto-open`, and **always on by default**. This promotes it to a persisted `BrowserPrefs` field (`autoOpenDevServer`) with a Settings → Browser toggle.

## ⚠️ Behavior change — default flips to OFF

A panel navigating to a website on its own — with no click — reads as the app doing something behind the user's back, which is a common complaint with auto-open features. With this change, detected ports are still tracked and shown on the workspace row; only the unprompted navigation is gated behind the opt-in. If you'd rather keep the old default, flipping `DEFAULT_BROWSER_PREFS.autoOpenDevServer` to `true` keeps everything else in this PR intact — happy to amend.

## Design

Follows the `defaultUrl` (#212) shape exactly: because Settings offers it too, it's a persisted pref rather than a module runtime value, so file-wins-at-startup and app-wins-at-runtime both fall out of writing to the same place. The `config.toml` key keeps working and now writes through `setBrowserPrefs`. `handlePortsUpdate` reads the pref at decision time via `useStore.getState()`.

New-field prefs migration is free per the `promptDefaultRev` note in CLAUDE.md (`{...DEFAULTS, ...stored}` fills in missing fields) — no rev bump needed since this field is new.

i18n: strings added to `en.ts`; the other locales fall back to the English default via `t(key, fallback)` until translated.

## Testing

`npm run typecheck` clean; `npm test` 2708 passed (the one failure on my machine is the pre-existing `resolveExistingShellPath` pwsh test — no PowerShell 7 on this box; fails identically on clean master). Toggled live: port detection still populates the workspace row with the pref off; navigation resumes when toggled on or set via config.toml.

Independent of #217 and #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cfhwse76gqxU7voD3iGCvt