### PR TITLE
Fix Ctrl+C / Ctrl+V not working on non-Latin keyboard layouts

### DIFF
--- a/src/renderer/hooks/terminal-keys.ts
+++ b/src/renderer/hooks/terminal-keys.ts
@@ -10,11 +10,30 @@ export const SHIFT_ENTER_SEQUENCE = '\x1b\r';
 export interface TerminalKeyEvent {
   type: string;
   key: string;
+  /** The physical key, e.g. 'KeyC'. Unlike `key`, it does not vary by layout. */
+  code: string;
   shiftKey: boolean;
   ctrlKey: boolean;
   altKey: boolean;
   metaKey: boolean;
   preventDefault(): void;
+}
+
+/**
+ * True when `event` is the physical key for `letter`.
+ *
+ * event.key is the character the key produces, so on a non-Latin layout
+ * Ctrl+C arrives as key === 'с' (Cyrillic) and never matches 'c'. event.code
+ * is the physical key and is layout-independent, so it fixes every non-Latin
+ * layout at once.
+ *
+ * event.key is still checked first: on Dvorak / Colemak the user presses the
+ * key that *shows* C, which is a different physical key, and matching code
+ * alone would break them.
+ */
+export function isLetterKey(event: TerminalKeyEvent, letter: string, code: string): boolean {
+  if (event.key === letter) return true;
+  return event.code === code && !/^[a-z]$/i.test(event.key);
 }
 
 /**

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -27,7 +27,7 @@ import { resetTerminalModes } from '../utils/terminal-reset';
 import { windowsPtyCompat } from '../utils/windows-pty';
 import { ReplayHold } from '../utils/replay-hold';
 import { trimTrailingWhitespace } from '../utils/copy-text';
-import { handleShiftEnter, isShiftEnter } from './terminal-keys';
+import { handleShiftEnter, isLetterKey, isShiftEnter } from './terminal-keys';
 import { applyKeyRemap } from '../key-remaps';
 import { isConEmuSubcommand } from './osc9';
 import { forgetSurface as forgetPromptLog, handlePromptMark, refreshHighlights } from '../utils/prompt-log';
@@ -1032,7 +1032,7 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
       // (issue #146). Routed through terminal.input (→ onData) rather than
       // pty.write so broadcast-input fans a remapped key out like any other.
       if (applyKeyRemap(event, (data) => terminal.input(data, true))) return false;
-      if (event.type === 'keydown' && event.ctrlKey && event.key === 'c') {
+      if (event.type === 'keydown' && event.ctrlKey && isLetterKey(event, 'c', 'KeyC')) {
         // ConPTY pads lines to full width with real spaces — trim them or
         // pasted blocks carry ragged trailing whitespace (issue #102).
         const selection = trimTrailingWhitespace(terminal.getSelection());
@@ -1043,7 +1043,7 @@ export function useTerminal({ surfaceId, shell, cwd, visible = true, focused = t
         }
       }
       // Ctrl+V: main reads the clipboard and tells us what to type.
-      if (event.type === 'keydown' && event.ctrlKey && event.key === 'v') {
+      if (event.type === 'keydown' && event.ctrlKey && isLetterKey(event, 'v', 'KeyV')) {
         // Prevent the browser 'paste' event — without this, xterm's built-in
         // paste handler ALSO writes the clipboard content through onData,
         // causing the text to appear twice in the terminal.

--- a/tests/unit/terminal-keys.test.ts
+++ b/tests/unit/terminal-keys.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   SHIFT_ENTER_SEQUENCE,
   handleShiftEnter,
+  isLetterKey,
   isShiftEnter,
   type TerminalKeyEvent,
 } from '../../src/renderer/hooks/terminal-keys';
@@ -10,6 +11,7 @@ function keyEvent(over: Partial<TerminalKeyEvent> = {}): TerminalKeyEvent & { pr
   return {
     type: 'keydown',
     key: 'Enter',
+    code: 'Enter',
     shiftKey: true,
     ctrlKey: false,
     altKey: false,
@@ -58,5 +60,47 @@ describe('Shift+Enter (issue #119)', () => {
 
   it('tells xterm not to handle the key as well', () => {
     expect(handleShiftEnter(keyEvent(), vi.fn())).toBe(false);
+  });
+});
+
+describe('isLetterKey — layout-independent letter matching', () => {
+  it('matches the Latin letter the key produces', () => {
+    expect(isLetterKey(keyEvent({ key: 'c', code: 'KeyC' }), 'c', 'KeyC')).toBe(true);
+    expect(isLetterKey(keyEvent({ key: 'v', code: 'KeyV' }), 'v', 'KeyV')).toBe(true);
+  });
+
+  // The bug: on a Russian layout the C key produces U+0441, Cyrillic "es". It
+  // looks identical to a Latin "c" and is a different character, so matching on
+  // event.key alone never fires and the keystroke falls through to the PTY.
+  it('matches Cyrillic, where the key produces с (U+0441) instead of c', () => {
+    expect(isLetterKey(keyEvent({ key: '\u0441', code: 'KeyC' }), 'c', 'KeyC')).toBe(true);
+    expect(isLetterKey(keyEvent({ key: 'м', code: 'KeyV' }), 'v', 'KeyV')).toBe(true);
+  });
+
+  it('matches Greek, and so every other non-Latin script, without listing them', () => {
+    expect(isLetterKey(keyEvent({ key: 'ψ', code: 'KeyC' }), 'c', 'KeyC')).toBe(true);
+  });
+
+  // Dvorak moves C to the physical I key. The user presses the key that shows
+  // C, so event.key is what has to decide here — matching event.code alone
+  // would silently break every remapped Latin layout.
+  it('follows the character on Dvorak, where C sits on a different physical key', () => {
+    expect(isLetterKey(keyEvent({ key: 'c', code: 'KeyI' }), 'c', 'KeyC')).toBe(true);
+  });
+
+  it('ignores the physical key when it produces some other Latin letter', () => {
+    // Physical KeyC on Dvorak produces 'j' — pressing it must not copy.
+    expect(isLetterKey(keyEvent({ key: 'j', code: 'KeyC' }), 'c', 'KeyC')).toBe(false);
+  });
+
+  it('leaves unrelated keys alone', () => {
+    expect(isLetterKey(keyEvent({ key: 'x', code: 'KeyX' }), 'c', 'KeyC')).toBe(false);
+    expect(isLetterKey(keyEvent({ key: 'ч', code: 'KeyX' }), 'c', 'KeyC')).toBe(false);
+  });
+
+  // Shift uppercases event.key, so Ctrl+Shift+C stays out of the terminal's
+  // bare-Ctrl+C copy branch and reaches the global shortcut handler as before.
+  it('does not match the shifted Latin letter', () => {
+    expect(isLetterKey(keyEvent({ key: 'C', code: 'KeyC' }), 'c', 'KeyC')).toBe(false);
   });
 });


### PR DESCRIPTION
Hi! 👋

First of all — thank you for wmux. I have been using it almost since the very first releases, and it is honestly the best thing I have found for Windows. It is open on my machine all day long.

There is one thing I have been waiting for in every single update: `Ctrl+C` simply does not work while my keyboard layout is set to Russian. I switch layouts dozens of times a day, and every time I want to copy something out of the terminal I first have to switch back to English. After waiting for a while I decided to just sit down and fix it myself.

And it is not only about Russian. The exact same thing happens on every non-Latin layout — Ukrainian, Bulgarian, Serbian, Greek, Hebrew, Arabic, Armenian, Georgian and others. So this small change helps quite a lot of people at once.

Thank you again for everything you put into this project — it is genuinely the best terminal experience on Windows. 🙏

### What goes wrong

The terminal key handler matches the shortcut against `event.key`:

```ts
if (event.type === 'keydown' && event.ctrlKey && event.key === 'c') {
```

`event.key` is the **character the key produces with the current layout**. On a Russian layout that physical key produces `с` — U+0441, Cyrillic "es" — and not `c` — U+0063, Latin "c". The two look identical on screen but they are different characters, so the condition is never true. The keystroke then falls through to the PTY as a plain `^C`, which is why copying silently does nothing and the running command gets interrupted instead. `Ctrl+V` has the same problem.

Native Windows applications do not suffer from this because they match virtual-key codes, which are layout-independent. That is why `Ctrl+C` works everywhere else in the OS and this looks like a wmux-specific bug to the user.

### The fix

`event.code` is the **physical key** and never changes with the layout: `KeyC` stays `KeyC` on Russian, Greek, Hebrew or anything else. Fixing all of them therefore does not need a list of languages — one check is enough.

Matching on `event.code` alone would be wrong, though. On Dvorak or Colemak the user presses the key that *shows* C, which is physically a different key. So `event.key` is still checked first, and `event.code` is only used as a fallback when the produced character is not a Latin letter:

```ts
export function isLetterKey(event: TerminalKeyEvent, letter: string, code: string): boolean {
  if (event.key === letter) return true;
  return event.code === code && !/^[a-z]$/i.test(event.key);
}
```

| Layout | `event.key` | `event.code` | Result |
|---|---|---|---|
| English (QWERTY) | `c` | `KeyC` | matches on key — unchanged |
| German, Spanish, French | `c` | `KeyC` | matches on key — unchanged |
| Russian, Greek, Hebrew, Arabic | `с`, `ψ`, `ב`… | `KeyC` | matches on code — **fixed** |
| Dvorak / Colemak (key showing C) | `c` | `KeyI` | matches on key — still works |
| Dvorak (physical KeyC, shows `j`) | `j` | `KeyC` | Latin letter, no match — correct |

The predicate lives in `src/renderer/hooks/terminal-keys.ts`, next to `isShiftEnter`, so it can be tested without spinning up Electron.

### What is deliberately not changed

- `Ctrl+C` with no selection still falls through to the PTY as `^C` (SIGINT). Only the "there is a selection, so copy it" branch is affected, exactly as before.
- `Ctrl+Shift+C` is unchanged on Latin layouts: Shift uppercases `event.key`, so it arrives as `C`, which is still a Latin letter and therefore never reaches this branch — it goes to the global `copy` shortcut as it always did. On a non-Latin layout it now lands in the terminal copy branch, which does the same thing the `copy` shortcut would have done; previously it did nothing at all there, because the global handler compares characters too.
- The `trimTrailingWhitespace` handling from #102 and the `preventDefault` that stops the double paste are kept as they were.

### Tests

Added unit tests in `tests/unit/terminal-keys.test.ts` covering Latin, Cyrillic, Greek and both Dvorak directions.

Also verified manually on Windows 10 with Russian and English layouts:

- Russian layout, text selected, `Ctrl+C` → copies (was: nothing, and the command got interrupted)
- Russian layout, nothing selected, `Ctrl+C` → still interrupts the command
- Russian layout, `Ctrl+V` → pastes
- English layout → behaves exactly as before

`npm test`, `npm run typecheck` and `npm run lint` are all as green as they are on `master`. (The one failing test I see locally, `pty-manager` → "finds a real file for pwsh", fails on a clean `master` checkout too — PowerShell 7 is simply not installed on this machine.)

### A note for a possible follow-up

The same symbol-based matching lives in `useKeyboardShortcuts.ts` and `key-remaps.ts`, which means that on a non-Latin layout **none** of the letter shortcuts work, not just copy and paste. I kept this PR narrow on purpose, but I would be happy to send a follow-up with the same treatment if you think it is worth it.
